### PR TITLE
adding OSError check to improve function on windows

### DIFF
--- a/src/albert/__init__.py
+++ b/src/albert/__init__.py
@@ -3,4 +3,4 @@ from albert.utils.client_credentials import ClientCredentials
 
 __all__ = ["Albert", "ClientCredentials"]
 
-__version__ = "0.5.35"
+__version__ = "0.5.36"

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -201,7 +201,7 @@ class TaskPropertyCreate(BaseResource):
 
 
 class PropertyDataPatchDatum(PatchDatum):
-    property_column_id: DataColumnId = Field(alias="id")
+    property_column_id: DataColumnId | PropertyDataId = Field(alias="id")
 
 
 class InventoryPropertyDataCreate(BaseResource):

--- a/src/albert/session.py
+++ b/src/albert/session.py
@@ -15,7 +15,7 @@ def get_token_refresh_time(token: str, *, buffer: timedelta | None) -> datetime:
     claims = jwt.decode(token, options={"verify_signature": False})
     try:
         exp_time = datetime.fromtimestamp(claims["exp"], tz=timezone.utc)
-    except ValueError:
+    except (OSError, ValueError):
         # exp is in millis, not seconds, so datetime fails
         exp_time = datetime.fromtimestamp(claims["exp"] / 1000, tz=timezone.utc)
     buffer = buffer or timedelta(seconds=0)


### PR DESCRIPTION
Windows machines sometimes throw an OS Error as opposed to a ValueError when parsing the time strings. This is a quick fix for that.