### PR TITLE
feat(smart-datasets): add target line data models and get_target_data

### DIFF
--- a/src/albert/collections/smart_datasets.py
+++ b/src/albert/collections/smart_datasets.py
@@ -1,7 +1,10 @@
+from pydantic import validate_call
+
 from albert.collections.base import BaseCollection
 from albert.core.session import AlbertSession
-from albert.core.shared.identifiers import SmartDatasetId
+from albert.core.shared.identifiers import SmartDatasetId, TargetId
 from albert.resources.smart_datasets import SmartDataset, SmartDatasetScope
+from albert.resources.targets import AggregateBy, TargetLineData
 
 
 class SmartDatasetCollection(BaseCollection):
@@ -33,6 +36,8 @@ class SmartDatasetCollection(BaseCollection):
         Updates a smart dataset by its ID.
     delete(id) -> None
         Deletes a smart dataset by its ID.
+    get_target_data(smart_dataset_id, target_id, ...) -> TargetLineData
+        Retrieves target line data for a specific target within a smart dataset.
     """
 
     _api_version = "v3"
@@ -147,3 +152,51 @@ class SmartDatasetCollection(BaseCollection):
         """
         url = f"{self.base_path}/{id}"
         self.session.delete(url)
+
+    @validate_call
+    def get_target_data(
+        self,
+        *,
+        smart_dataset_id: SmartDatasetId,
+        target_id: TargetId,
+        aggregate_by: AggregateBy | None = None,
+        inventory_id: str | None = None,
+        lot_id: str | None = None,
+        workflow_id: str | None = None,
+    ) -> TargetLineData:
+        """
+        Retrieves target line data for a specific target within a smart dataset.
+
+        Parameters
+        ----------
+        smart_dataset_id : SmartDatasetId
+            The ID of the smart dataset.
+        target_id : TargetId
+            The ID of the target.
+        aggregate_by : AggregateBy, optional
+            The aggregation dimension. Defaults to ``"measurement"`` server-side.
+        inventory_id : str, optional
+            Scopes data to a specific inventory item.
+        lot_id : str, optional
+            Scopes data to a specific lot.
+        workflow_id : str, optional
+            Scopes data to a specific workflow run.
+
+        Returns
+        -------
+        TargetLineData
+            The target line data for the given target.
+        """
+        url = f"{self.base_path}/{smart_dataset_id}/targets/{target_id}/data"
+        params: dict = {}
+        if aggregate_by is not None:
+            params["aggregate_by"] = aggregate_by.value
+        if inventory_id is not None:
+            params["inventory_id"] = inventory_id
+        if lot_id is not None:
+            params["lot_id"] = lot_id
+        if workflow_id is not None:
+            params["workflow_id"] = workflow_id
+        response = self.session.get(url, params=params or None)
+        body = response.json()["result"]["body"]
+        return TargetLineData(**body)

--- a/src/albert/resources/targets.py
+++ b/src/albert/resources/targets.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
+from typing import Annotated, Literal
 
 from pydantic import Field
 
@@ -156,3 +157,97 @@ class Target(BaseResource):
     target_value: TargetValue = Field(alias="targetValue")
     is_required: bool = Field(alias="isRequired")
     validation: list[dict] | None = Field(default=None)
+
+
+class AggregateBy(str, Enum):
+    """Aggregation dimension for target line data queries.
+
+    Attributes
+    ----------
+    MEASUREMENT : str
+        Aggregate by individual measurement.
+    WORKFLOW : str
+        Aggregate by workflow run.
+    INVENTORY : str
+        Aggregate by inventory item.
+    LOT : str
+        Aggregate by lot.
+    """
+
+    MEASUREMENT = "measurement"
+    WORKFLOW = "workflow"
+    INVENTORY = "inventory"
+    LOT = "lot"
+
+
+class TargetLineBetweenValue(BaseAlbertModel):
+    """Target value for a 'between' range constraint.
+
+    Attributes
+    ----------
+    operator : Literal["between"]
+        The comparison operator.
+    min : float
+        Lower bound of the range.
+    max : float
+        Upper bound of the range.
+    """
+
+    operator: Literal["between"]
+    min: float
+    max: float
+
+
+class TargetLineScalarValue(BaseAlbertModel):
+    """Target value for a scalar comparison constraint.
+
+    Attributes
+    ----------
+    operator : Literal["lt", "lte", "gt", "gte", "eq"]
+        The comparison operator.
+    value : float
+        The scalar threshold.
+    """
+
+    operator: Literal["lt", "lte", "gt", "gte", "eq"]
+    value: float
+
+
+class TargetLineSetValue(BaseAlbertModel):
+    """Target value for an in-set constraint.
+
+    Attributes
+    ----------
+    operator : Literal["in-set"]
+        The comparison operator.
+    values : list[str | float]
+        The set of allowed values.
+    """
+
+    operator: Literal["in-set"]
+    values: list[str | float]
+
+
+TargetLineValue = Annotated[
+    TargetLineBetweenValue | TargetLineScalarValue | TargetLineSetValue,
+    Field(discriminator="operator"),
+]
+"""Discriminated union of target line value shapes, keyed on ``operator``."""
+
+
+class TargetLineData(BaseAlbertModel):
+    """Response payload for a target line data request.
+
+    Attributes
+    ----------
+    target_id : str
+        The target ID.
+    target_value : TargetLineValue
+        The target constraint and its operator.
+    data_points : list[float]
+        The data points associated with this target.
+    """
+
+    target_id: str = Field(alias="targetId")
+    target_value: TargetLineValue = Field(alias="targetValue")
+    data_points: list[float] = Field(alias="dataPoints")


### PR DESCRIPTION
## Summary
- Adds `AggregateBy`, `TargetLineBetweenValue`, `TargetLineScalarValue`, `TargetLineSetValue`, `TargetLineValue`, and `TargetLineData` to `resources/targets.py` to model the response from the target line data endpoint
- Adds `SmartDatasetCollection.get_target_data()` wrapping `GET /api/v3/smartdatasets/{smartDatasetId}/targets/{targetId}/data` with optional `aggregate_by`, `inventory_id`, `lot_id`, and `workflow_id` filters
- Part of FEAT-123 (Target Lines)

## Note
The `between` operator response shape (`min`/`max` at top level vs nested under `value`) should be verified against a live API response — see FEAT-123 sdk.md for details.