### PR TITLE
fix: revert ui lotId lookup

### DIFF
--- a/src/albert/__init__.py
+++ b/src/albert/__init__.py
@@ -4,4 +4,4 @@ from albert.core.auth.sso import AlbertSSOClient
 
 __all__ = ["Albert", "AlbertClientCredentials", "AlbertSSOClient"]
 
-__version__ = "1.5.2"
+__version__ = "1.5.3"

--- a/src/albert/collections/custom_templates.py
+++ b/src/albert/collections/custom_templates.py
@@ -5,6 +5,7 @@ from albert.core.logging import logger
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import PaginationMode
+from albert.core.shared.identifiers import CustomTemplateId
 from albert.exceptions import AlbertHTTPError
 from albert.resources.custom_templates import CustomTemplate, CustomTemplateSearchItem
 
@@ -27,7 +28,7 @@ class CustomTemplatesCollection(BaseCollection):
         super().__init__(session=session)
         self.base_path = f"/api/{CustomTemplatesCollection._api_version}/customtemplates"
 
-    def get_by_id(self, *, id) -> CustomTemplate:
+    def get_by_id(self, *, id: CustomTemplateId) -> CustomTemplate:
         """Get a Custom Template by ID
 
         Parameters
@@ -38,7 +39,7 @@ class CustomTemplatesCollection(BaseCollection):
         Returns
         -------
         CustomTemplate
-            The CutomTemplate with the provided ID (or None if not found)
+            The CutomTemplate with the provided ID
         """
         url = f"{self.base_path}/{id}"
         response = self.session.get(url)

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -266,15 +266,6 @@ LinkId = Annotated[str, AfterValidator(ensure_link_id)]
 
 
 def ensure_lot_id(id: str) -> str:
-    if id and "-" in id:
-        id_upper = id.upper()
-        parts = id_upper.split("-")
-        if id_upper.startswith("ALB0-") and len(parts) >= 3:
-            id = f"B{parts[-1]}"
-        elif parts[0].startswith("B"):
-            id = parts[0]
-        else:
-            id = parts[-1]
     return _ensure_albert_id(id, "LotId")
 
 

--- a/src/albert/resources/custom_templates.py
+++ b/src/albert/resources/custom_templates.py
@@ -5,7 +5,7 @@ from pydantic import Field, model_validator
 
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.enums import SecurityClass, Status
-from albert.core.shared.identifiers import NotebookId
+from albert.core.shared.identifiers import CustomTemplateId, NotebookId
 from albert.core.shared.models.base import BaseResource, EntityLink
 from albert.core.shared.types import MetadataItem, SerializeAsEntityLink
 from albert.resources._mixins import HydrationMixin
@@ -198,7 +198,7 @@ class CustomTemplate(BaseTaggedResource):
     """
 
     name: str
-    id: str = Field(alias="albertId")
+    id: CustomTemplateId = Field(alias="albertId")
     category: TemplateCategory = Field(default=TemplateCategory.GENERAL)
     metadata: dict[str, MetadataItem] | None = Field(default=None, alias="Metadata")
     data: CustomTemplateData | None = Field(default=None, alias="Data")
@@ -238,7 +238,7 @@ class CustomTemplateSearchItemTeam(BaseAlbertModel):
 
 class CustomTemplateSearchItem(BaseAlbertModel, HydrationMixin[CustomTemplate]):
     name: str
-    id: str = Field(alias="albertId")
+    id: CustomTemplateId = Field(alias="albertId")
     created_by_name: str = Field(..., alias="createdByName")
     created_at: str = Field(..., alias="createdAt")
     category: str


### PR DESCRIPTION
# Summary
Reverting the change to lookup LotId from UI (lotNumber) - because no direct way to map them, also LotNumber or BarcodeId shown in UI can be modified by the user.

## Type (mark all that apply)

- [ ] Added — new feature
- [x] Fixed — bug fix
- [ ] Changed — existing functionality update
- [ ] Deprecated — will be removed soon
- [ ] Removed — feature removed

## Checklist

- [x] PR title follows Conventional Commits (e.g., `feat: add X`)
- [x] Tests added/updated for behavior changes
- [ ] Docs updated (if applicable)

## Breaking changes
<!-- Migration notes or N/A. -->
