### PR TITLE
get full data column or parameter after search

### DIFF
--- a/src/albert/__init__.py
+++ b/src/albert/__init__.py
@@ -3,4 +3,4 @@ from albert.utils.client_credentials import ClientCredentials
 
 __all__ = ["Albert", "ClientCredentials"]
 
-__version__ = "0.6.0"
+__version__ = "0.6.1"


### PR DESCRIPTION
Now that Parameters and Data Columns have metadata fields, the full Data Columns / Parameters were not being returned by the list APIs. This PR updates the deserialization  methods of the search results to match patterns established elsewhere in the SDK where this behavior is needed (do a GET on the full object).