### PR TITLE
feat(substance_v4): add SubstanceCollectionV4 wrapping v4 substance API

### DIFF
--- a/docs/collections/substances_v4.md
+++ b/docs/collections/substances_v4.md
@@ -1,0 +1,1 @@
+::: albert.collections.substance_v4.SubstanceV4Collection

--- a/docs/migration/alpha-to-v1.md
+++ b/docs/migration/alpha-to-v1.md
@@ -66,7 +66,7 @@ If you run into any issues, please open a [GitHub issue](https://github.com/albe
 
 *For advanced scenarios, you can still construct an auth manager manually and pass it to* `Albert(auth_manager=...)`.
 
-For complete details, see the [Authentication Guide](./authentication.md).
+For complete details, see the [Authentication Guide](../authentication.md).
 
 ---
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,0 +1,11 @@
+# Migration Guides
+
+This section documents breaking changes and feature transitions across Albert Python SDK versions.
+Pick the guide that matches your upgrade path.
+
+| Guide | Description |
+|---|---|
+| [Alpha → v1.0](alpha-to-v1.md) | Breaking changes introduced in the v1.0.0 release |
+| [Substances v3 → v4 (🧪Beta)](substances-v4.md) | Adopting the new Substance API ahead of SDK 2.0 |
+
+If you run into any issues, please open a [GitHub issue](https://github.com/albert-labs/albert-python/issues).

--- a/docs/migration/substances-v4.md
+++ b/docs/migration/substances-v4.md
@@ -1,0 +1,186 @@
+# Substances v3 → v4 (🧪Beta)
+
+!!! warning "Beta Feature"
+    `substances_v4` is currently in beta. The v3 `client.substances` collection
+    continues to work without any changes. Adopting `substances_v4` now is
+    entirely opt-in — you can migrate at your own pace before SDK 2.0.
+
+## What's changing
+
+The "v3" and "v4" labels refer to the underlying Albert backend API version — they
+are not SDK version numbers. Today, `client.substances` calls the v3 backend API,
+which supports only basic CAS-based lookups. The new `client.substances_v4`
+collection wraps the v4 backend API, which is a ground-up rework that brings
+richer substance data, multiple identifier types, search, and write capabilities
+that simply do not exist in v3.
+
+**Timeline:**
+
+| SDK version | What's available |
+|---|---|
+| 1.x (current) | Both `client.substances` (v3) and `client.substances_v4` (beta) are available |
+| 2.0 (planned) | `substances_v4` is renamed to `substances`; v3 is removed |
+
+Migrating now means your code is ready for 2.0 with only a rename.
+
+!!! danger "CAS is obsolete in SDK 2.0"
+    Starting with SDK 2.0 (v4 substances), **all write operations target the Substance entity
+    exclusively**. CAS is no longer updated by any SDK write call.
+
+    This means downstream systems that are fed from CAS — including **reports** and
+    **SQL Data Warehouse tables** — will **not** reflect changes made through the SDK once
+    you are on v4. Only the Substance entity and its associated tables are updated.
+
+    If your pipeline reads from CAS-based DWH tables or CAS-backed reports, you must
+    update those consumers to read from the Substance entity tables before migrating.
+
+---
+
+## What's new in v4
+
+- **Multiple identifier types** — look up substances by CAS ID, substance ID (`SUB…`), or external ID; v3 supports CAS ID only.
+- **Richer response model** — `SubstanceV4Info` includes toxicology data, exposure controls (ACGIH, OSHA, AIHA, NIOSH), REACH registration, carcinogen flags, and more.
+- **Search** — `search()` provides paginated free-text and field-level search across the substance catalogue.
+- **Create** — `create()` allows registering new substance records.
+- **Metadata updates** — `update_metadata()` lets you patch notes, description, SMILES, and custom tenant metadata.
+
+---
+
+## Side-by-side comparison
+
+| | v3 `client.substances` | v4 `client.substances_v4` |
+|---|---|---|
+| Look up by CAS | ✅ | ✅ |
+| Look up by substance ID | ❌ | ✅ |
+| Look up by external ID | ❌ | ✅ |
+| Bulk lookup | ✅ `get_by_ids(cas_ids=[...])` | ✅ `get_by_ids(cas_ids=[], sub_ids=[], ...)` |
+| Search | ❌ | ✅ `search(search_key=..., cas=..., ...)` |
+| Create | ❌ | ✅ `create(substance=...)` |
+| Update metadata | ❌ | ✅ `update_metadata(id=..., metadata=...)` |
+| Default region | `"US"` | `"global"` |
+| Return model | `SubstanceInfo` | `SubstanceV4Info` |
+
+---
+
+## Migrating
+
+### `get_by_id`
+
+```python
+# v3
+substance = client.substances.get_by_id(cas_id="64-17-5", region="US")
+
+# v4
+substance = client.substances_v4.get_by_id(cas_id="64-17-5")
+# or by substance ID:
+substance = client.substances_v4.get_by_id(sub_id="SUB00001")
+```
+
+!!! note "Region default changed"
+    v3 defaults to `region="US"`. v4 defaults to `region="global"`. Pass
+    `region="US"` explicitly if you rely on US-specific hazard data.
+
+### `get_by_ids`
+
+```python
+# v3 — CAS IDs only
+substances = client.substances.get_by_ids(cas_ids=["64-17-5", "67-56-1"])
+
+# v4 — CAS IDs, substance IDs, or external IDs
+substances = client.substances_v4.get_by_ids(cas_ids=["64-17-5", "67-56-1"])
+substances = client.substances_v4.get_by_ids(sub_ids=["SUB00001", "SUB00002"])
+```
+
+### `search` (new in v4)
+
+```python
+from albert import Albert
+
+client = Albert.from_client_credentials(...)
+
+# Free-text search
+for substance in client.substances_v4.search(search_key="ethanol", max_items=50):
+    print(substance.name, substance.cas_id)
+
+# Field-level search
+for substance in client.substances_v4.search(cas="64-17-5"):
+    print(substance.substance_id)
+```
+
+### `create` (new in v4)
+
+```python
+from albert.resources.substance_v4 import (
+    SubstanceV4Create,
+    SubstanceV4Identifier,
+    SubstanceV4Attribute,
+)
+
+substance = SubstanceV4Create(
+    identifiers=[
+        SubstanceV4Identifier(attributeName="casID", value="64-17-5"),
+    ],
+    attributes=[
+        SubstanceV4Attribute(attributeName="name", data="Ethanol"),
+    ],
+)
+result = client.substances_v4.create(substance=substance)
+print(result.created_items)
+```
+
+### `update_metadata` (new in v4)
+
+```python
+from albert.resources.substance_v4 import SubstanceV4Metadata
+
+current = SubstanceV4Metadata(notes="Old note", description="Common solvent")
+updated = SubstanceV4Metadata(
+    notes="Reviewed 2026-04",   # update
+    description="Common solvent",  # unchanged — not sent
+    cas_smiles="CCO",           # add (was None)
+)
+
+client.substances_v4.update_metadata(
+    id="SUB00001",
+    current_metadata=current,
+    updated_metadata=updated,
+)
+```
+
+---
+
+## Models reference
+
+All v4 models live in `albert.resources.substance_v4`. In SDK 2.0 the `V4` infix
+will be dropped; adopting these names now means the migration is a single
+find-and-replace.
+
+| Model | Used by | Purpose |
+|---|---|---|
+| `SubstanceV4Info` | `get_by_id`, `get_by_ids` | Full substance record (toxicology, exposure controls, REACH, carcinogen flags, …) |
+| `SubstanceV4SearchItem` | `search` | Lightweight record returned from search results |
+| `SubstanceV4Create` | `create` | Input model for creating a new substance |
+| `SubstanceV4MetadataItem` | `SubstanceV4Create`, `SubstanceV4Metadata` | Single list-type metadata value — `{id, name}` on read; `{id, value}` on write for multi-select |
+| `SubstanceV4Identifier` | `SubstanceV4Create` | Single identifier entry (`casID`, `ecListNo`, or `ts`) |
+| `SubstanceV4Attribute` | `SubstanceV4Create` | Single attribute entry (e.g. `name`, `hazards`) |
+| `SubstanceV4CreateResult` | `create` | Result envelope — `created_items`, `failed_items`, `existing_items` |
+| `SubstanceV4Metadata` | `update_metadata` | Patchable metadata fields: `notes`, `description`, `cas_smiles`, `inchi_key`, `iupac_name`, `cactus_status`, custom tenant metadata |
+
+---
+
+## Response model changes
+
+`SubstanceV4Info` is a superset of `SubstanceInfo`. Field names are preserved
+where they existed in v3; new fields are simply added.
+
+| Field | v3 `SubstanceInfo` | v4 `SubstanceV4Info` |
+|---|---|---|
+| `cas_id` | ✅ | ✅ |
+| `substance_id` | ❌ | ✅ |
+| `ec_list_no` | ❌ | ✅ |
+| `name` | `str` | `list[dict]` (multi-language) |
+| `hazards` | ✅ | ✅ (same structure) |
+| Toxicology | ❌ | ✅ (`oral_acute_toxicity`, etc.) |
+| Exposure controls | ❌ | ✅ (ACGIH, OSHA, AIHA, NIOSH) |
+| REACH | ❌ | ✅ (`reach_registration_no`) |
+| Carcinogen flags | ❌ | ✅ (`ntp_carcinogen`, `iarc_carcinogen`, `osha_carcinogen`) |

--- a/docs/resources/substances_v4.md
+++ b/docs/resources/substances_v4.md
@@ -1,0 +1,1 @@
+::: albert.resources.substance_v4

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,7 +122,10 @@ nav:
       - Authentication: authentication.md
       - Concepts: concepts.md
       - Configuration: configuration.md
-      - Migration Guide: migration.md
+      - Migration Guides:
+          - Overview: migration/index.md
+          - Alpha → v1.0: migration/alpha-to-v1.md
+          - Substances v3 → v4 (🧪Beta): migration/substances-v4.md
       - Contributing: CONTRIBUTING.md
   - SDK Reference:
       - Clients:
@@ -173,6 +176,7 @@ nav:
           - Storage Classes: collections/storage_classes.md
           - Storage Locations: collections/storage_locations.md
           - Substances: collections/substances.md
+          - Substances V4 (🧪Beta): collections/substances_v4.md
           - Synthesis: collections/synthesis.md
           - Tags: collections/tags.md
           - Targets (🧪Beta): collections/targets.md
@@ -223,6 +227,7 @@ nav:
           - Storage Classes: resources/storage_classes.md
           - Storage Locations: resources/storage_locations.md
           - Substances: resources/substances.md
+          - Substances V4: resources/substances_v4.md
           - Synthesis: resources/synthesis.md
           - Tags: resources/tags.md
           - Targets (🧪Beta): resources/targets.md

--- a/src/albert/client.py
+++ b/src/albert/client.py
@@ -43,6 +43,7 @@ from albert.collections.smart_datasets import SmartDatasetCollection
 from albert.collections.storage_classes import StorageClassesCollection
 from albert.collections.storage_locations import StorageLocationsCollection
 from albert.collections.substance import SubstanceCollection
+from albert.collections.substance_v4 import SubstanceV4Collection
 from albert.collections.synthesis import SynthesisCollection
 from albert.collections.tags import TagCollection
 from albert.collections.targets import TargetCollection
@@ -336,6 +337,10 @@ class Albert:
     @property
     def substances(self) -> SubstanceCollection:
         return SubstanceCollection(session=self.session)
+
+    @property
+    def substances_v4(self) -> SubstanceV4Collection:
+        return SubstanceV4Collection(session=self.session)
 
     @property
     def links(self) -> LinksCollection:

--- a/src/albert/collections/cas.py
+++ b/src/albert/collections/cas.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 from collections.abc import Iterator
 from typing import Any
 
@@ -56,6 +57,14 @@ class CasCollection(BaseCollection):
         session : AlbertSession
             The Albert session instance.
         """
+        warnings.warn(
+            "CasCollection is deprecated and will be removed in SDK 2.0. "
+            "Use client.substances_v4 instead. "
+            "In SDK 2.0, all write operations target the Substance entity exclusively — "
+            "CAS entities, reports, and SQL DWH tables backed by CAS will no longer be updated.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         super().__init__(session=session)
         self.base_path = f"/api/{CasCollection._api_version}/cas"
 

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -929,6 +929,7 @@ class InventoryCollection(BaseCollection):
         Notes
         -----
         The following fields can be updated: ``alias``, ``description``, ``is_formula_override``, ``metadata``, ``name``, ``security_class``, ``unit_category``.
+        On individual CAS entries (via ``cas``): ``min``, ``max``, ``target``, ``cas_category``, ``substance_id``, ``inventory_function``.
         """
         # Fetch the current object state from the server or database
         current_object = self.get_by_id(id=inventory_item.id)

--- a/src/albert/collections/substance_v4.py
+++ b/src/albert/collections/substance_v4.py
@@ -1,0 +1,383 @@
+import json
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import validate_call
+
+from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
+from albert.core.session import AlbertSession
+from albert.core.shared.enums import PaginationMode
+from albert.resources.substance_v4 import (
+    SubstanceV4Create,
+    SubstanceV4CreateResult,
+    SubstanceV4Info,
+    SubstanceV4Metadata,
+    SubstanceV4Response,
+    SubstanceV4SearchItem,
+)
+
+_SEARCH_PAGE_SIZE = 20  # maximum page size accepted by the v4 search endpoint
+
+
+class SubstanceV4SearchPaginator(AlbertPaginator):
+    """Paginator for substance v4 search using integer offset pagination."""
+
+    def __init__(
+        self,
+        *,
+        path: str,
+        session: AlbertSession,
+        params: dict[str, Any] | None = None,
+        max_items: int | None = None,
+    ):
+        params = dict(params or {})
+        self._offset = int(params.get("startKey", 0))
+        params["startKey"] = self._offset
+        params["limit"] = _SEARCH_PAGE_SIZE
+        super().__init__(
+            path=path,
+            mode=PaginationMode.OFFSET,
+            session=session,
+            deserialize=lambda items: [SubstanceV4SearchItem.model_validate(i) for i in items],
+            params=params,
+            max_items=max_items,
+        )
+
+    def _create_iterator(self) -> Iterator[SubstanceV4SearchItem]:
+        """Yield paginated search items."""
+        yielded = 0
+        while True:
+            response = self._request()
+            items = response.json().get("substances", [])
+
+            if not items:
+                return
+
+            for item in self.deserialize(items):
+                yield item
+                yielded += 1
+                if self.max_items is not None and yielded >= self.max_items:
+                    return
+
+            self._offset += len(items)
+            self.params["startKey"] = self._offset
+
+
+class SubstanceV4Collection(BaseCollection):
+    """SubstanceV4Collection manages substance entities in the Albert platform (🧪Beta).
+
+    !!! warning "Beta Feature!"
+        Please do not use in production or without explicit guidance from Albert. You might otherwise have a bad experience.
+        This feature currently falls outside of the Albert support contract, but we'd love your feedback!
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The Albert session instance.
+
+    Attributes
+    ----------
+    base_path : str
+        The base URL for substance API requests.
+
+    Methods
+    -------
+    get_by_ids(...) -> list[SubstanceV4Info]
+        Retrieves substances by CAS IDs, substance IDs, or external IDs.
+    get_by_id(...) -> SubstanceV4Info
+        Retrieves a single substance by CAS ID, substance ID, or external ID.
+    search(...) -> Iterator[SubstanceV4SearchItem]
+        Searches substances by keyword or advanced filters.
+    create(substance) -> SubstanceV4CreateResult
+        Creates a new substance record.
+    update_metadata(id, current_metadata, updated_metadata) -> None
+        Updates metadata fields on a substance by diffing current vs updated state.
+    """
+
+    _api_version = "v4"
+
+    def __init__(self, *, session: AlbertSession):
+        super().__init__(session=session)
+        self.base_path = f"/api/{SubstanceV4Collection._api_version}/substances"
+
+    @validate_call
+    def get_by_ids(
+        self,
+        *,
+        cas_ids: list[str] | None = None,
+        sub_ids: list[str] | None = None,
+        external_ids: list[str] | None = None,
+        region: str = "global",
+        catch_errors: bool | None = None,
+        language: str | None = None,
+        classification_type: str | None = None,
+    ) -> list[SubstanceV4Info]:
+        """Retrieve substances by their identifiers.
+
+        At least one of ``cas_ids``, ``sub_ids``, or ``external_ids`` must be provided.
+
+        Parameters
+        ----------
+        cas_ids : list[str] | None
+            CAS numbers to look up.
+        sub_ids : list[str] | None
+            Substance IDs to look up.
+        external_ids : list[str] | None
+            External IDs to look up.
+        region : str, optional
+            Region for hazard data. Common values: ``"global"``, ``"EU"``, ``"US"``,
+            ``"UK"``. Defaults to ``"global"``.
+        catch_errors : bool | None, optional
+            Whether to suppress errors for unknown substances, by default None.
+        language : str | None, optional
+            BCP-47 language code for name translation (e.g. ``"EN"``, ``"DE"``,
+            ``"FR"``), by default None.
+        classification_type : str | None, optional
+            Filter by classification type. Accepted values: ``"HARMONISED"``,
+            ``"NOTIFIED"``, ``"SELF_CLASSIFIED"``; or their display labels
+            ``"Harmonised C&L"``, ``"Notified C&L"``, ``"Self Classified"``,
+            by default None.
+
+        Returns
+        -------
+        list[SubstanceV4Info]
+            The matching substances.
+        """
+        if not any([cas_ids, sub_ids, external_ids]):
+            raise ValueError("At least one of cas_ids, sub_ids, or external_ids must be provided.")
+
+        params: dict = {"region": region}
+        if cas_ids:
+            params["casIDs"] = ",".join(cas_ids)
+        if sub_ids:
+            params["subIDs"] = ",".join(sub_ids)
+        if external_ids:
+            params["externalIDs"] = ",".join(external_ids)
+        if catch_errors is not None:
+            params["catchErrors"] = json.dumps(catch_errors)
+        if language:
+            params["language"] = language
+        if classification_type:
+            params["classificationType"] = classification_type
+
+        response = self.session.get(self.base_path, params=params)
+        return SubstanceV4Response.model_validate(response.json()).substances
+
+    @validate_call
+    def get_by_id(
+        self,
+        *,
+        cas_id: str | None = None,
+        sub_id: str | None = None,
+        external_id: str | None = None,
+        region: str = "global",
+        catch_errors: bool | None = None,
+        language: str | None = None,
+        classification_type: str | None = None,
+    ) -> SubstanceV4Info:
+        """Retrieve a single substance by its identifier.
+
+        Provide exactly one of ``cas_id``, ``sub_id``, or ``external_id``.
+
+        Parameters
+        ----------
+        cas_id : str | None
+            The CAS number.
+        sub_id : str | None
+            The substance ID.
+        external_id : str | None
+            The external ID.
+        region : str, optional
+            Region for hazard data. Common values: ``"global"``, ``"EU"``, ``"US"``,
+            ``"UK"``. Defaults to ``"global"``.
+        catch_errors : bool | None, optional
+            Whether to suppress errors for unknown substances, by default None.
+        language : str | None, optional
+            BCP-47 language code for name translation (e.g. ``"EN"``, ``"DE"``,
+            ``"FR"``), by default None.
+        classification_type : str | None, optional
+            Filter by classification type. Accepted values: ``"HARMONISED"``,
+            ``"NOTIFIED"``, ``"SELF_CLASSIFIED"``; or their display labels
+            ``"Harmonised C&L"``, ``"Notified C&L"``, ``"Self Classified"``,
+            by default None.
+
+        Returns
+        -------
+        SubstanceV4Info
+            The matching substance.
+        """
+        provided = sum([cas_id is not None, sub_id is not None, external_id is not None])
+        if provided != 1:
+            raise ValueError("Exactly one of cas_id, sub_id, or external_id must be provided.")
+
+        results = self.get_by_ids(
+            cas_ids=[cas_id] if cas_id else None,
+            sub_ids=[sub_id] if sub_id else None,
+            external_ids=[external_id] if external_id else None,
+            region=region,
+            catch_errors=catch_errors,
+            language=language,
+            classification_type=classification_type,
+        )
+        if not results:
+            raise ValueError("No substance found for the provided identifier.")
+        return results[0]
+
+    @validate_call
+    def search(
+        self,
+        *,
+        search_key: str | None = None,
+        cas: str | None = None,
+        ec: str | None = None,
+        name: str | None = None,
+        region: str = "global",
+        classification_type: str | None = None,
+        start_key: int = 0,
+        max_items: int = 100,
+    ) -> Iterator[SubstanceV4SearchItem]:
+        """Search for substances by keyword or advanced filters.
+
+        At least one of ``search_key``, ``cas``, ``ec``, or ``name`` must be provided.
+        If both ``search_key`` and advanced filters are provided, the advanced filters
+        take precedence.
+
+        Parameters
+        ----------
+        search_key : str | None
+            Free-text search term.
+        cas : str | None
+            Filter by CAS identifier.
+        ec : str | None
+            Filter by EC identifier.
+        name : str | None
+            Filter by substance name.
+        region : str, optional
+            Region for hazard data. Common values: ``"global"``, ``"EU"``, ``"US"``,
+            ``"UK"``. Defaults to ``"global"``.
+        classification_type : str | None, optional
+            Filter by classification type. Accepted values: ``"HARMONISED"``,
+            ``"NOTIFIED"``, ``"SELF_CLASSIFIED"``; or their display labels
+            ``"Harmonised C&L"``, ``"Notified C&L"``, ``"Self Classified"``,
+            by default None.
+        start_key : int, optional
+            Offset to resume pagination from, by default 0.
+        max_items : int, optional
+            Maximum number of items to yield, by default 100.
+
+        Yields
+        ------
+        SubstanceV4SearchItem
+            Matching substance search records.
+        """
+        if not any([search_key, cas, ec, name]):
+            raise ValueError("At least one of search_key, cas, ec, or name must be provided.")
+
+        params: dict = {"region": region, "startKey": start_key}
+        if search_key:
+            params["searchKey"] = search_key
+        if cas:
+            params["cas"] = cas
+        if ec:
+            params["ec"] = ec
+        if name:
+            params["name"] = name
+        if classification_type:
+            params["classificationType"] = classification_type
+
+        yield from SubstanceV4SearchPaginator(
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+        )
+
+    @validate_call
+    def create(self, *, substance: SubstanceV4Create) -> SubstanceV4CreateResult:
+        """Create a new substance record.
+
+        Parameters
+        ----------
+        substance : SubstanceV4Create
+            The substance data to create.
+
+        Returns
+        -------
+        SubstanceV4CreateResult
+            The result containing created, failed, and existing items.
+        """
+        payload = [substance.model_dump(by_alias=True, mode="json", exclude_none=True)]
+        response = self.session.post(self.base_path, json=payload)
+        return SubstanceV4CreateResult.model_validate(response.json())
+
+    @validate_call
+    def update_metadata(
+        self,
+        *,
+        id: str,
+        current_metadata: SubstanceV4Metadata,
+        updated_metadata: SubstanceV4Metadata,
+    ) -> None:
+        """Update metadata fields on a substance.
+
+        Diffs ``current_metadata`` against ``updated_metadata`` and sends only the
+        changed fields. Scalar fields support ``add`` and ``update``; custom tenant
+        metadata fields also support ``delete`` (set the key to ``None`` in
+        ``updated_metadata`` with a value in ``current_metadata``).
+
+        Parameters
+        ----------
+        id : str
+            The substance ID to update.
+        current_metadata : SubstanceV4Metadata
+            The current metadata state of the substance.
+        updated_metadata : SubstanceV4Metadata
+            The desired metadata state of the substance.
+
+        Notes
+        -----
+        The following fields can be updated: ``notes``, ``description``, ``cas_smiles``,
+        ``inchi_key``, ``iupac_name``, ``cactus_status``, and any custom metadata fields
+        configured for the tenant.
+        """
+        sub_id = id if id.startswith("SUB") else f"SUB{id}"
+        operations = []
+
+        for attr, wire_name in [
+            ("notes", "notes"),
+            ("description", "description"),
+            ("cas_smiles", "casSmiles"),
+            ("inchi_key", "inchiKey"),
+            ("iupac_name", "iUpacName"),
+            ("cactus_status", "cactusStatus"),
+        ]:
+            old = getattr(current_metadata, attr)
+            new = getattr(updated_metadata, attr)
+            if old == new:
+                continue
+            if old is None and new is not None:
+                operations.append({"operation": "add", "attribute": wire_name, "newValue": new})
+            elif old is not None and new is not None:
+                operations.append(
+                    {
+                        "operation": "update",
+                        "attribute": wire_name,
+                        "oldValue": old,
+                        "newValue": new,
+                    }
+                )
+            # spec does not support delete for scalar fields — skip old→None case
+
+        metadata_patches = self._generate_metadata_diff(
+            existing_metadata=current_metadata.metadata or {},
+            updated_metadata=updated_metadata.metadata or {},
+        )
+        operations.extend(
+            p.model_dump(by_alias=True, mode="json", exclude_none=True) for p in metadata_patches
+        )
+
+        if not operations:
+            return
+
+        self.session.patch(f"{self.base_path}/metadata/{sub_id}", json={"data": operations})

--- a/src/albert/resources/custom_fields.py
+++ b/src/albert/resources/custom_fields.py
@@ -30,6 +30,7 @@ class ServiceType(str, Enum):
     DATA_TEMPLATES = "datatemplates"
     PARAMETER_GROUPS = "parametergroups"
     CAS = "cas"
+    SUBSTANCES = "substances"
 
 
 class FieldCategory(str, Enum):

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -78,6 +78,8 @@ class CasAmount(BaseAlbertModel):
         The CAS number. Obtained from the Cas object when provided.
     inventory_function: list[ListItem | EntityLink | str] | None
         Business-controlled functions associated with the CAS in this inventory context.
+    substance_id : str | None
+        The substance ID linked to this CAS entry.
 
     !!! tip
     ---
@@ -95,6 +97,7 @@ class CasAmount(BaseAlbertModel):
     )
     type: str | None = Field(default=None)
     classification_type: str | None = Field(default=None, alias="classificationType")
+    substance_id: str | None = Field(default=None, alias="substanceId")
 
     # Read-only fields
     cas: Cas | None = Field(default=None, exclude=True)

--- a/src/albert/resources/substance_v4.py
+++ b/src/albert/resources/substance_v4.py
@@ -1,0 +1,276 @@
+from typing import Any, Literal
+
+from pydantic import ConfigDict, Field
+
+from albert.core.base import BaseAlbertModel
+from albert.core.shared.types import MetadataItem
+
+
+class SubstanceV4SearchItem(BaseAlbertModel):
+    """A lightweight substance record from a search result.
+
+    Attributes
+    ----------
+    substance_id : str | None
+        The unique substance identifier.
+    cas_id : str | None
+        The CAS number.
+    ec_list_no : str | None
+        The EC list number.
+    name : str | None
+        The substance name.
+    hazards : list[dict] | None
+        Hazard classifications.
+    wgk : str | None
+        Water hazard class (WGK).
+    classification_type : str | None
+        The classification type (e.g. Harmonised C&L, Self Classified).
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    substance_id: str | None = Field(None, alias="substanceId")
+    cas_id: str | None = Field(None, alias="casID")
+    ec_list_no: str | None = Field(None, alias="ecListNo")
+    name: str | None = None
+    hazards: list[dict] | None = None
+    wgk: str | None = Field(None, alias="WGK")
+    classification_type: str | None = Field(None, alias="classificationType")
+
+
+class SubstanceV4Info(BaseAlbertModel):
+    """A full substance record.
+
+    Attributes
+    ----------
+    substance_id : str | None
+        The unique substance identifier.
+    cas_id : str | None
+        The CAS number.
+    ec_list_no : str | None
+        The EC list number.
+    index_no : str | None
+        The index number.
+    name : list[dict] | None
+        The substance name in one or more languages.
+    hazards : list[dict] | None
+        Hazard classifications.
+    specific_concentration_limit : list[dict] | None
+        Specific concentration limits.
+    oels : bool | None
+        Whether occupational exposure limits exist.
+    exposure_controls_acgih : list[dict] | None
+        ACGIH exposure controls.
+    exposure_controls_osha : list[dict] | None
+        OSHA exposure controls.
+    exposure_controls_aiha : list[dict] | None
+        AIHA exposure controls.
+    exposure_controls_niosh : list[dict] | None
+        NIOSH exposure controls.
+    lethal_dose_and_concentrations : list[dict] | None
+        Lethal dose and concentration data.
+    inhalation_acute_toxicity : float | None
+        Inhalation acute toxicity value.
+    dermal_acute_toxicity : float | None
+        Dermal acute toxicity value.
+    oral_acute_toxicity : float | None
+        Oral acute toxicity value.
+    health_effects : str | None
+        Health effects description.
+    ntp_carcinogen : str | None
+        NTP carcinogen classification.
+    iarc_carcinogen : str | None
+        IARC carcinogen classification.
+    osha_carcinogen : bool | None
+        OSHA carcinogen flag.
+    classification_type : str | None
+        The classification type.
+    classification : str | None
+        The classification value.
+    reach_registration_no : str | None
+        REACH registration number.
+    source : str | None
+        Data source.
+    metadata : dict[str, Any] | None
+        Tenant custom metadata. Scalar fields are plain strings or numbers.
+        List-type fields return a list of ``MetadataItem`` objects
+        with ``name`` and ``id``.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    substance_id: str | None = Field(None, alias="substanceId")
+    cas_id: str | None = Field(None, alias="casID")
+    ec_list_no: str | None = Field(None, alias="ecListNo")
+    index_no: str | None = Field(None, alias="indexNo")
+    name: list[dict] | None = None
+    hazards: list[dict] | None = None
+    specific_concentration_limit: list[dict] | None = Field(
+        None, alias="specificConcentrationLimit"
+    )
+    oels: bool | None = None
+    exposure_controls_acgih: list[dict] | None = Field(None, alias="exposureControlsACGIH")
+    exposure_controls_osha: list[dict] | None = Field(None, alias="exposureControlsOSHA")
+    exposure_controls_aiha: list[dict] | None = Field(None, alias="exposureControlsAIHA")
+    exposure_controls_niosh: list[dict] | None = Field(None, alias="exposureControlsNIOSH")
+    lethal_dose_and_concentrations: list[dict] | None = Field(
+        None, alias="lethalDoseAndConcentrations"
+    )
+    inhalation_acute_toxicity: float | None = Field(None, alias="inhalationAcuteToxicity")
+    dermal_acute_toxicity: float | None = Field(None, alias="dermalAcuteToxicity")
+    oral_acute_toxicity: float | None = Field(None, alias="oralAcuteToxicity")
+    health_effects: str | None = Field(None, alias="healthEffects")
+    ntp_carcinogen: str | None = Field(None, alias="ntpCarcinogen")
+    iarc_carcinogen: str | None = Field(None, alias="iarcCarcinogen")
+    osha_carcinogen: bool | None = Field(None, alias="oshaCarcinogen")
+    classification_type: str | None = Field(None, alias="classificationType")
+    classification: str | None = None
+    reach_registration_no: str | None = Field(None, alias="reachRegistrationNo")
+    source: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class SubstanceV4Response(BaseAlbertModel):
+    """A collection of substances with any associated retrieval errors.
+
+    Attributes
+    ----------
+    substances : list[SubstanceV4Info]
+        The retrieved substances.
+    substance_errors : list[dict] | None
+        Errors for any substances that could not be retrieved, if any.
+    """
+
+    substances: list[SubstanceV4Info]
+    substance_errors: list[dict] | None = Field(None, alias="substanceErrors")
+
+
+class SubstanceV4Identifier(BaseAlbertModel):
+    """An identifier entry for creating a substance.
+
+    Attributes
+    ----------
+    attribute_name : str
+        The identifier type. One of ``casID``, ``ecListNo``, ``ts``.
+    value : str
+        The identifier value.
+    """
+
+    attribute_name: Literal["casID", "ecListNo", "ts"] = Field(..., alias="attributeName")
+    value: str
+
+
+class SubstanceV4Attribute(BaseAlbertModel):
+    """An attribute entry for creating a substance.
+
+    Attributes
+    ----------
+    attribute_name : str
+        The attribute name (e.g. ``hazards``, ``name``).
+    data : Any
+        The attribute data.
+    region : str | None
+        The region the attribute applies to, if any.
+    """
+
+    attribute_name: str = Field(..., alias="attributeName")
+    data: Any
+    region: str | None = None
+
+
+class SubstanceV4Create(BaseAlbertModel):
+    """Defines a new substance to create.
+
+    Attributes
+    ----------
+    identifiers : list[SubstanceV4Identifier]
+        At least one identifier (casID, ecListNo, or ts).
+    attributes : list[SubstanceV4Attribute]
+        Attribute data to associate with the substance.
+    substance_id : str | None
+        Optional explicit substance ID.
+    is_global_record : bool
+        Whether to create as a global record. Defaults to ``True``.
+    category : str | None
+        Substance category (e.g. ``User``, ``Verisk``, ``TSCA - Public``).
+    notes : str | None
+        Free-text notes for the substance.
+    description : str | None
+        A description of the substance.
+    cas_smiles : str | None
+        The SMILES string for the substance.
+    inchi_key : str | None
+        The InChI key for the substance.
+    iupac_name : str | None
+        The IUPAC name for the substance.
+    cactus_status : str | None
+        The Cactus status for the substance.
+    metadata : dict[str, MetadataItem] | None
+        Custom tenant metadata. Scalar fields take a plain string. Single-select
+        list fields take a bare list ID string (e.g. ``"LST1253"``). Multi-select
+        List-type fields take an ``EntityLink`` or ``list[EntityLink]``.
+    """
+
+    identifiers: list[SubstanceV4Identifier]
+    attributes: list[SubstanceV4Attribute]
+    substance_id: str | None = Field(None, alias="substanceId")
+    is_global_record: bool = Field(True, alias="isGlobalRecord")
+    category: str | None = None
+    notes: str | None = None
+    description: str | None = None
+    cas_smiles: str | None = Field(None, alias="casSmiles")
+    inchi_key: str | None = Field(None, alias="inchiKey")
+    iupac_name: str | None = Field(None, alias="iUpacName")
+    cactus_status: str | None = Field(None, alias="cactusStatus")
+    metadata: dict[str, MetadataItem] | None = Field(None, alias="Metadata")
+
+
+class SubstanceV4CreateResult(BaseAlbertModel):
+    """Result of a substance creation request.
+
+    Attributes
+    ----------
+    created_items : list[SubstanceV4Info]
+        Successfully created substances.
+    failed_items : list[dict]
+        Items that failed to create, with error details.
+    existing_items : list[dict]
+        Items that already existed.
+    """
+
+    created_items: list[SubstanceV4Info] = Field(default_factory=list, alias="createdItems")
+    failed_items: list[dict] = Field(default_factory=list, alias="failedItems")
+    existing_items: list[dict] = Field(default_factory=list, alias="existingItems")
+
+
+class SubstanceV4Metadata(BaseAlbertModel):
+    """Metadata fields that can be updated on a substance.
+
+    Attributes
+    ----------
+    notes : str | None
+        Free-text notes for the substance.
+    description : str | None
+        A description of the substance.
+    cas_smiles : str | None
+        The SMILES string for the substance.
+    inchi_key : str | None
+        The InChI key for the substance.
+    iupac_name : str | None
+        The IUPAC name for the substance.
+    cactus_status : str | None
+        The Cactus status for the substance.
+    metadata : dict[str, MetadataItem] | None
+        Custom tenant metadata. Scalar fields take a plain string. Single-select
+        list fields take a bare list ID string (e.g. ``"LST1253"``). Multi-select
+        list fields take a list of ``MetadataItem`` objects with ``id``
+        and ``value``.
+    """
+
+    notes: str | None = None
+    description: str | None = None
+    cas_smiles: str | None = Field(None, alias="casSmiles")
+    inchi_key: str | None = Field(None, alias="inchiKey")
+    iupac_name: str | None = Field(None, alias="iUpacName")
+    cactus_status: str | None = Field(None, alias="cactusStatus")
+    metadata: dict[str, MetadataItem] | None = None

--- a/src/albert/utils/inventory.py
+++ b/src/albert/utils/inventory.py
@@ -46,6 +46,8 @@ def _build_cas_add_operation(cas_amount: CasAmount) -> dict[str, Any]:
         operation["type"] = cas_amount.type
     if cas_amount.classification_type:
         operation["classificationType"] = cas_amount.classification_type
+    if cas_amount.substance_id:
+        operation["substanceId"] = cas_amount.substance_id
     return operation
 
 
@@ -160,6 +162,7 @@ def _build_cas_update_operations(existing: CasAmount, updated: CasAmount) -> lis
         ("min", existing.min, updated.min),
         ("inventoryValue", existing.target, updated.target),
         ("casCategory", existing.cas_category, updated.cas_category),
+        ("substanceId", existing.substance_id, updated.substance_id),
     ]
 
     operations: list[dict[str, Any]] = []

--- a/tests/collections/test_substance_v4.py
+++ b/tests/collections/test_substance_v4.py
@@ -1,0 +1,106 @@
+import uuid
+
+import pytest
+
+from albert.client import Albert
+from albert.resources.custom_fields import CustomField, FieldType, ServiceType
+from albert.resources.substance_v4 import (
+    SubstanceV4Attribute,
+    SubstanceV4Create,
+    SubstanceV4Identifier,
+    SubstanceV4Info,
+    SubstanceV4Metadata,
+)
+
+CAS_IDS = [
+    "134180-76-0",
+    "26530-20-1",
+    "68515-48-0",
+    "1330-20-7",
+    "7732-18-5",
+]
+
+
+def test_get_by_ids(client: Albert):
+    """Test retrieving multiple substances by CAS IDs."""
+    substances = client.substances_v4.get_by_ids(cas_ids=CAS_IDS)
+    assert isinstance(substances, list)
+    assert len(substances) >= len(
+        CAS_IDS
+    )  # API may return multiple entries per CAS (e.g. different classification types)
+    for substance in substances:
+        assert isinstance(substance, SubstanceV4Info)
+
+
+def test_get_by_id(client: Albert):
+    """Test retrieving a single substance by CAS ID."""
+    substance = client.substances_v4.get_by_id(cas_id="7732-18-5")
+    assert substance is not None
+    assert isinstance(substance, SubstanceV4Info)
+    assert substance.cas_id == "7732-18-5"
+
+
+def test_get_by_id_region(client: Albert):
+    """Test retrieving a substance with a specific region."""
+    substance = client.substances_v4.get_by_id(cas_id="134180-76-0", region="EU")
+    assert substance is not None
+    assert substance.cas_id == "134180-76-0"
+
+
+def test_get_by_ids_requires_at_least_one_identifier(client: Albert):
+    """Test that get_by_ids raises when no identifier is provided."""
+    with pytest.raises(ValueError):
+        client.substances_v4.get_by_ids()
+
+
+def test_update_metadata(client: Albert, static_custom_fields: list[CustomField]):
+    """Test updating scalar and custom string metadata fields on a tenant substance."""
+    substance_string_field = next(
+        cf
+        for cf in static_custom_fields
+        if cf.service == ServiceType.SUBSTANCES and cf.field_type == FieldType.STRING
+    )
+
+    # Create a fresh tenant substance each run (unique ts → always new, no oldValue mismatch)
+    result = client.substances_v4.create(
+        substance=SubstanceV4Create(
+            is_global_record=False,
+            identifiers=[
+                SubstanceV4Identifier(
+                    attributeName="ts", value=f"sdk-test-sub-{uuid.uuid4().hex[:8]}"
+                )
+            ],
+            attributes=[
+                SubstanceV4Attribute(
+                    attributeName="name",
+                    region="global",
+                    data=[{"name": "SDK Test Substance", "language_code": "EN"}],
+                ),
+            ],
+        )
+    )
+    assert result.created_items, "Expected a freshly created substance"
+    sub_id = result.created_items[0].substance_id
+    assert sub_id
+
+    # All fields start as None → all operations are "add"
+    client.substances_v4.update_metadata(
+        id=sub_id,
+        current_metadata=SubstanceV4Metadata(),
+        updated_metadata=SubstanceV4Metadata(
+            notes="sdk test note",
+            cas_smiles="CCO",
+            metadata={substance_string_field.name: "sdk test value"},
+        ),
+    )
+
+
+# TODO: search tests disabled — backend pagination bug causes duplicates and
+# inconsistent page sizes. Re-enable once the backend fixes startKey/limit behaviour.
+# Ticket filed with backend team.
+
+# def test_search_by_search_key(client: Albert): ...
+# def test_search_by_cas(client: Albert): ...
+# def test_search_by_name(client: Albert): ...
+# def test_search_max_items(client: Albert): ...
+# def test_search_with_start_key(client: Albert): ...

--- a/tests/resources/test_inventory.py
+++ b/tests/resources/test_inventory.py
@@ -34,6 +34,7 @@ def test_cas_amount_attributes():
         "updated",
         "classification_type",
         "type",
+        "substance_id",
     }
 
 

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -113,6 +113,7 @@ def generate_custom_fields() -> list[CustomField]:
         ServiceType.PARAMETER_GROUPS,
         ServiceType.DATA_TEMPLATES,
         ServiceType.CAS,
+        ServiceType.SUBSTANCES,
     ]
 
     seeds = []


### PR DESCRIPTION
## Summary
- Adds `SubstanceCollectionV4` at `client.substances_v4` wrapping the new `/api/v4/substances` API
- Implements `get_by_ids`, `get_by_id`, `search` (with paginator), `create`, and `update_metadata`
- Adds `SubstanceV4Info`, `SubstanceV4SearchItem`, `SubstanceV4Create`, `SubstanceV4CreateResult`, `SubstanceV4Metadata`, and `SubstanceV4Response` resource models
- Fully additive and non-breaking — v3 `SubstanceCollection` is untouched; `V4` suffix will be stripped in SDK 2.0 when v3 is deprecated