### PR TITLE
fix(specs): allowed float reference values

### DIFF
--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -270,6 +270,13 @@ class InventorySpecValue(BaseAlbertModel):
     reference: str | None = Field(default=None)
     comparison_operator: str | None = Field(default=None, alias="comparisonOperator")
 
+    @field_validator("min", "max", "reference", mode="before")
+    @classmethod
+    def cast_float_to_str(cls, v: Any) -> Any:
+        if isinstance(v, float):
+            return str(v)
+        return v
+
 
 class InventorySpec(BaseAlbertModel):
     id: str | None = Field(default=None, alias="albertId")


### PR DESCRIPTION
@prasad-albert  this is a temporary fix because the API is returning floats when its contract says they should be string. I need this fixed ASAP so I am putting in this befroevalidator as a workaround - we can remove when it is fixed properly.