### PR TITLE
ci(workflows): add Claude Code at-mention workflow

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,40 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  pull_request_review:
+    types: [submitted]
+  issues:
+    types: [opened, assigned]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_teams: "albert-labs/sdk-maintainers"
+          claude_args: "--model claude-sonnet-4-6"
+          additional_permissions: |
+            actions: read


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/claude-code.yml` to enable `@claude` mentions in issues, PR comments, PR review comments, and PR reviews
- Restricted to `albert-labs/sdk-maintainers` team via `allowed_teams` — non-members are silently ignored, protecting Anthropic API credits
- Pins model to `claude-sonnet-4-6` for predictable cost