### PR TITLE
fix(parametergroups, tasks): clear-then-update metadata list items

### DIFF
--- a/src/albert/__init__.py
+++ b/src/albert/__init__.py
@@ -3,4 +3,4 @@ from albert.utils.credentials import ClientCredentials
 
 __all__ = ["Albert", "ClientCredentials"]
 
-__version__ = "0.11.8"
+__version__ = "0.11.9"

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Iterator
 
 from pydantic import validate_call
@@ -18,10 +20,12 @@ from albert.resources.tasks import (
     TaskAdapter,
     TaskCategory,
     TaskHistory,
+    TaskPatchPayload,
 )
 from albert.session import AlbertSession
 from albert.utils.logging import logger
 from albert.utils.pagination import AlbertPaginator, PaginationMode
+from albert.utils.patches import PatchDatum, PatchOperation, PatchPayload
 
 
 class TaskCollection(BaseCollection):
@@ -334,7 +338,75 @@ class TaskCollection(BaseCollection):
             params=params,
         )
 
-    def _generate_adv_patch_payload(self, *, updated: BaseTask) -> dict:
+    def _is_metadata_item_list(
+        self,
+        *,
+        existing_object: BaseTask,
+        updated_object: BaseTask,
+        metadata_field: str,
+    ) -> bool:
+        """Return True if the metadata field is list-typed on either object."""
+
+        if not metadata_field.startswith("Metadata."):
+            return False
+
+        metadata_field = metadata_field.split(".")[1]
+
+        if existing_object.metadata is None:
+            existing_object.metadata = {}
+        if updated_object.metadata is None:
+            updated_object.metadata = {}
+
+        existing = existing_object.metadata.get(metadata_field, None)
+        updated = updated_object.metadata.get(metadata_field, None)
+
+        return isinstance(existing, list) or isinstance(updated, list)
+
+    def _generate_patch_payload(
+        self,
+        *,
+        existing: BaseTask,
+        updated: BaseTask,
+    ) -> tuple[PatchPayload, dict[str, list[str]]]:
+        """Generate patch payload and capture metadata list updates."""
+
+        base_payload = super()._generate_patch_payload(
+            existing=existing,
+            updated=updated,
+        )
+
+        new_data: list[PatchDatum] = []
+        list_metadata_updates: dict[str, list[str]] = {}
+
+        for datum in base_payload.data:
+            if self._is_metadata_item_list(
+                existing_object=existing,
+                updated_object=updated,
+                metadata_field=datum.attribute,
+            ):
+                key = datum.attribute.split(".", 1)[1]
+                updated_list = updated.metadata.get(key) or []
+                list_values: list[str] = [
+                    item.id if hasattr(item, "id") else item for item in updated_list
+                ]
+
+                list_metadata_updates[datum.attribute] = list_values
+                continue
+
+            new_data.append(
+                PatchDatum(
+                    operation=datum.operation,
+                    attribute=datum.attribute,
+                    new_value=datum.new_value,
+                    old_value=datum.old_value,
+                )
+            )
+
+        return TaskPatchPayload(data=new_data, id=existing.id), list_metadata_updates
+
+    def _generate_adv_patch_payload(
+        self, *, updated: BaseTask, existing: BaseTask
+    ) -> tuple[dict, dict[str, list[str]]]:
         """Generate a patch payload for updating a task.
 
         Parameters
@@ -346,17 +418,15 @@ class TaskCollection(BaseCollection):
 
         Returns
         -------
-        dict
-            The patch payload for updating the task.
+        tuple[dict, dict[str, list[str]]]
+            The patch payload for updating the task and metadata list updates.
         """
         _updatable_attributes_special = {"inventory_information"}
-        existing = self.get_by_id(id=updated.id)
-        patch_payload_obj = self._generate_patch_payload(
+        base_payload, list_metadata_updates = self._generate_patch_payload(
             existing=existing,
             updated=updated,
         )
-        patch_payload = patch_payload_obj.model_dump(mode="json", by_alias=True)
-        patch_payload["id"] = updated.id
+        patch_payload = base_payload.model_dump(mode="json", by_alias=True)
 
         for attribute in _updatable_attributes_special:
             old_value = getattr(existing, attribute)
@@ -373,7 +443,7 @@ class TaskCollection(BaseCollection):
                 if len(inv_to_remove) > 0:
                     patch_payload["data"].append(
                         {
-                            "operation": "delete",
+                            "operation": PatchOperation.DELETE,
                             "attribute": "inventory",
                             "oldValue": inv_to_remove,
                         }
@@ -387,13 +457,13 @@ class TaskCollection(BaseCollection):
                 if len(inv_to_add) > 0:
                     patch_payload["data"].append(
                         {
-                            "operation": "add",
+                            "operation": PatchOperation.ADD,
                             "attribute": "inventory",
                             "newValue": inv_to_add,
                         }
                     )
 
-        return [patch_payload]
+        return patch_payload, list_metadata_updates
 
     def update(self, *, task: BaseTask) -> BaseTask:
         """Update a task.
@@ -408,14 +478,52 @@ class TaskCollection(BaseCollection):
         BaseTask
             The updated Task object as it exists in the Albert platform.
         """
-        patch_payload = self._generate_adv_patch_payload(updated=task)
-        if len(patch_payload[0]["data"]) == 0:
+        existing = self.get_by_id(id=task.id)
+        patch_payload, list_metadata_updates = self._generate_adv_patch_payload(
+            updated=task, existing=existing
+        )
+        patch_operations = patch_payload.get("data", [])
+
+        if len(patch_operations) == 0 and len(list_metadata_updates) == 0:
             logger.info(f"Task {task.id} is already up to date")
             return task
-        self.session.patch(
-            url=f"{self.base_path}/{task.id}",
-            json=patch_payload,
-        )
+        path = f"{self.base_path}/{task.id}"
+
+        for datum in patch_operations:
+            patch_payload = TaskPatchPayload(data=[datum], id=task.id)
+            self.session.patch(
+                url=path,
+                json=[patch_payload.model_dump(mode="json", by_alias=True, exclude_none=True)],
+            )
+
+        # For metadata list field updates, we clear, then update
+        # since duplicate attribute values are not allowed in single patch request.
+        for attribute, values in list_metadata_updates.items():
+            entity_links = existing.metadata.get(attribute.split(".")[1])
+            old_values = [item.id if hasattr(item, "id") else item for item in entity_links]
+            clear_datum = PatchDatum(
+                operation=PatchOperation.DELETE, attribute=attribute, oldValue=old_values
+            )
+            clear_payload = TaskPatchPayload(data=[clear_datum], id=task.id)
+            self.session.patch(
+                url=path,
+                json=[clear_payload.model_dump(mode="json", by_alias=True, exclude_none=True)],
+            )
+            if values:
+                update_datum = PatchDatum(
+                    operation=PatchOperation.UPDATE,
+                    attribute=attribute,
+                    newValue=values,
+                    oldValue=[],
+                )
+
+                update_payload = TaskPatchPayload(data=[update_datum], id=task.id)
+                self.session.patch(
+                    url=path,
+                    json=[
+                        update_payload.model_dump(mode="json", by_alias=True, exclude_none=False)
+                    ],
+                )
         return self.get_by_id(id=task.id)
 
     def get_history(

--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -118,7 +118,7 @@ class ParameterValue(BaseAlbertModel):
     value: str | SerializeAsEntityLink[InventoryItem] | None = Field(default=None)
     unit: SerializeAsEntityLink[Unit] | None = Field(alias="Unit", default=None)
     added: AuditFields | None = Field(alias="Added", default=None, exclude=True)
-    validation: list[ValueValidation] | None = Field(default=None)
+    validation: list[ValueValidation] = Field(default_factory=list)
 
     # Read-only fields
     name: str | None = Field(default=None, exclude=True, frozen=True)

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -13,6 +13,7 @@ from albert.resources.serialization import SerializeAsEntityLink
 from albert.resources.tagged_base import BaseTaggedEntity
 from albert.resources.users import User
 from albert.resources.workflows import Workflow
+from albert.utils.patches import PatchPayload
 
 
 class TaskCategory(str, Enum):
@@ -324,3 +325,15 @@ class TaskHistoryEvent(BaseAlbertModel):
 
 class TaskHistory(BaseAlbertModel):
     items: list[TaskHistoryEvent] = Field(alias="Items")
+
+
+class TaskPatchPayload(PatchPayload):
+    """A payload for a PATCH request to update a Task.
+
+    Attributes
+    ----------
+    id:  str
+        The id of the Task to be updated.
+    """
+
+    id: str

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -56,7 +56,6 @@ def test_dupe_raises_error(client: Albert, seeded_parameter_groups: list[Paramet
         client.parameter_groups.create(parameter_group=pg)
 
 
-@pytest.mark.xfail(reason="TODO: Somethign broken w/ patching. FIX ASAP")
 def test_update(
     client: Albert,
     seeded_parameter_groups: list[ParameterGroup],

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -22,7 +22,7 @@ def test_update(client: Albert, seeded_tasks, seed_prefix: str, static_lists: li
     new_name = f"{seed_prefix}-new name"
     task.name = new_name
     new_metadata = change_metadata(
-        task.metadata, static_lists=seeded_tasks, seed_prefix=seed_prefix
+        task.metadata, static_lists=static_lists, seed_prefix=seed_prefix
     )
     task.metadata = new_metadata
     updated_task = client.tasks.update(task=task)

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -87,6 +87,7 @@ def generate_custom_fields() -> list[CustomField]:
         ServiceType.PROJECTS,
         ServiceType.TASKS,
         ServiceType.USERS,
+        ServiceType.PARAMETER_GROUPS,
     ]
 
     seeds = []

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -60,6 +60,7 @@ from albert.resources.tasks import (
     BatchSizeUnit,
     BatchTask,
     Block,
+    GeneralTask,
     InventoryInformation,
     PropertyTask,
     TaskCategory,
@@ -987,12 +988,12 @@ def generate_task_seeds(
     task_string_custom_fields = [
         x
         for x in static_custom_fields
-        if x.service == ServiceType.PARAMETER_GROUPS and x.field_type == FieldType.STRING
+        if x.service == ServiceType.TASKS and x.field_type == FieldType.STRING
     ]
     task_list_custom_fields = [
         x
         for x in static_custom_fields
-        if x.service == ServiceType.PARAMETER_GROUPS and x.field_type == FieldType.LIST
+        if x.service == ServiceType.TASKS and x.field_type == FieldType.LIST
     ]
     faux_metadata = {}
     for i, custom_field in enumerate(task_string_custom_fields):
@@ -1048,22 +1049,16 @@ def generate_task_seeds(
             due_date="2024-10-31",
             location=seeded_locations[1],
         ),
-        # Property Task 3
-        PropertyTask(
-            name=f"{seed_prefix} - Property Task with metadata",
-            category=TaskCategory.PROPERTY,
+        # General Task 1
+        GeneralTask(
+            name=f"{seed_prefix} - General Task with metadata",
+            category=TaskCategory.GENERAL,
             inventory_information=[
                 InventoryInformation(
                     inventory_id=seeded_inventory[2].id,
                 )
             ],
             priority=TaskPriority.HIGH,
-            blocks=[
-                Block(
-                    workflow=[seeded_workflows[1]],
-                    data_template=[seeded_data_templates[1]],
-                )
-            ],
             due_date="2024-10-31",
             location=seeded_locations[1],
             metadata=faux_metadata,

--- a/tests/utils/test_patches.py
+++ b/tests/utils/test_patches.py
@@ -47,7 +47,7 @@ def change_metadata(
         elif isinstance(v, list):
             used_ids = [x.id for x in v]
             new_list = [x for x in static_lists if x.id not in used_ids and x.list_type == k]
-            new_metadata[k] = new_list
+            new_metadata[k] = [x.to_entity_link() for x in new_list]
 
     return new_metadata
 


### PR DESCRIPTION
`update()` metadata for `parameter-groups` and `tasks` broke after [b5c32f7827fd630e7cc30cc05afbd74015ff5f77](https://github.com/MoleculeEngineering/api-parametergroup/commit/b5c32f7827fd630e7cc30cc05afbd74015ff5f77)
we can not longer do ADD + DELETE for same metadata field (raises duplicate attr error) in one patch request.
workaround right now is to clear, then update (2 PATCH requests)
