### PR TITLE
chore(dev): pin rich and update agent note

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -155,6 +155,7 @@ Do:
 - Keep docstrings Numpy-style for public APIs.
 - Use ruff for formatting/linting and respect line length 99.
 - Follow existing collection/resource patterns and naming.
+- Only add tests when explicitly requested by the user.
 
 Don’t:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ dev = [
     "griffe-pydantic>=1.1.2",
     "mike>=2.1.3",
     "pre-commit>=4.2.0",
+    "rich>=14.3.2,<15"
 ]
 
 [project.urls]


### PR DESCRIPTION
Summary:
- Pin rich dev dependency to >=14.3.2,<15
- Note in AGENTS to only add tests when requested