### PR TITLE
Fix/update block workflow

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -156,7 +156,8 @@ class TaskCollection(BaseCollection):
                 if w.name == "No Parameter Group" and len(b.workflow) > 1:
                     # hardcoded default workflow
                     continue
-                existing_workflow_id = w.id
+                if w.category != "INITIAL":
+                    existing_workflow_id = w.id
         if existing_workflow_id == workflow_id:
             logger.info(f"Block {block_id} already has workflow {workflow_id}")
             return None


### PR DESCRIPTION
update_block_workflow() currently does not check if the existing_workflow_id is the "FINAL" workflow. 

**Issue 1:**
This causes the existing_workflow_id to become assigned to the "INITIAL" workflow, which can cause a patch error if the FINAL workflow does not equal the INITIAL workflow. 

**Issue 2:**
This also prevents the blocks FINAL workflow from being patched back to the INITIAL workflow 