### PR TITLE
Adds update_or_create_task_properties method to Property Data Collection

### DIFF
--- a/src/albert/__init__.py
+++ b/src/albert/__init__.py
@@ -3,4 +3,4 @@ from albert.utils.client_credentials import ClientCredentials
 
 __all__ = ["Albert", "ClientCredentials"]
 
-__version__ = "0.5.39"
+__version__ = "0.5.40"

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -175,6 +175,38 @@ class InventoryDataColumn(BaseAlbertModel):
 
 
 class TaskPropertyCreate(BaseResource):
+    """
+    Represents a task property to be created.
+
+    This class is used to create new task properties. Users can use the `Workflowe.get_interval_id`
+    method to find the correct interval given the names and setpoints of the parameters.
+
+    Parameters
+    ----------
+    entity : Literal[DataEntity.TASK]
+        The entity type, which is always `DataEntity.TASK` for task properties.
+    interval_combination : str
+        The interval combination, which can be found using `Workflowe.get_interval_id`.
+        Examples include "default", "ROW4XROW2", "ROW2".
+    data_column : TaskDataColumn
+        The data column associated with the task property.
+    value : str, optional
+        The value of the task property, by default None.
+    visible_trial_number : int, optional
+        The visible trial number, by default None. This can always be left empty.
+    trial_number : int, optional
+        The trial number, by default None. Leave this blank to create a new row/trial.
+    data_template : SerializeAsEntityLink[DataTemplate]
+        The data template associated with the task property.
+
+    Notes
+    -----
+    - Users can use `Workflow.get_interval_id(parameter_values={"name1":"value1", "name2":"value2"})`
+      to find the correct interval given the names and setpoints of the parameters.
+    - Leave `trial_number` blank to create a new row/trial.
+    - `visible_trial_number` can always be left empty.
+    """
+
     entity: Literal[DataEntity.TASK] = Field(default=DataEntity.TASK)
     interval_combination: str = Field(
         alias="intervalCombination",


### PR DESCRIPTION
Users often do not want to think about the details of how to update each cell of Property Data in Tasks. This method will update existing values, calculated values, or add new values dynamically.