### PR TITLE
feat(attributes): add AttributeCollection with CRUD and reference values

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,6 +117,13 @@ class TagCollection(BaseCollection):
     """
 ```
 
+## Deprecations
+
+- Deprecating a **method**: use `@deprecated("... will be removed in 2.0. Use X instead.")` from `typing_extensions`. This gives IDE strike-through and static analysis warnings at the call site.
+- Deprecating a **class**: call `warnings.warn(..., DeprecationWarning, stacklevel=2)` in `__init__`. This fires a runtime warning at instantiation time.
+- Message format: `"thing() is deprecated and will be removed in 2.0. Use client.x.y() instead."`
+- Note: `@deprecated` alone does **not** emit a runtime `DeprecationWarning` — it is a static analysis hint only.
+
 ## After Every Code Edit
 
 ```bash

--- a/docs/collections/attributes.md
+++ b/docs/collections/attributes.md
@@ -1,0 +1,1 @@
+::: albert.collections.attributes.AttributeCollection

--- a/docs/migration/alpha-to-v1.md
+++ b/docs/migration/alpha-to-v1.md
@@ -66,7 +66,7 @@ If you run into any issues, please open a [GitHub issue](https://github.com/albe
 
 *For advanced scenarios, you can still construct an auth manager manually and pass it to* `Albert(auth_manager=...)`.
 
-For complete details, see the [Authentication Guide](./authentication.md).
+For complete details, see the [Authentication Guide](../authentication.md).
 
 ---
 

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -1,0 +1,11 @@
+# Migration Guides
+
+This section documents breaking changes and feature transitions across Albert Python SDK versions.
+Pick the guide that matches your upgrade path.
+
+| Guide | Description |
+|---|---|
+| [Alpha → v1.0](alpha-to-v1.md) | Breaking changes introduced in the v1.0.0 release |
+| [Specs → Attributes (🧪 Beta)](specs-to-attributes.md) | Replacing `inventory.get_specs` / `add_specs` with the new Attributes API ahead of SDK 2.0 |
+
+If you run into any issues, please open a [GitHub issue](https://github.com/albert-labs/albert-python/issues).

--- a/docs/migration/index.md
+++ b/docs/migration/index.md
@@ -7,5 +7,6 @@ Pick the guide that matches your upgrade path.
 |---|---|
 | [Alpha → v1.0](alpha-to-v1.md) | Breaking changes introduced in the v1.0.0 release |
 | [Substances v3 → v4 (🧪Beta)](substances-v4.md) | Adopting the new Substance API ahead of SDK 2.0 |
+| [Specs → Attributes (🧪 Beta)](specs-to-attributes.md) | Replacing `inventory.get_specs` / `add_specs` with the new Attributes API ahead of SDK 2.0 |
 
 If you run into any issues, please open a [GitHub issue](https://github.com/albert-labs/albert-python/issues).

--- a/docs/migration/specs-to-attributes.md
+++ b/docs/migration/specs-to-attributes.md
@@ -1,0 +1,202 @@
+# Specs → Attributes (🧪 Beta)
+
+!!! warning "Beta Feature"
+    `client.attributes` is currently in beta. The existing `client.inventory.get_specs()`
+    and `client.inventory.add_specs()` methods continue to work but are deprecated and will
+    be removed in SDK 2.0. Adopting the new Attributes API now is entirely opt-in — you can
+    migrate at your own pace.
+
+## What's changing
+
+The legacy Specs system is being replaced by two new concepts:
+
+- **Attributes** — globally-defined, reusable property templates (e.g. "Viscosity @ 25°C")
+  managed at the tenant level via `client.attributes`.
+- **Reference Values** — the actual measured or assigned values for a given attribute on a
+  specific inventory item or lot, managed via `client.attributes.add_values()` and related
+  methods.
+
+Previously, specs were defined and assigned to inventory items in a single step using
+`InventorySpec`. The new API separates **definition** (what property is being tracked)
+from **value** (what that property measures for this specific item).
+
+**Timeline:**
+
+| SDK version | What's available |
+|---|---|
+| 1.x (current) | Both `client.inventory.get_specs()` / `add_specs()` (deprecated) and `client.attributes` (beta) are available |
+| 2.0 (planned) | `get_specs()`, `add_specs()`, `InventorySpec`, `InventorySpecValue`, `InventorySpecList` are removed |
+
+Migrating now means your code is ready for 2.0 without further changes.
+
+---
+
+## What's new
+
+- **Centralised attribute library** — attributes are defined once at the tenant level and
+  reused across any number of inventory items and lots. Specs were defined per-item with no
+  sharing.
+- **Typed validation** — each attribute declares a `datatype` (`number`, `string`, `enum`)
+  with optional range or operator constraints.
+- **Lot-level values** — reference values can be assigned to individual lots (`LOT…`), not
+  just inventory items.
+- **Scoped reads** — `get_values(scope=ALL)` returns values for an inventory item and all
+  its lots in one call.
+- **Search** — `client.attributes.search()` provides full-text and field-level search across
+  the attribute catalogue.
+
+---
+
+## Side-by-side comparison
+
+| | `client.inventory` (deprecated) | `client.attributes` (new) |
+|---|---|---|
+| Define a property | Inline in `InventorySpec` | `client.attributes.create(attribute=...)` |
+| Assign a value to inventory | `add_specs(inventory_id=..., specs=[...])` | `add_values(parent_id=..., values=[...])` |
+| Read values for inventory | `get_specs(ids=[...])` | `get_values(parent_id=..., scope=SELF)` |
+| Read values for inventory + lots | ❌ not supported | `get_values(parent_id=..., scope=ALL)` |
+| Read values for lots only | ❌ not supported | `get_values(parent_id=..., scope=LOT)` |
+| Bulk read across many items | ❌ not supported | `get_bulk_values(parent_ids=[...])` |
+| Remove a specific value | ❌ not supported | `delete_values(parent_id=..., attribute_ids=[...])` |
+| Remove all values | ❌ not supported | `clear_values(parent_id=...)` |
+| Search attributes | ❌ not supported | `client.attributes.search(text=...)` |
+| Shared attribute definitions | ❌ not supported | ✅ defined once, used everywhere |
+| Return model | `InventorySpecList` | `AttributeValuesResponse` |
+
+---
+
+## Migrating
+
+### Step 1 — Create attribute definitions
+
+In the old system, property definitions lived inside each `InventorySpec`. In the new system,
+you define attributes once and reuse them.
+
+```python
+from albert.resources.attributes import Attribute, AttributeCategory, ValidationItem
+from albert.resources.parameter_groups import DataType, Operator
+
+# Create a reusable "Viscosity" attribute
+viscosity_attr = client.attributes.create(
+    attribute=Attribute(
+        datacolumn_id="DAC123",           # the data column this property maps to
+        category=AttributeCategory.PROPERTY,
+        reference_name="Viscosity @ 25°C",
+        validation=[
+            ValidationItem(
+                datatype=DataType.NUMBER,
+                min=0.0,
+                max=500.0,
+                operator=Operator.BETWEEN,
+            )
+        ],
+    )
+)
+print(viscosity_attr.id)  # e.g. "ATR469"
+```
+
+---
+
+### Step 2 — Assign values to inventory items
+
+```python
+from albert.resources.attributes import AttributeValue
+
+# Before (deprecated)
+from albert.resources.inventory import InventorySpec, InventorySpecValue
+
+client.inventory.add_specs(
+    inventory_id="INVA123",
+    specs=[
+        InventorySpec(
+            name="Viscosity",
+            data_column_id="DAC123",
+            value=InventorySpecValue(reference="45.2"),
+        )
+    ],
+)
+
+# After
+client.attributes.add_values(
+    parent_id="INVA123",
+    values=[
+        AttributeValue(attributeId=viscosity_attr.id, referenceValue=45.2),
+    ],
+)
+```
+
+`add_values` is upsert — if a value already exists for an attribute it is updated, not
+duplicated.
+
+---
+
+### Step 3 — Read values back
+
+```python
+# Before (deprecated)
+spec_lists = client.inventory.get_specs(ids=["INVA123"])
+for spec_list in spec_lists:
+    for spec in spec_list.specs:
+        print(spec.name, spec.value.reference)
+
+# After — inventory item only (scope defaults to SELF)
+for response in client.attributes.get_values(parent_id="INVA123"):
+    for attr_value in response.attributes:
+        print(attr_value.attribute_definition.name, attr_value.reference_value)
+
+# After — inventory item + all its lots
+for response in client.attributes.get_values(
+    parent_id="INVA123",
+    scope=AttributeScope.ALL,
+):
+    print(response.parent_id)
+    for attr_value in response.attributes:
+        print(attr_value.attribute_definition.name, attr_value.reference_value)
+```
+
+---
+
+### Removing values
+
+The old `InventorySpec` API had no way to remove values. The new API supports both targeted
+and full removal.
+
+```python
+# Remove a specific attribute's value
+client.attributes.delete_values(
+    parent_id="INVA123",
+    attribute_ids=["ATR469"],
+)
+
+# Remove all attribute values from an inventory item
+client.attributes.clear_values(parent_id="INVA123")
+
+# Remove all values from an inventory item and all its lots
+client.attributes.clear_values(parent_id="INVA123", scope=AttributeScope.ALL)
+```
+
+---
+
+## Resource model changes
+
+| | `InventorySpec` (deprecated) | `AttributeValue` + `AttributeValuesResponse` (new) |
+|---|---|---|
+| Property identifier | `data_column_id: str` (inline) | `attribute_id: AttributeId` (references a shared `Attribute`) |
+| Value | `InventorySpecValue.reference: str` | `reference_value: str \| float \| None` |
+| Range | `InventorySpecValue.min`, `.max` | `AttributeValueRange.min`, `.max`, `.comparison_operator` |
+| Property metadata | Embedded in `InventorySpec` | Separate `AttributeDefinition` (name, datacolumn, unit, validation, prmCount) |
+| Lot-level support | ❌ | ✅ — any `parent_id` including `LOT…` IDs |
+
+---
+
+## Deprecated symbols
+
+The following are deprecated in 1.x and will be removed in 2.0:
+
+| Symbol | Replacement |
+|---|---|
+| `client.inventory.get_specs()` | `client.attributes.get_values()` |
+| `client.inventory.add_specs()` | `client.attributes.add_values()` |
+| `InventorySpec` | `Attribute` + `AttributeValue` |
+| `InventorySpecValue` | `AttributeValueRange` |
+| `InventorySpecList` | `AttributeValuesResponse` |

--- a/docs/migration/specs-to-attributes.md
+++ b/docs/migration/specs-to-attributes.md
@@ -1,0 +1,202 @@
+# Specs → Attributes (🧪 Beta)
+
+!!! warning "Beta Feature"
+    `client.attributes` is currently in beta. The existing `client.inventory.get_specs()`
+    and `client.inventory.add_specs()` methods continue to work but are deprecated and will
+    be removed in SDK 2.0. Adopting the new Attributes API now is entirely opt-in — you can
+    migrate at your own pace.
+
+## What's changing
+
+The legacy Specs system is being replaced by two new concepts:
+
+- **Attributes** — globally-defined, reusable property templates (e.g. "Viscosity @ 25°C")
+  managed at the tenant level via `client.attributes`.
+- **Reference Values** — the actual measured or assigned values for a given attribute on a
+  specific inventory item or lot, managed via `client.attributes.add_values()` and related
+  methods.
+
+Previously, specs were defined and assigned to inventory items in a single step using
+`InventorySpec`. The new API separates **definition** (what property is being tracked)
+from **value** (what that property measures for this specific item).
+
+**Timeline:**
+
+| SDK version | What's available |
+|---|---|
+| 1.x (current) | Both `client.inventory.get_specs()` / `add_specs()` (deprecated) and `client.attributes` (beta) are available |
+| 2.0 (planned) | `get_specs()`, `add_specs()`, `InventorySpec`, `InventorySpecValue`, `InventorySpecList` are removed |
+
+Migrating now means your code is ready for 2.0 without further changes.
+
+---
+
+## What's new
+
+- **Centralised attribute library** — attributes are defined once at the tenant level and
+  reused across any number of inventory items and lots. Specs were defined per-item with no
+  sharing.
+- **Typed validation** — each attribute declares a `datatype` (`number`, `string`, `enum`)
+  with optional range or operator constraints.
+- **Lot-level values** — reference values can be assigned to individual lots (`LOT…`), not
+  just inventory items.
+- **Scoped reads** — `get_values(scope=ALL)` returns values for an inventory item and all
+  its lots in one call.
+- **Search** — `client.attributes.search()` provides full-text and field-level search across
+  the attribute catalogue.
+
+---
+
+## Side-by-side comparison
+
+| | `client.inventory` (deprecated) | `client.attributes` (new) |
+|---|---|---|
+| Define a property | Inline in `InventorySpec` | `client.attributes.create(attribute=...)` |
+| Assign a value to inventory | `add_specs(inventory_id=..., specs=[...])` | `add_values(parent_id=..., values=[...])` |
+| Read values for multiple inventory items | `get_specs(ids=[...])` | `get_by_parent_ids(parent_ids=[...])` |
+| Read values for inventory + lots | ❌ not supported | `get_values(parent_id=..., scope=ALL)` |
+| Read values for lots only | ❌ not supported | `get_values(parent_id=..., scope=LOT)` |
+| Remove a specific value | ❌ not supported | `delete_values(parent_id=..., attribute_ids=[...])` |
+| Remove all values | ❌ not supported | `clear_values(parent_id=...)` |
+| Search attributes | ❌ not supported | `client.attributes.search(text=...)` |
+| Shared attribute definitions | ❌ not supported | ✅ defined once, used everywhere |
+| Return model | `InventorySpecList` | `AttributeValuesResponse` |
+
+---
+
+## Migrating
+
+### Step 1 — Create attribute definitions
+
+In the old system, property definitions lived inside each `InventorySpec`. In the new system,
+you define attributes once and reuse them.
+
+```python
+from albert.resources.attributes import Attribute, AttributeCategory, ValidationItem
+from albert.resources.parameter_groups import DataType, Operator
+
+# Create a reusable "Viscosity" attribute
+viscosity_attr = client.attributes.create(
+    attribute=Attribute(
+        datacolumn_id="DAC123",           # the data column this property maps to
+        category=AttributeCategory.PROPERTY,
+        reference_name="Viscosity @ 25°C",
+        validation=[
+            ValidationItem(
+                datatype=DataType.NUMBER,
+                min=0.0,
+                max=500.0,
+                operator=Operator.BETWEEN,
+            )
+        ],
+    )
+)
+print(viscosity_attr.id)  # e.g. "ATR469"
+```
+
+---
+
+### Step 2 — Assign values to inventory items
+
+```python
+from albert.resources.attributes import AttributeValue
+
+# Before (deprecated)
+from albert.resources.inventory import InventorySpec, InventorySpecValue
+
+client.inventory.add_specs(
+    inventory_id="INVA123",
+    specs=[
+        InventorySpec(
+            name="Viscosity",
+            data_column_id="DAC123",
+            value=InventorySpecValue(reference="45.2"),
+        )
+    ],
+)
+
+# After
+client.attributes.add_values(
+    parent_id="INVA123",
+    values=[
+        AttributeValue(attributeId=viscosity_attr.id, referenceValue=45.2),
+    ],
+)
+```
+
+`add_values` is upsert — if a value already exists for an attribute it is updated, not
+duplicated.
+
+---
+
+### Step 3 — Read values back
+
+```python
+# Before (deprecated)
+spec_lists = client.inventory.get_specs(ids=["INVA123", "INVA456"])
+for spec_list in spec_lists:
+    for spec in spec_list.specs:
+        print(spec.name, spec.value.reference)
+
+# After — bulk read across multiple inventory items
+responses = client.attributes.get_by_parent_ids(parent_ids=["INVA123", "INVA456"])
+for response in responses:
+    for attr_value in response.attributes:
+        print(attr_value.attribute_definition.name, attr_value.reference_value)
+
+# After — single item with lot-level scope
+for response in client.attributes.get_values(
+    parent_id="INVA123",
+    scope=AttributeScope.ALL,
+):
+    print(response.parent_id)
+    for attr_value in response.attributes:
+        print(attr_value.attribute_definition.name, attr_value.reference_value)
+```
+
+---
+
+### Removing values
+
+The old `InventorySpec` API had no way to remove values. The new API supports both targeted
+and full removal.
+
+```python
+# Remove a specific attribute's value
+client.attributes.delete_values(
+    parent_id="INVA123",
+    attribute_ids=["ATR469"],
+)
+
+# Remove all attribute values from an inventory item
+client.attributes.clear_values(parent_id="INVA123")
+
+# Remove all values from an inventory item and all its lots
+client.attributes.clear_values(parent_id="INVA123", scope=AttributeScope.ALL)
+```
+
+---
+
+## Resource model changes
+
+| | `InventorySpec` (deprecated) | `AttributeValue` + `AttributeValuesResponse` (new) |
+|---|---|---|
+| Property identifier | `data_column_id: str` (inline) | `attribute_id: AttributeId` (references a shared `Attribute`) |
+| Value | `InventorySpecValue.reference: str` | `reference_value: str \| float \| None` |
+| Range | `InventorySpecValue.min`, `.max` | `AttributeValueRange.min`, `.max`, `.comparison_operator` |
+| Property metadata | Embedded in `InventorySpec` | Separate `AttributeDefinition` (name, datacolumn, unit, validation, prmCount) |
+| Lot-level support | ❌ | ✅ — any `parent_id` including `LOT…` IDs |
+
+---
+
+## Deprecated symbols
+
+The following are deprecated in 1.x and will be removed in 2.0:
+
+| Symbol | Replacement |
+|---|---|
+| `client.inventory.get_specs()` | `client.attributes.get_by_parent_ids()` |
+| `client.inventory.add_specs()` | `client.attributes.add_values()` |
+| `InventorySpec` | `Attribute` + `AttributeValue` |
+| `InventorySpecValue` | `AttributeValueRange` |
+| `InventorySpecList` | `AttributeValuesResponse` |

--- a/docs/migration/substances-v4.md
+++ b/docs/migration/substances-v4.md
@@ -130,20 +130,13 @@ print(result.created_items)
 
 ### `update_metadata` (new in v4)
 
+Pass only the keyword arguments you want to change — all others are left unchanged.
+
 ```python
-from albert.resources.substance_v4 import SubstanceV4Metadata
-
-current = SubstanceV4Metadata(notes="Old note", description="Common solvent")
-updated = SubstanceV4Metadata(
-    notes="Reviewed 2026-04",   # update
-    description="Common solvent",  # unchanged — not sent
-    cas_smiles="CCO",           # add (was None)
-)
-
 client.substances_v4.update_metadata(
     id="SUB00001",
-    current_metadata=current,
-    updated_metadata=updated,
+    notes="Reviewed 2026-04",
+    cas_smiles="CCO",
 )
 ```
 

--- a/docs/resources/attributes.md
+++ b/docs/resources/attributes.md
@@ -1,0 +1,1 @@
+::: albert.resources.attributes

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,7 +122,10 @@ nav:
       - Authentication: authentication.md
       - Concepts: concepts.md
       - Configuration: configuration.md
-      - Migration Guide: migration.md
+      - Migration Guides:
+          - Overview: migration/index.md
+          - Alpha → v1.0: migration/alpha-to-v1.md
+          - Specs → Attributes (🧪 Beta): migration/specs-to-attributes.md
       - Contributing: CONTRIBUTING.md
   - SDK Reference:
       - Clients:
@@ -134,6 +137,7 @@ nav:
       - Collections:
           - Activities: collections/activities.md
           - Attachments: collections/attachments.md
+          - Attributes: collections/attributes.md
           - Batch Data: collections/batch_data.md
           - Base: collections/base.md
           - Breakthrough:
@@ -186,6 +190,7 @@ nav:
       - Resources:
           - Activities: resources/activities.md
           - Attachments: resources/attachments.md
+          - Attributes: resources/attributes.md
           - ACL: resources/acls.md
           - Batch Data: resources/batch_data.md
           - Breakthrough:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -126,6 +126,7 @@ nav:
           - Overview: migration/index.md
           - Alpha → v1.0: migration/alpha-to-v1.md
           - Substances v3 → v4 (🧪Beta): migration/substances-v4.md
+          - Specs → Attributes (🧪 Beta): migration/specs-to-attributes.md
       - Contributing: CONTRIBUTING.md
   - SDK Reference:
       - Clients:
@@ -137,6 +138,7 @@ nav:
       - Collections:
           - Activities: collections/activities.md
           - Attachments: collections/attachments.md
+          - Attributes: collections/attributes.md
           - Batch Data: collections/batch_data.md
           - Base: collections/base.md
           - Breakthrough:
@@ -190,6 +192,7 @@ nav:
       - Resources:
           - Activities: resources/activities.md
           - Attachments: resources/attachments.md
+          - Attributes: resources/attributes.md
           - ACL: resources/acls.md
           - Batch Data: resources/batch_data.md
           - Breakthrough:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pydantic[email]>=2.8.2,<3",
     "pyjwt>=2.10.0,<3",
     "tenacity>=8.2.3",
+    "typing_extensions>=4.6.1",
 ]
 
 [dependency-groups]

--- a/src/albert/client.py
+++ b/src/albert/client.py
@@ -6,6 +6,7 @@ from pydantic import SecretStr
 
 from albert.collections.activities import ActivityCollection
 from albert.collections.attachments import AttachmentCollection
+from albert.collections.attributes import AttributeCollection
 from albert.collections.batch_data import BatchDataCollection
 from albert.collections.btdataset import BTDatasetCollection
 from albert.collections.btinsight import BTInsightCollection
@@ -180,6 +181,10 @@ class Albert:
     @property
     def attachments(self) -> AttachmentCollection:
         return AttachmentCollection(session=self.session)
+
+    @property
+    def attributes(self) -> AttributeCollection:
+        return AttributeCollection(session=self.session)
 
     @property
     def tags(self) -> TagCollection:

--- a/src/albert/client.py
+++ b/src/albert/client.py
@@ -6,6 +6,7 @@ from pydantic import SecretStr
 
 from albert.collections.activities import ActivityCollection
 from albert.collections.attachments import AttachmentCollection
+from albert.collections.attributes import AttributeCollection
 from albert.collections.batch_data import BatchDataCollection
 from albert.collections.btdataset import BTDatasetCollection
 from albert.collections.btinsight import BTInsightCollection
@@ -181,6 +182,10 @@ class Albert:
     @property
     def attachments(self) -> AttachmentCollection:
         return AttachmentCollection(session=self.session)
+
+    @property
+    def attributes(self) -> AttributeCollection:
+        return AttributeCollection(session=self.session)
 
     @property
     def tags(self) -> TagCollection:

--- a/src/albert/collections/attributes.py
+++ b/src/albert/collections/attributes.py
@@ -153,6 +153,7 @@ class AttributeCollection(BaseCollection):
         items = data.get("Items") or data.get("items") or []
         return [Attribute(**item) for item in items]
 
+    @validate_call
     def create(self, *, attribute: Attribute) -> Attribute:
         """Create a new attribute.
 
@@ -172,11 +173,9 @@ class AttributeCollection(BaseCollection):
         response = self.session.post(self.base_path, json=payload)
         return Attribute(**response.json())
 
+    @validate_call
     def update(self, *, attribute: Attribute) -> Attribute:
         """Update an existing attribute.
-
-        Enum value changes are handled transparently via a separate enums
-        endpoint before applying any field-level patches.
 
         Parameters
         ----------
@@ -187,6 +186,11 @@ class AttributeCollection(BaseCollection):
         -------
         Attribute
             The updated Attribute.
+
+        Notes
+        -----
+        The following fields can be updated: ``reference_name``, ``parameters``,
+        ``validation``, ``unit_id``.
         """
         if attribute.id is None:
             raise ValueError("Attribute ID is required for update.")

--- a/src/albert/collections/attributes.py
+++ b/src/albert/collections/attributes.py
@@ -1,0 +1,544 @@
+from collections.abc import Iterator
+from contextlib import suppress
+from typing import Any
+
+from pydantic import validate_call
+
+from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
+from albert.core.session import AlbertSession
+from albert.core.shared.enums import OrderBy, PaginationMode
+from albert.core.shared.identifiers import AttributeId, DataColumnId
+from albert.core.shared.models.patch import PatchDatum, PatchOperation, PatchPayload
+from albert.exceptions import AlbertException
+from albert.resources.attributes import (
+    Attribute,
+    AttributeCategory,
+    AttributeScope,
+    AttributeSearchItem,
+    AttributeValue,
+    AttributeValuesResponse,
+)
+from albert.resources.parameter_groups import DataType
+from albert.utils._patch import generate_enum_patches
+
+
+class AttributeCollection(BaseCollection):
+    """AttributeCollection manages Attribute entities in the Albert platform.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The Albert session instance.
+
+    Attributes
+    ----------
+    base_path : str
+        The base URL for attribute API requests.
+
+    Methods
+    -------
+    get_all(category, start_key, max_items) -> Iterator[Attribute]
+        Lists all attributes with optional filters.
+    get_by_id(id) -> Attribute
+        Retrieves an attribute by its ID.
+    get_by_ids(ids) -> list[Attribute]
+        Retrieves multiple attributes by their IDs.
+    create(attribute) -> Attribute
+        Creates a new attribute.
+    update(attribute) -> Attribute
+        Updates an existing attribute.
+    delete(id) -> None
+        Deletes an attribute by its ID.
+    search(...) -> Iterator[AttributeSearchItem]
+        Searches for attributes.
+    add_values(parent_id, values) -> AttributeValuesResponse
+        Adds or updates reference values for a parent entity.
+    get_values(parent_id, scope, start_key, max_items) -> Iterator[AttributeValuesResponse]
+        Retrieves reference values for a parent entity.
+    get_bulk_values(parent_ids) -> list[AttributeValuesResponse]
+        Retrieves reference values for multiple parent entities.
+    delete_values(parent_id, attribute_ids, scope) -> None
+        Deletes specific reference values from a parent entity.
+    clear_values(parent_id, scope) -> None
+        Removes all reference values from a parent entity.
+    """
+
+    _updatable_attributes = {"reference_name", "parameters", "validation"}
+    _api_version = "v3"
+
+    def __init__(self, *, session: AlbertSession):
+        """Initialize the AttributeCollection.
+
+        Parameters
+        ----------
+        session : AlbertSession
+            The Albert session instance.
+        """
+        super().__init__(session=session)
+        self.base_path = f"/api/{self._api_version}/attributes"
+
+    @validate_call
+    def get_all(
+        self,
+        *,
+        category: AttributeCategory | None = None,
+        start_key: str | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[Attribute]:
+        """List all attributes with optional filters.
+
+        Parameters
+        ----------
+        category : AttributeCategory, optional
+            Filter attributes by category.
+        start_key : str, optional
+            Pagination start key from a previous request.
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[Attribute]
+            An iterator over Attribute entities.
+        """
+        params: dict[str, Any] = {}
+        if category is not None:
+            params["category"] = category.value
+        if start_key is not None:
+            params["startKey"] = start_key
+
+        yield from AlbertPaginator(
+            path=self.base_path,
+            mode=PaginationMode.KEY,
+            session=self.session,
+            deserialize=lambda items: [Attribute(**item) for item in items],
+            params=params,
+            max_items=max_items,
+        )
+
+    @validate_call
+    def get_by_id(self, *, id: AttributeId) -> Attribute:
+        """Retrieve an attribute by its ID.
+
+        Parameters
+        ----------
+        id : str
+            The attribute ID.
+
+        Returns
+        -------
+        Attribute
+            The matching Attribute.
+        """
+        response = self.session.get(f"{self.base_path}/{id}")
+        return Attribute(**response.json())
+
+    @validate_call
+    def get_by_ids(self, *, ids: list[AttributeId]) -> list[Attribute]:
+        """Retrieve multiple attributes by their IDs.
+
+        Parameters
+        ----------
+        ids : list[str]
+            A list of attribute IDs.
+
+        Returns
+        -------
+        list[Attribute]
+            The matching Attribute objects.
+        """
+        response = self.session.get(f"{self.base_path}/ids", params={"id": ids})
+        data = response.json()
+        items = data.get("Items") or data.get("items") or []
+        return [Attribute(**item) for item in items]
+
+    def create(self, *, attribute: Attribute) -> Attribute:
+        """Create a new attribute.
+
+        Parameters
+        ----------
+        attribute : Attribute
+            The attribute to create.
+
+        Returns
+        -------
+        Attribute
+            The created Attribute.
+        """
+        payload = attribute.model_dump(
+            by_alias=True, exclude_unset=True, mode="json", exclude={"id"}
+        )
+        response = self.session.post(self.base_path, json=payload)
+        return Attribute(**response.json())
+
+    def update(self, *, attribute: Attribute) -> Attribute:
+        """Update an existing attribute.
+
+        Enum value changes are handled transparently via a separate enums
+        endpoint before applying any field-level patches.
+
+        Parameters
+        ----------
+        attribute : Attribute
+            The updated Attribute object. Must have an ID set.
+
+        Returns
+        -------
+        Attribute
+            The updated Attribute.
+        """
+        if attribute.id is None:
+            raise ValueError("Attribute ID is required for update.")
+
+        existing = self.get_by_id(id=attribute.id)
+
+        enum_patches = self._generate_enum_patches(existing=existing, updated=attribute)
+        if enum_patches:
+            self.session.put(f"{self.base_path}/{attribute.id}/enums", json={"data": enum_patches})
+
+        patch_payload = self._generate_attribute_patch_payload(
+            existing=existing, updated=attribute, skip_validation=bool(enum_patches)
+        )
+        if len(patch_payload.data) > 0:
+            self.session.patch(
+                f"{self.base_path}/{attribute.id}",
+                json=patch_payload.model_dump(by_alias=True, mode="json"),
+            )
+
+        return self.get_by_id(id=attribute.id)
+
+    @validate_call
+    def delete(self, *, id: AttributeId) -> None:
+        """Delete an attribute by its ID.
+
+        Parameters
+        ----------
+        id : str
+            The attribute ID.
+
+        Returns
+        -------
+        None
+        """
+        self.session.delete(f"{self.base_path}/{id}")
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        order_by: OrderBy = OrderBy.DESCENDING,
+        sort_by: str | None = None,
+        datacolumn_id: list[DataColumnId] | None = None,
+        datacolumn_name: list[str] | None = None,
+        parameter: list[str] | None = None,
+        unit: list[str] | None = None,
+        data_type: list[DataType] | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[AttributeSearchItem]:
+        """Search for attributes with optional filters.
+
+        Parameters
+        ----------
+        text : str, optional
+            Full-text search term.
+        order_by : OrderBy, optional
+            Sort order. Default is DESCENDING.
+        sort_by : str, optional
+            Field to sort results by.
+        datacolumn_id : list[str], optional
+            Filter by data column IDs.
+        datacolumn_name : list[str], optional
+            Filter by data column names.
+        parameter : list[str], optional
+            Filter by parameter name(s) (e.g., ``["Temperature", "Pressure"]``).
+        unit : list[str], optional
+            Filter by unit name(s) (e.g., ``["cP", "MPa"]``).
+        data_type : list[DataType], optional
+            Filter by data type(s).
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[AttributeSearchItem]
+            An iterator over search results.
+        """
+        body: dict[str, Any] = {"order": order_by}
+        if text is not None:
+            body["text"] = text
+        if sort_by is not None:
+            body["sortBy"] = sort_by
+        if datacolumn_id is not None:
+            body["datacolumnId"] = datacolumn_id
+        if datacolumn_name is not None:
+            body["datacolumnName"] = datacolumn_name
+        if parameter is not None:
+            body["parameter"] = parameter
+        if unit is not None:
+            body["unit"] = unit
+        if data_type is not None:
+            body["dataType"] = data_type
+
+        yield from AlbertPaginator(
+            path=f"{self.base_path}/search",
+            mode=PaginationMode.OFFSET,
+            session=self.session,
+            deserialize=lambda items: [AttributeSearchItem(**item) for item in items],
+            method="POST",
+            json=body,
+            max_items=max_items,
+        )
+
+    # --- Attribute Values ---
+
+    @validate_call
+    def add_values(
+        self,
+        *,
+        parent_id: str,
+        values: list[AttributeValue],
+    ) -> AttributeValuesResponse:
+        """Add or update reference values for a parent entity.
+
+        If a value already exists for any of the provided attributes it is
+        replaced. Attributes not mentioned in ``values`` are left unchanged.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity (inventory item, lot, etc.).
+        values : list[AttributeValue]
+            The attribute values to add or update.
+
+        Returns
+        -------
+        AttributeValuesResponse
+            The saved attribute values with full attribute definitions.
+        """
+        attribute_ids = [v.attribute_id for v in values]
+        with suppress(AlbertException):
+            self.delete_values(parent_id=parent_id, attribute_ids=attribute_ids)
+        payload = [v.model_dump(by_alias=True, mode="json", exclude_none=True) for v in values]
+        response = self.session.put(f"{self.base_path}/values/{parent_id}", json=payload)
+        return AttributeValuesResponse(**response.json())
+
+    @validate_call
+    def get_values(
+        self,
+        *,
+        parent_id: str,
+        scope: AttributeScope | None = None,
+        start_key: str | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[AttributeValuesResponse]:
+        """Retrieve reference values for a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        scope : AttributeScope, optional
+            Defines which entities to fetch values for.
+            ``SELF`` (default) — the parent entity only.
+            ``LOT`` — lot entities under the parent (inventory parents only).
+            ``ALL`` — parent and all child entities.
+        start_key : str, optional
+            Pagination start key from a previous request.
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[AttributeValuesResponse]
+            An iterator over attribute value responses, one per entity.
+        """
+        params: dict[str, Any] = {}
+        if scope is not None:
+            params["scope"] = scope.value
+        if start_key is not None:
+            params["startKey"] = start_key
+
+        yield from AlbertPaginator(
+            path=f"{self.base_path}/values/{parent_id}",
+            mode=PaginationMode.KEY,
+            session=self.session,
+            deserialize=lambda items: [AttributeValuesResponse(**item) for item in items],
+            params=params,
+            max_items=max_items,
+        )
+
+    @validate_call
+    def get_bulk_values(
+        self,
+        *,
+        parent_ids: list[str],
+    ) -> list[AttributeValuesResponse]:
+        """Retrieve reference values for multiple parent entities in one call.
+
+        Parameters
+        ----------
+        parent_ids : list[str]
+            The IDs of the parent entities to fetch values for.
+
+        Returns
+        -------
+        list[AttributeValuesResponse]
+            Attribute values for each parent entity that has values set.
+        """
+        response = self.session.get(f"{self.base_path}/values", params={"parentId": parent_ids})
+        data = response.json()
+        items = data.get("Items") or data.get("items") or []
+        return [AttributeValuesResponse(**item) for item in items]
+
+    @validate_call
+    def delete_values(
+        self,
+        *,
+        parent_id: str,
+        attribute_ids: list[AttributeId],
+        scope: AttributeScope | None = None,
+    ) -> None:
+        """Delete specific reference values from a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        attribute_ids : list[str]
+            The attribute IDs whose values should be removed.
+        scope : AttributeScope, optional
+            Scope of deletion. Defaults to ``SELF``.
+
+        Returns
+        -------
+        None
+        """
+        params: dict[str, Any] = {"attributeId": attribute_ids}
+        if scope is not None:
+            params["scope"] = scope.value
+        self.session.delete(f"{self.base_path}/values/{parent_id}", params=params)
+
+    @validate_call
+    def clear_values(
+        self,
+        *,
+        parent_id: str,
+        scope: AttributeScope | None = None,
+    ) -> None:
+        """Remove all reference values from a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        scope : AttributeScope, optional
+            Scope of deletion. Defaults to ``SELF``.
+
+        Returns
+        -------
+        None
+        """
+        params: dict[str, Any] = {}
+        if scope is not None:
+            params["scope"] = scope.value
+        self.session.delete(f"{self.base_path}/values/{parent_id}", params=params)
+
+    # --- Internal helpers ---
+
+    def _generate_attribute_patch_payload(
+        self, *, existing: Attribute, updated: Attribute, skip_validation: bool = False
+    ) -> PatchPayload:
+        data: list[PatchDatum] = []
+
+        old_name = existing.reference_name
+        new_name = updated.reference_name
+        if new_name is not None and old_name != new_name:
+            if old_name is None:
+                data.append(
+                    PatchDatum(
+                        attribute="referenceName",
+                        operation=PatchOperation.ADD,
+                        new_value=new_name,
+                    )
+                )
+            else:
+                data.append(
+                    PatchDatum(
+                        attribute="referenceName",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_name,
+                        new_value=new_name,
+                    )
+                )
+
+        old_validation = existing.validation
+        new_validation = updated.validation
+        if not skip_validation and new_validation is not None and old_validation != new_validation:
+            old_val_dump = (
+                [v.model_dump(by_alias=True, mode="json") for v in old_validation]
+                if old_validation
+                else []
+            )
+            new_val_dump = [v.model_dump(by_alias=True, mode="json") for v in new_validation]
+            if old_val_dump != new_val_dump:
+                data.append(
+                    PatchDatum(
+                        attribute="validation",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_val_dump,
+                        new_value=new_val_dump,
+                    )
+                )
+
+        old_params = existing.parameters
+        new_params = updated.parameters
+        if new_params is not None:
+            old_params_dump = self._dump_parameters(old_params)
+            new_params_dump = self._dump_parameters(new_params)
+            if old_params_dump != new_params_dump:
+                data.append(
+                    PatchDatum(
+                        attribute="parameters",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_params_dump,
+                        new_value=new_params_dump,
+                    )
+                )
+
+        if updated.unit_id is not None and existing.unit is None:
+            data.append(
+                PatchDatum(
+                    attribute="unitId",
+                    operation=PatchOperation.ADD,
+                    new_value=updated.unit_id,
+                )
+            )
+
+        return PatchPayload(data=data)
+
+    @staticmethod
+    def _dump_parameters(params: list | None) -> list[dict[str, Any]]:
+        if not params:
+            return []
+        return [p.model_dump(by_alias=True, mode="json", exclude_none=True) for p in params]
+
+    @staticmethod
+    def _generate_enum_patches(*, existing: Attribute, updated: Attribute) -> list[dict]:
+        if not updated.validation or not existing.validation:
+            return []
+
+        updated_val = updated.validation[0]
+        existing_val = existing.validation[0]
+
+        if updated_val.datatype != DataType.ENUM or existing_val.datatype != DataType.ENUM:
+            return []
+
+        existing_enums = existing_val.value if isinstance(existing_val.value, list) else []
+        updated_enums = updated_val.value if isinstance(updated_val.value, list) else []
+
+        return generate_enum_patches(
+            existing_enums=existing_enums,
+            updated_enums=updated_enums,
+        )

--- a/src/albert/collections/attributes.py
+++ b/src/albert/collections/attributes.py
@@ -1,0 +1,571 @@
+from collections.abc import Iterator
+from contextlib import suppress
+from typing import Any
+
+from pydantic import validate_call
+
+from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
+from albert.core.session import AlbertSession
+from albert.core.shared.enums import OrderBy, PaginationMode
+from albert.core.shared.identifiers import AttributeId, DataColumnId
+from albert.core.shared.models.patch import PatchDatum, PatchOperation, PatchPayload
+from albert.exceptions import NotFoundError
+from albert.resources.attributes import (
+    Attribute,
+    AttributeCategory,
+    AttributeScope,
+    AttributeSearchItem,
+    AttributeValue,
+    AttributeValuesResponse,
+    AttributeValuesResponseItem,
+)
+from albert.resources.parameter_groups import DataType
+from albert.utils._patch import generate_enum_patches
+
+
+class AttributeCollection(BaseCollection):
+    """AttributeCollection manages Attribute entities in the Albert platform.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The Albert session instance.
+
+    Attributes
+    ----------
+    base_path : str
+        The base URL for attribute API requests.
+
+    Methods
+    -------
+    get_all(category, start_key, max_items) -> Iterator[Attribute]
+        Lists all attributes with optional filters.
+    get_by_id(id) -> Attribute
+        Retrieves an attribute by its ID.
+    get_by_ids(ids) -> list[Attribute]
+        Retrieves multiple attributes by their IDs.
+    create(attribute) -> Attribute
+        Creates a new attribute.
+    update(attribute) -> Attribute
+        Updates an existing attribute.
+    delete(id) -> None
+        Deletes an attribute by its ID.
+    search(...) -> Iterator[AttributeSearchItem]
+        Searches for attributes.
+    add_values(parent_id, values) -> AttributeValuesResponse
+        Adds or updates reference values for a parent entity.
+    get_values(parent_id, scope, start_key, max_items) -> Iterator[AttributeValuesResponse]
+        Retrieves reference values for a parent entity.
+    get_by_parent_ids(parent_ids, max_items) -> list[AttributeValuesResponse]
+        Retrieves reference values for multiple parent entities.
+    delete_values(parent_id, attribute_ids, scope) -> None
+        Deletes specific reference values from a parent entity.
+    clear_values(parent_id, scope) -> None
+        Removes all reference values from a parent entity.
+    """
+
+    _updatable_attributes = {"reference_name", "parameters", "validation"}
+    _api_version = "v3"
+
+    def __init__(self, *, session: AlbertSession):
+        """Initialize the AttributeCollection.
+
+        Parameters
+        ----------
+        session : AlbertSession
+            The Albert session instance.
+        """
+        super().__init__(session=session)
+        self.base_path = f"/api/{self._api_version}/attributes"
+
+    @validate_call
+    def get_all(
+        self,
+        *,
+        category: AttributeCategory | None = None,
+        start_key: str | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[Attribute]:
+        """List all attributes with optional filters.
+
+        Parameters
+        ----------
+        category : AttributeCategory, optional
+            Filter attributes by category.
+        start_key : str, optional
+            Pagination start key from a previous request.
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[Attribute]
+            An iterator over Attribute entities.
+        """
+        params: dict[str, Any] = {}
+        if category is not None:
+            params["category"] = category.value
+        if start_key is not None:
+            params["startKey"] = start_key
+
+        yield from AlbertPaginator(
+            path=self.base_path,
+            mode=PaginationMode.KEY,
+            session=self.session,
+            deserialize=lambda items: [Attribute(**item) for item in items],
+            params=params,
+            max_items=max_items,
+        )
+
+    @validate_call
+    def get_by_id(self, *, id: AttributeId) -> Attribute:
+        """Retrieve an attribute by its ID.
+
+        Parameters
+        ----------
+        id : str
+            The attribute ID.
+
+        Returns
+        -------
+        Attribute
+            The matching Attribute.
+        """
+        response = self.session.get(f"{self.base_path}/{id}")
+        return Attribute(**response.json())
+
+    @validate_call
+    def get_by_ids(self, *, ids: list[AttributeId]) -> list[Attribute]:
+        """Retrieve multiple attributes by their IDs.
+
+        Parameters
+        ----------
+        ids : list[str]
+            A list of attribute IDs.
+
+        Returns
+        -------
+        list[Attribute]
+            The matching Attribute objects.
+        """
+        response = self.session.get(f"{self.base_path}/ids", params={"id": ids})
+        data = response.json()
+        items = data.get("Items") or data.get("items") or []
+        return [Attribute(**item) for item in items]
+
+    @validate_call
+    def create(self, *, attribute: Attribute) -> Attribute:
+        """Create a new attribute.
+
+        Parameters
+        ----------
+        attribute : Attribute
+            The attribute to create.
+
+        Returns
+        -------
+        Attribute
+            The created Attribute.
+        """
+        payload = attribute.model_dump(
+            by_alias=True, exclude_unset=True, mode="json", exclude={"id"}
+        )
+        response = self.session.post(self.base_path, json=payload)
+        return Attribute(**response.json())
+
+    @validate_call
+    def update(self, *, attribute: Attribute) -> Attribute:
+        """Update an existing attribute.
+
+        Parameters
+        ----------
+        attribute : Attribute
+            The updated Attribute object. Must have an ID set.
+
+        Returns
+        -------
+        Attribute
+            The updated Attribute.
+
+        Notes
+        -----
+        The following fields can be updated: ``reference_name``, ``parameters``,
+        ``validation``. ``unit_id`` can only be set once (when no unit is currently
+        assigned); it cannot be changed afterwards.
+        """
+        if attribute.id is None:
+            raise ValueError("Attribute ID is required for update.")
+
+        existing = self.get_by_id(id=attribute.id)
+
+        enum_patches = self._generate_enum_patches(existing=existing, updated=attribute)
+        if enum_patches:
+            self.session.put(f"{self.base_path}/{attribute.id}/enums", json={"data": enum_patches})
+
+        patch_payload = self._generate_attribute_patch_payload(
+            existing=existing, updated=attribute, skip_validation=bool(enum_patches)
+        )
+        if len(patch_payload.data) > 0:
+            self.session.patch(
+                f"{self.base_path}/{attribute.id}",
+                json=patch_payload.model_dump(by_alias=True, mode="json"),
+            )
+
+        return self.get_by_id(id=attribute.id)
+
+    @validate_call
+    def delete(self, *, id: AttributeId) -> None:
+        """Delete an attribute by its ID.
+
+        Parameters
+        ----------
+        id : str
+            The attribute ID.
+
+        Returns
+        -------
+        None
+        """
+        self.session.delete(f"{self.base_path}/{id}")
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        order_by: OrderBy = OrderBy.DESCENDING,
+        sort_by: str | None = None,
+        datacolumn_id: list[DataColumnId] | None = None,
+        datacolumn_name: list[str] | None = None,
+        parameter: list[str] | None = None,
+        unit: list[str] | None = None,
+        data_type: list[DataType] | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[AttributeSearchItem]:
+        """Search for attributes with optional filters.
+
+        Parameters
+        ----------
+        text : str, optional
+            Full-text search term.
+        order_by : OrderBy, optional
+            Sort order. Default is DESCENDING.
+        sort_by : str, optional
+            Field to sort results by.
+        datacolumn_id : list[str], optional
+            Filter by data column IDs.
+        datacolumn_name : list[str], optional
+            Filter by data column names.
+        parameter : list[str], optional
+            Filter by parameter name(s) (e.g., ``["Temperature", "Pressure"]``).
+        unit : list[str], optional
+            Filter by unit name(s) (e.g., ``["cP", "MPa"]``).
+        data_type : list[DataType], optional
+            Filter by data type(s).
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[AttributeSearchItem]
+            An iterator over search results.
+        """
+        body: dict[str, Any] = {"order": order_by}
+        if text is not None:
+            body["text"] = text
+        if sort_by is not None:
+            body["sortBy"] = sort_by
+        if datacolumn_id is not None:
+            body["datacolumnId"] = datacolumn_id
+        if datacolumn_name is not None:
+            body["datacolumnName"] = datacolumn_name
+        if parameter is not None:
+            body["parameter"] = parameter
+        if unit is not None:
+            body["unit"] = unit
+        if data_type is not None:
+            body["dataType"] = data_type
+
+        yield from AlbertPaginator(
+            path=f"{self.base_path}/search",
+            mode=PaginationMode.OFFSET,
+            session=self.session,
+            deserialize=lambda items: [AttributeSearchItem(**item) for item in items],
+            method="POST",
+            json=body,
+            max_items=max_items,
+        )
+
+    # --- Attribute Values ---
+
+    @validate_call
+    def add_values(
+        self,
+        *,
+        parent_id: str,
+        values: list[AttributeValue],
+    ) -> AttributeValuesResponse:
+        """Add or update reference values for a parent entity.
+
+        If a value already exists for any of the provided attributes it is
+        replaced. Attributes not mentioned in ``values`` are left unchanged.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity (inventory item, lot, etc.).
+        values : list[AttributeValue]
+            The attribute values to add or update.
+
+        Returns
+        -------
+        AttributeValuesResponse
+            The saved attribute values with full attribute definitions.
+        """
+        attribute_ids = [v.attribute_id for v in values]
+        with suppress(NotFoundError):
+            self.delete_values(parent_id=parent_id, attribute_ids=attribute_ids)
+        payload = [v.model_dump(by_alias=True, mode="json", exclude_none=True) for v in values]
+        response = self.session.put(f"{self.base_path}/values/{parent_id}", json=payload)
+        return AttributeValuesResponse(**response.json())
+
+    @validate_call
+    def get_values(
+        self,
+        *,
+        parent_id: str,
+        scope: AttributeScope | None = None,
+        start_key: str | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[AttributeValuesResponse]:
+        """Retrieve reference values for a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        scope : AttributeScope, optional
+            Defines which entities to fetch values for.
+            ``SELF`` (default) — the parent entity only.
+            ``LOT`` — lot entities under the parent (inventory parents only).
+            ``ALL`` — parent and all child entities.
+        start_key : str, optional
+            Pagination start key from a previous request.
+        max_items : int, optional
+            Maximum number of items to return.
+
+        Returns
+        -------
+        Iterator[AttributeValuesResponse]
+            An iterator over attribute value responses, one per entity.
+        """
+        params: dict[str, Any] = {}
+        if scope is not None:
+            params["scope"] = scope.value
+        if start_key is not None:
+            params["startKey"] = start_key
+
+        yield from AlbertPaginator(
+            path=f"{self.base_path}/values/{parent_id}",
+            mode=PaginationMode.KEY,
+            session=self.session,
+            deserialize=lambda items: [AttributeValuesResponse(**item) for item in items],
+            params=params,
+            max_items=max_items,
+        )
+
+    @validate_call
+    def get_by_parent_ids(
+        self,
+        *,
+        parent_ids: list[str],
+        max_items: int | None = None,
+    ) -> list[AttributeValuesResponse]:
+        """Retrieve reference values for multiple parent entities.
+
+        Parameters
+        ----------
+        parent_ids : list[str]
+            The IDs of the parent entities to fetch values for.
+        max_items : int | None, optional
+            Maximum total number of attribute value items to return across all
+            parents. When None (default), all pages are fetched for every parent.
+
+        Returns
+        -------
+        list[AttributeValuesResponse]
+            Attribute values for each parent entity that has values set.
+        """
+        pending: list[dict] = [{"parentId": pid} for pid in parent_ids]
+        accumulated: dict[str, list[AttributeValuesResponseItem]] = {}
+        total = 0
+
+        while pending:
+            response = self.session.post(f"{self.base_path}/values", json=pending)
+            next_pending: list[dict] = []
+            for item in response.json().get("items") or []:
+                parsed = AttributeValuesResponse.model_validate(item)
+                accumulated.setdefault(parsed.parent_id, []).extend(parsed.attributes)
+                total += len(parsed.attributes)
+                if last_key := item.get("lastKey"):
+                    next_pending.append({"parentId": parsed.parent_id, "startKey": last_key})
+            pending = next_pending
+            if max_items is not None and total >= max_items:
+                break
+
+        return [
+            AttributeValuesResponse.model_validate({"parentId": pid, "attributes": attrs})
+            for pid, attrs in accumulated.items()
+        ]
+
+    @validate_call
+    def delete_values(
+        self,
+        *,
+        parent_id: str,
+        attribute_ids: list[AttributeId],
+        scope: AttributeScope | None = None,
+    ) -> None:
+        """Delete specific reference values from a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        attribute_ids : list[str]
+            The attribute IDs whose values should be removed.
+        scope : AttributeScope, optional
+            Scope of deletion. Defaults to ``SELF``.
+
+        Returns
+        -------
+        None
+        """
+        params: dict[str, Any] = {"attributeId": attribute_ids}
+        if scope is not None:
+            params["scope"] = scope.value
+        self.session.delete(f"{self.base_path}/values/{parent_id}", params=params)
+
+    @validate_call
+    def clear_values(
+        self,
+        *,
+        parent_id: str,
+        scope: AttributeScope | None = None,
+    ) -> None:
+        """Remove all reference values from a parent entity.
+
+        Parameters
+        ----------
+        parent_id : str
+            The ID of the parent entity.
+        scope : AttributeScope, optional
+            Scope of deletion. Defaults to ``SELF``.
+
+        Returns
+        -------
+        None
+        """
+        params: dict[str, Any] = {}
+        if scope is not None:
+            params["scope"] = scope.value
+        self.session.delete(f"{self.base_path}/values/{parent_id}", params=params)
+
+    # --- Internal helpers ---
+
+    def _generate_attribute_patch_payload(
+        self, *, existing: Attribute, updated: Attribute, skip_validation: bool = False
+    ) -> PatchPayload:
+        data: list[PatchDatum] = []
+
+        old_name = existing.reference_name
+        new_name = updated.reference_name
+        if new_name is not None and old_name != new_name:
+            if old_name is None:
+                data.append(
+                    PatchDatum(
+                        attribute="referenceName",
+                        operation=PatchOperation.ADD,
+                        new_value=new_name,
+                    )
+                )
+            else:
+                data.append(
+                    PatchDatum(
+                        attribute="referenceName",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_name,
+                        new_value=new_name,
+                    )
+                )
+
+        old_validation = existing.validation
+        new_validation = updated.validation
+        if not skip_validation and new_validation is not None and old_validation != new_validation:
+            old_val_dump = (
+                [v.model_dump(by_alias=True, mode="json") for v in old_validation]
+                if old_validation
+                else []
+            )
+            new_val_dump = [v.model_dump(by_alias=True, mode="json") for v in new_validation]
+            if old_val_dump != new_val_dump:
+                data.append(
+                    PatchDatum(
+                        attribute="validation",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_val_dump,
+                        new_value=new_val_dump,
+                    )
+                )
+
+        old_params = existing.parameters
+        new_params = updated.parameters
+        if new_params is not None:
+            old_params_dump = self._dump_parameters(old_params)
+            new_params_dump = self._dump_parameters(new_params)
+            if old_params_dump != new_params_dump:
+                data.append(
+                    PatchDatum(
+                        attribute="parameters",
+                        operation=PatchOperation.UPDATE,
+                        old_value=old_params_dump,
+                        new_value=new_params_dump,
+                    )
+                )
+
+        if updated.unit_id is not None and existing.unit is None:
+            data.append(
+                PatchDatum(
+                    attribute="unitId",
+                    operation=PatchOperation.ADD,
+                    new_value=updated.unit_id,
+                )
+            )
+
+        return PatchPayload(data=data)
+
+    @staticmethod
+    def _dump_parameters(params: list | None) -> list[dict[str, Any]]:
+        if not params:
+            return []
+        return [p.model_dump(by_alias=True, mode="json", exclude_none=True) for p in params]
+
+    @staticmethod
+    def _generate_enum_patches(*, existing: Attribute, updated: Attribute) -> list[dict]:
+        if not updated.validation or not existing.validation:
+            return []
+
+        updated_val = updated.validation[0]
+        existing_val = existing.validation[0]
+
+        if updated_val.datatype != DataType.ENUM or existing_val.datatype != DataType.ENUM:
+            return []
+
+        existing_enums = existing_val.value if isinstance(existing_val.value, list) else []
+        updated_enums = updated_val.value if isinstance(updated_val.value, list) else []
+
+        return generate_enum_patches(
+            existing_enums=existing_enums,
+            updated_enums=updated_enums,
+        )

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -280,7 +280,7 @@ class InventoryCollection(BaseCollection):
 
     @deprecated(
         "add_specs() is deprecated and will be removed in 2.0. "
-        "Use client.attributes.set_values() instead."
+        "Use client.attributes.add_values() instead."
     )
     @validate_call
     def add_specs(

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Iterator
 
 from pydantic import TypeAdapter, validate_call
+from typing_extensions import deprecated
 
 from albert.collections.base import BaseCollection
 from albert.collections.cas import Cas
@@ -251,6 +252,10 @@ class InventoryCollection(BaseCollection):
         return inventory
 
     @validate_call
+    @deprecated(
+        "get_specs() is deprecated and will be removed in 2.0. "
+        "Use client.attributes.get_values() instead."
+    )
     def get_specs(self, *, ids: list[InventoryId]) -> list[InventorySpecList]:
         """Get the specs for a list of inventory items.
 
@@ -273,6 +278,10 @@ class InventoryCollection(BaseCollection):
             for item in self.session.get(url, params={"id": batch}).json()
         ]
 
+    @deprecated(
+        "add_specs() is deprecated and will be removed in 2.0. "
+        "Use client.attributes.set_values() instead."
+    )
     @validate_call
     def add_specs(
         self,

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -2,6 +2,7 @@ import logging
 from collections.abc import Iterator
 
 from pydantic import TypeAdapter, validate_call
+from typing_extensions import deprecated
 
 from albert.collections.base import BaseCollection
 from albert.collections.cas import Cas
@@ -250,6 +251,10 @@ class InventoryCollection(BaseCollection):
             inventory.extend([InventoryItem(**item) for item in response.json()["Items"]])
         return inventory
 
+    @deprecated(
+        "get_specs() is deprecated and will be removed in 2.0. "
+        "Use client.attributes.get_by_parent_ids() instead."
+    )
     @validate_call
     def get_specs(self, *, ids: list[InventoryId]) -> list[InventorySpecList]:
         """Get the specs for a list of inventory items.
@@ -273,6 +278,10 @@ class InventoryCollection(BaseCollection):
             for item in self.session.get(url, params={"id": batch}).json()
         ]
 
+    @deprecated(
+        "add_specs() is deprecated and will be removed in 2.0. "
+        "Use client.attributes.add_values() instead."
+    )
     @validate_call
     def add_specs(
         self,

--- a/src/albert/core/pagination.py
+++ b/src/albert/core/pagination.py
@@ -96,7 +96,7 @@ class AlbertPaginator(Iterator[ItemType]):
         while True:
             response = self._request()
             data = response.json()
-            items = data.get("Items", [])
+            items = data.get("Items") or data.get("items") or []
             item_count = len(items)
 
             if not items and self.mode == PaginationMode.OFFSET:

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -4,6 +4,7 @@ from typing import Annotated
 from pydantic import AfterValidator
 
 _ALBERT_PREFIXES = {
+    "AttributeId": "ATR",
     "AttachmentId": "ATT",
     "BlockId": "BLK",
     "BTInsightId": "INS",
@@ -82,6 +83,13 @@ def _ensure_albert_id(id: str, id_type: str) -> str:
         raise ValueError(f"{id_type} {id} has invalid prefix. Expected: {prefix}")
 
     return f"{prefix}{id.upper()}"
+
+
+def ensure_attribute_id(id: str) -> str:
+    return _ensure_albert_id(id, "AttributeId")
+
+
+AttributeId = Annotated[str, AfterValidator(ensure_attribute_id)]
 
 
 def ensure_attachment_id(id: str) -> str:

--- a/src/albert/resources/attributes.py
+++ b/src/albert/resources/attributes.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+from pydantic import Field, field_validator
+
+from albert.core.base import BaseAlbertModel
+from albert.core.shared.identifiers import AttributeId, DataColumnId, ParameterId, UnitId
+from albert.core.shared.models.base import BaseResource, EntityLink, EntityLinkWithName
+from albert.resources.parameter_groups import DataType, EnumValidationValue, Operator
+
+
+class AttributeCategory(str, Enum):
+    """Category of an attribute."""
+
+    PROPERTY = "Property"
+
+
+class AttributeScope(str, Enum):
+    """Scope used when fetching or deleting attribute values."""
+
+    SELF = "SELF"
+    LOT = "LOT"
+    ALL = "ALL"
+
+
+class ValidationItem(BaseAlbertModel):
+    """A validation rule for an attribute.
+
+    Uses the same DataType and Operator enums as parameter groups, but min/max
+    are float (not str) because the attributes API sends numeric values.
+    """
+
+    datatype: DataType | None = None
+    min: float | None = None
+    max: float | None = None
+    value: float | list[EnumValidationValue] | None = None
+    operator: Operator | None = None
+
+    @field_validator("datatype", mode="before")
+    @classmethod
+    def normalize_datatype(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            try:
+                return DataType(v.lower())
+            except ValueError:
+                return None
+        return v
+
+
+class AttributeParameterItem(BaseAlbertModel):
+    """A parameter reference within an attribute definition."""
+
+    id: ParameterId
+    name: str | None = None
+    category: str | None = None
+    value: str | dict | None = None
+    unit: EntityLinkWithName | None = None
+    unit_id: UnitId | None = Field(None, alias="unitId")
+
+
+class Attribute(BaseResource):
+    """Represents a centralized attribute definition."""
+
+    id: AttributeId | None = Field(None, alias="albertId")
+    reference_name: str | None = Field(None, alias="referenceName")
+    full_name: str | None = Field(None, alias="fullName")
+    name_override: bool | None = Field(None, alias="nameOverride")
+    datacolumn: EntityLinkWithName | None = None
+    datacolumn_id: DataColumnId | None = Field(None, alias="datacolumnId")
+    unit: EntityLinkWithName | None = None
+    unit_id: UnitId | None = Field(None, alias="unitId")
+    workflow: EntityLink | None = None
+    validation: list[ValidationItem] | None = None
+    category: AttributeCategory | None = None
+    parameters: list[AttributeParameterItem] | None = None
+
+    @field_validator("parameters", mode="before")
+    @classmethod
+    def coerce_parameters(cls, v: Any) -> Any:
+        if isinstance(v, dict) and "values" in v:
+            return v["values"]
+        return v
+
+
+class AttributeSearchItem(BaseAlbertModel):
+    """A lightweight attribute result returned by the search endpoint."""
+
+    id: AttributeId = Field(alias="albertId")
+    name: str | None = None
+    datacolumn_id: str | None = Field(None, alias="datacolumnId")
+    datacolumn_name: str | None = Field(None, alias="datacolumnName")
+    unit_name: str | None = Field(None, alias="unitName")
+    parameters: list[dict] | None = None
+
+
+# --- Attribute value models ---
+
+
+class AttributeValueRange(BaseAlbertModel):
+    """A numeric range constraint for a reference value."""
+
+    min: float | None = None
+    max: float | None = None
+    comparison_operator: str | None = Field(None, alias="comparisonOperator")
+
+
+class AttributeValue(BaseAlbertModel):
+    """A reference value to assign to a parent entity for a given attribute."""
+
+    attribute_id: AttributeId = Field(alias="attributeId")
+    reference_value: str | float | None = Field(None, alias="referenceValue")
+    range: AttributeValueRange | None = None
+
+
+class AttributeDefinition(BaseAlbertModel):
+    """Read-only embed of attribute metadata within a values response.
+
+    Distinct from Attribute: uses ``name`` (not ``referenceName``) and
+    ``prmCount`` (count only, not the full parameters list).
+    """
+
+    name: str
+    full_name: str = Field(alias="fullName")
+    datacolumn: EntityLinkWithName
+    category: AttributeCategory
+    unit: EntityLinkWithName | None = None
+    workflow: EntityLink
+    validation: list[ValidationItem]
+    prm_count: int = Field(alias="prmCount")
+
+
+class AttributeValuesResponseItem(BaseAlbertModel):
+    """A single attribute value entry within a values response."""
+
+    id: AttributeId = Field(alias="albertId")
+    attribute_definition: AttributeDefinition = Field(alias="attributeDefinition")
+    reference_value: str | float | None = Field(None, alias="referenceValue")
+    range: AttributeValueRange | None = None
+
+
+class AttributeValuesResponse(BaseAlbertModel):
+    """Attribute values for a single parent entity."""
+
+    parent_id: str = Field(alias="parentId")
+    attributes: list[AttributeValuesResponseItem]

--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -42,6 +42,7 @@ class Operator(str, Enum):
     GREATER_THAN_OR_EQUAL = "gte"
     GREATER_THAN = "gt"
     EQUALS = "eq"
+    NOT_EQUALS = "neq"
 
 
 class EnumValidationValue(BaseAlbertModel):

--- a/tests/collections/test_attributes.py
+++ b/tests/collections/test_attributes.py
@@ -1,0 +1,326 @@
+import uuid
+from contextlib import suppress
+
+import pytest
+
+from albert import Albert
+from albert.exceptions import NotFoundError
+from albert.resources.attributes import (
+    Attribute,
+    AttributeCategory,
+    AttributeScope,
+    AttributeSearchItem,
+    AttributeValue,
+    AttributeValuesResponse,
+    ValidationItem,
+)
+from albert.resources.data_columns import DataColumn
+from albert.resources.inventory import InventoryItem
+from albert.resources.lots import Lot
+from albert.resources.parameter_groups import DataType, EnumValidationValue, Operator
+
+
+def test_attribute_create(client: Albert, seeded_data_columns: list[DataColumn]):
+    """Test creating an attribute and verifying the returned ID and category."""
+    attribute = Attribute(
+        datacolumn_id=seeded_data_columns[0].id,
+        category=AttributeCategory.PROPERTY,
+        validation=[ValidationItem(datatype=DataType.NUMBER)],
+    )
+    created = client.attributes.create(attribute=attribute)
+
+    assert created.id is not None
+    assert created.id.startswith("ATR")
+    assert created.category == AttributeCategory.PROPERTY
+
+    with suppress(NotFoundError):
+        client.attributes.delete(id=created.id)
+
+
+def test_attribute_get_by_id(client: Albert, seeded_attributes: list[Attribute]):
+    """Test retrieving an attribute by its ID."""
+    target = seeded_attributes[0]
+    result = client.attributes.get_by_id(id=target.id)
+
+    assert isinstance(result, Attribute)
+    assert result.id == target.id
+    assert result.category == AttributeCategory.PROPERTY
+
+
+def test_attribute_get_by_ids(client: Albert, seeded_attributes: list[Attribute]):
+    """Test retrieving multiple attributes by a list of IDs."""
+    ids = [a.id for a in seeded_attributes]
+    results = client.attributes.get_by_ids(ids=ids)
+
+    assert len(results) == len(seeded_attributes)
+    returned_ids = {r.id for r in results}
+    for attr_id in ids:
+        assert attr_id in returned_ids
+
+
+def test_attribute_get_all(client: Albert, seeded_attributes: list[Attribute]):
+    """Test listing attributes with max_items respects the limit."""
+    results = list(client.attributes.get_all(max_items=5))
+
+    assert len(results) <= 5
+    for item in results:
+        assert isinstance(item, Attribute)
+        assert item.id is not None
+        assert item.id.startswith("ATR")
+
+
+def test_attribute_get_all_by_category(client: Albert, seeded_attributes: list[Attribute]):
+    """Test listing attributes filtered by category."""
+    results = list(client.attributes.get_all(category=AttributeCategory.PROPERTY, max_items=10))
+
+    assert len(results) > 0
+    for item in results:
+        assert item.category == AttributeCategory.PROPERTY
+
+
+def test_attribute_update_reference_name(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating an attribute's reference name."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[2].id)
+    new_ref_name = f"updated-ref-{uuid.uuid4().hex[:8]}"
+    attr.reference_name = new_ref_name
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.reference_name == new_ref_name
+
+
+def test_attribute_update_validation(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating an attribute's validation rules."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[0].id)
+    attr.validation = [
+        ValidationItem(datatype=DataType.NUMBER, min=0.0, max=100.0, operator=Operator.BETWEEN)
+    ]
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.validation is not None
+    assert updated.validation[0].datatype == DataType.NUMBER
+    assert updated.validation[0].min == 0.0
+    assert updated.validation[0].max == 100.0
+
+
+def test_attribute_update_enum(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating enum values within an attribute's validation."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[1].id)
+    assert attr.validation is not None
+    assert attr.validation[0].datatype == DataType.ENUM
+
+    existing_values = attr.validation[0].value
+    assert isinstance(existing_values, list)
+
+    attr.validation[0].value = [
+        *existing_values,
+        EnumValidationValue(text="Option3"),
+    ]
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.validation is not None
+    enum_texts = [v.text for v in updated.validation[0].value]
+    assert "Option1" in enum_texts
+    assert "Option2" in enum_texts
+    assert "Option3" in enum_texts
+
+
+def test_attribute_delete(client: Albert, seeded_data_columns: list[DataColumn]):
+    """Test deleting an attribute removes it from the platform."""
+    attribute = Attribute(
+        datacolumn_id=seeded_data_columns[3].id,
+        category=AttributeCategory.PROPERTY,
+        validation=[ValidationItem(datatype=DataType.STRING)],
+    )
+    created = client.attributes.create(attribute=attribute)
+    assert created.id is not None
+
+    client.attributes.delete(id=created.id)
+
+    with pytest.raises(NotFoundError):
+        client.attributes.get_by_id(id=created.id)
+
+
+def test_attribute_search(client: Albert, seeded_attributes: list[Attribute]):
+    """Test searching attributes returns AttributeSearchItem results."""
+    results = list(client.attributes.search(max_items=10))
+
+    assert len(results) > 0
+    for item in results:
+        assert isinstance(item, AttributeSearchItem)
+        assert item.id is not None
+        assert item.id.startswith("ATR")
+
+
+def test_attribute_search_by_text(client: Albert, seeded_attributes: list[Attribute]):
+    """Test searching attributes by text returns matching results."""
+    attr = seeded_attributes[1]
+    assert attr.datacolumn is not None
+
+    results = list(client.attributes.search(text=attr.datacolumn.name, max_items=10))
+
+    assert len(results) > 0
+    ids = [r.id for r in results]
+    assert attr.id in ids
+
+
+# --- Attribute Values ---
+
+
+def test_attribute_add_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test add_values sets reference values and handles duplicates without error."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    values = [AttributeValue(attributeId=attr.id, referenceValue=42.0)]
+    result = client.attributes.add_values(parent_id=inventory.id, values=values)
+
+    assert isinstance(result, AttributeValuesResponse)
+    assert result.parent_id == inventory.id
+    assert len(result.attributes) == 1
+    assert result.attributes[0].id == attr.id
+    assert result.attributes[0].reference_value == 42.0
+
+    # Calling add_values again with the same attribute should update, not raise
+    result2 = client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=99.0)],
+    )
+    assert result2.attributes[0].reference_value == 99.0
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_get_values_scope_self(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test get_values with scope=SELF returns only the parent entity's values."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=10.0)],
+    )
+
+    results = list(client.attributes.get_values(parent_id=inventory.id, scope=AttributeScope.SELF))
+
+    assert len(results) >= 1
+    parent_ids = [r.parent_id for r in results]
+    assert inventory.id in parent_ids
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_get_values_scope_all(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+    seeded_lots: list[Lot],
+):
+    """Test get_values with scope=ALL returns values for inventory and its lots."""
+    inventory = seeded_inventory[0]
+    lot = seeded_lots[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=5.0)],
+    )
+    client.attributes.add_values(
+        parent_id=lot.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=7.5)],
+    )
+
+    results = list(client.attributes.get_values(parent_id=inventory.id, scope=AttributeScope.ALL))
+    parent_ids = {r.parent_id for r in results}
+
+    assert inventory.id in parent_ids
+    assert lot.id in parent_ids
+
+    client.attributes.clear_values(parent_id=inventory.id, scope=AttributeScope.ALL)
+
+
+@pytest.mark.xfail(reason="GET /attributes/values bulk endpoint returns 500 — backend issue")
+def test_attribute_get_bulk_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test get_bulk_values returns values for multiple parent entities."""
+    inv1 = seeded_inventory[0]
+    inv2 = seeded_inventory[1]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inv1.id, values=[AttributeValue(attributeId=attr.id, referenceValue=1.0)]
+    )
+    client.attributes.add_values(
+        parent_id=inv2.id, values=[AttributeValue(attributeId=attr.id, referenceValue=2.0)]
+    )
+
+    try:
+        results = client.attributes.get_bulk_values(parent_ids=[inv1.id, inv2.id])
+        returned_ids = {r.parent_id for r in results}
+        assert inv1.id in returned_ids
+        assert inv2.id in returned_ids
+    finally:
+        client.attributes.clear_values(parent_id=inv1.id)
+        client.attributes.clear_values(parent_id=inv2.id)
+
+
+def test_attribute_delete_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test delete_values removes only the specified attribute values."""
+    inventory = seeded_inventory[0]
+    attr0 = seeded_attributes[0]
+    attr1 = seeded_attributes[2]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[
+            AttributeValue(attributeId=attr0.id, referenceValue=1.0),
+            AttributeValue(attributeId=attr1.id, referenceValue="hello"),
+        ],
+    )
+
+    client.attributes.delete_values(parent_id=inventory.id, attribute_ids=[attr0.id])
+
+    results = list(client.attributes.get_values(parent_id=inventory.id))
+    remaining_ids = {a.id for r in results for a in r.attributes}
+
+    assert attr0.id not in remaining_ids
+    assert attr1.id in remaining_ids
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_clear_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test clear_values removes all attribute values from a parent entity."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=99.0)],
+    )
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+    results = list(client.attributes.get_values(parent_id=inventory.id))
+    assert all(len(r.attributes) == 0 for r in results)

--- a/tests/collections/test_attributes.py
+++ b/tests/collections/test_attributes.py
@@ -1,0 +1,329 @@
+import uuid
+from contextlib import suppress
+
+import pytest
+
+from albert import Albert
+from albert.exceptions import NotFoundError
+from albert.resources.attributes import (
+    Attribute,
+    AttributeCategory,
+    AttributeScope,
+    AttributeSearchItem,
+    AttributeValue,
+    AttributeValuesResponse,
+    ValidationItem,
+)
+from albert.resources.data_columns import DataColumn
+from albert.resources.inventory import InventoryItem
+from albert.resources.lots import Lot
+from albert.resources.parameter_groups import DataType, EnumValidationValue, Operator
+
+
+def test_attribute_create(client: Albert, seeded_data_columns: list[DataColumn]):
+    """Test creating an attribute and verifying the returned ID and category."""
+    attribute = Attribute(
+        datacolumn_id=seeded_data_columns[0].id,
+        category=AttributeCategory.PROPERTY,
+        validation=[ValidationItem(datatype=DataType.NUMBER)],
+    )
+    created = client.attributes.create(attribute=attribute)
+
+    assert created.id is not None
+    assert created.id.startswith("ATR")
+    assert created.category == AttributeCategory.PROPERTY
+
+    with suppress(NotFoundError):
+        client.attributes.delete(id=created.id)
+
+
+def test_attribute_get_by_id(client: Albert, seeded_attributes: list[Attribute]):
+    """Test retrieving an attribute by its ID."""
+    target = seeded_attributes[0]
+    result = client.attributes.get_by_id(id=target.id)
+
+    assert isinstance(result, Attribute)
+    assert result.id == target.id
+    assert result.category == AttributeCategory.PROPERTY
+
+
+def test_attribute_get_by_ids(client: Albert, seeded_attributes: list[Attribute]):
+    """Test retrieving multiple attributes by a list of IDs."""
+    ids = [a.id for a in seeded_attributes]
+    results = client.attributes.get_by_ids(ids=ids)
+
+    assert len(results) == len(seeded_attributes)
+    returned_ids = {r.id for r in results}
+    for attr_id in ids:
+        assert attr_id in returned_ids
+
+
+def test_attribute_get_all(client: Albert, seeded_attributes: list[Attribute]):
+    """Test listing attributes with max_items respects the limit."""
+    results = list(client.attributes.get_all(max_items=5))
+
+    assert len(results) <= 5
+    for item in results:
+        assert isinstance(item, Attribute)
+        assert item.id is not None
+        assert item.id.startswith("ATR")
+
+
+def test_attribute_get_all_by_category(client: Albert, seeded_attributes: list[Attribute]):
+    """Test listing attributes filtered by category."""
+    results = list(client.attributes.get_all(category=AttributeCategory.PROPERTY, max_items=10))
+
+    assert len(results) > 0
+    for item in results:
+        assert item.category == AttributeCategory.PROPERTY
+
+
+def test_attribute_update_reference_name(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating an attribute's reference name."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[2].id)
+    new_ref_name = f"updated-ref-{uuid.uuid4().hex[:8]}"
+    attr.reference_name = new_ref_name
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.reference_name == new_ref_name
+
+
+def test_attribute_update_validation(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating an attribute's validation rules."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[0].id)
+    attr.validation = [
+        ValidationItem(datatype=DataType.NUMBER, min=0.0, max=100.0, operator=Operator.BETWEEN)
+    ]
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.validation is not None
+    assert updated.validation[0].datatype == DataType.NUMBER
+    assert updated.validation[0].min == 0.0
+    assert updated.validation[0].max == 100.0
+
+
+def test_attribute_update_enum(client: Albert, seeded_attributes: list[Attribute]):
+    """Test updating enum values within an attribute's validation."""
+    attr = client.attributes.get_by_id(id=seeded_attributes[1].id)
+    assert attr.validation is not None
+    assert attr.validation[0].datatype == DataType.ENUM
+
+    existing_values = attr.validation[0].value
+    assert isinstance(existing_values, list)
+
+    attr.validation[0].value = [
+        *existing_values,
+        EnumValidationValue(text="Option3"),
+    ]
+
+    updated = client.attributes.update(attribute=attr)
+
+    assert updated.validation is not None
+    enum_texts = [v.text for v in updated.validation[0].value]
+    assert "Option1" in enum_texts
+    assert "Option2" in enum_texts
+    assert "Option3" in enum_texts
+
+
+def test_attribute_delete(client: Albert, seeded_data_columns: list[DataColumn]):
+    """Test deleting an attribute removes it from the platform."""
+    attribute = Attribute(
+        datacolumn_id=seeded_data_columns[3].id,
+        category=AttributeCategory.PROPERTY,
+        validation=[ValidationItem(datatype=DataType.STRING)],
+    )
+    created = client.attributes.create(attribute=attribute)
+    assert created.id is not None
+
+    client.attributes.delete(id=created.id)
+
+    with pytest.raises(NotFoundError):
+        client.attributes.get_by_id(id=created.id)
+
+
+def test_attribute_search(client: Albert, seeded_attributes: list[Attribute]):
+    """Test searching attributes returns AttributeSearchItem results."""
+    results = list(client.attributes.search(max_items=10))
+
+    assert len(results) > 0
+    for item in results:
+        assert isinstance(item, AttributeSearchItem)
+        assert item.id is not None
+        assert item.id.startswith("ATR")
+
+
+def test_attribute_search_by_text(client: Albert, seeded_attributes: list[Attribute]):
+    """Test searching attributes by text returns matching results."""
+    attr = seeded_attributes[1]
+    assert attr.datacolumn is not None
+
+    results = list(client.attributes.search(text=attr.datacolumn.name, max_items=10))
+
+    assert len(results) > 0
+    ids = [r.id for r in results]
+    assert attr.id in ids
+
+
+# --- Attribute Values ---
+
+
+def test_attribute_add_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test add_values sets reference values and handles duplicates without error."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    values = [AttributeValue(attributeId=attr.id, referenceValue=42.0)]
+    result = client.attributes.add_values(parent_id=inventory.id, values=values)
+
+    assert isinstance(result, AttributeValuesResponse)
+    assert result.parent_id == inventory.id
+    assert len(result.attributes) == 1
+    assert result.attributes[0].id == attr.id
+    assert result.attributes[0].reference_value == 42.0
+
+    # Calling add_values again with the same attribute should update, not raise
+    result2 = client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=99.0)],
+    )
+    assert result2.attributes[0].reference_value == 99.0
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_get_values_scope_self(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test get_values with scope=SELF returns only the parent entity's values."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=10.0)],
+    )
+
+    results = list(client.attributes.get_values(parent_id=inventory.id, scope=AttributeScope.SELF))
+
+    assert len(results) >= 1
+    parent_ids = [r.parent_id for r in results]
+    assert inventory.id in parent_ids
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_get_values_scope_all(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+    seeded_lots: list[Lot],
+):
+    """Test get_values with scope=ALL returns values for inventory and its lots."""
+    inventory = seeded_inventory[0]
+    lot = seeded_lots[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=5.0)],
+    )
+    client.attributes.add_values(
+        parent_id=lot.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=7.5)],
+    )
+
+    results = list(client.attributes.get_values(parent_id=inventory.id, scope=AttributeScope.ALL))
+    parent_ids = {r.parent_id for r in results}
+
+    assert inventory.id in parent_ids
+    assert lot.id in parent_ids
+
+    client.attributes.clear_values(parent_id=inventory.id, scope=AttributeScope.ALL)
+
+
+@pytest.mark.xfail(
+    reason="POST /api/v3/attributes/values is not yet deployed to prod.",
+    strict=False,
+)
+def test_attribute_get_by_parent_ids(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test get_by_parent_ids returns values for multiple parent entities."""
+    inv1 = seeded_inventory[0]
+    inv2 = seeded_inventory[1]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inv1.id, values=[AttributeValue(attributeId=attr.id, referenceValue=1.0)]
+    )
+    client.attributes.add_values(
+        parent_id=inv2.id, values=[AttributeValue(attributeId=attr.id, referenceValue=2.0)]
+    )
+
+    try:
+        results = client.attributes.get_by_parent_ids(parent_ids=[inv1.id, inv2.id])
+        returned_ids = {r.parent_id for r in results}
+        assert inv1.id in returned_ids
+        assert inv2.id in returned_ids
+    finally:
+        client.attributes.clear_values(parent_id=inv1.id)
+        client.attributes.clear_values(parent_id=inv2.id)
+
+
+def test_attribute_delete_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test delete_values removes only the specified attribute values."""
+    inventory = seeded_inventory[0]
+    attr0 = seeded_attributes[0]
+    attr1 = seeded_attributes[2]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[
+            AttributeValue(attributeId=attr0.id, referenceValue=1.0),
+            AttributeValue(attributeId=attr1.id, referenceValue="hello"),
+        ],
+    )
+
+    client.attributes.delete_values(parent_id=inventory.id, attribute_ids=[attr0.id])
+
+    results = list(client.attributes.get_values(parent_id=inventory.id))
+    remaining_ids = {a.id for r in results for a in r.attributes}
+
+    assert attr0.id not in remaining_ids
+    assert attr1.id in remaining_ids
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+
+def test_attribute_clear_values(
+    client: Albert,
+    seeded_attributes: list[Attribute],
+    seeded_inventory: list[InventoryItem],
+):
+    """Test clear_values removes all attribute values from a parent entity."""
+    inventory = seeded_inventory[0]
+    attr = seeded_attributes[0]
+
+    client.attributes.add_values(
+        parent_id=inventory.id,
+        values=[AttributeValue(attributeId=attr.id, referenceValue=99.0)],
+    )
+
+    client.attributes.clear_values(parent_id=inventory.id)
+
+    results = list(client.attributes.get_values(parent_id=inventory.id))
+    assert all(len(r.attributes) == 0 for r in results)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from albert.collections.worksheets import WorksheetCollection
 from albert.core.shared.enums import Status
 from albert.exceptions import BadRequestError, ForbiddenError, NotFoundError
 from albert.resources.attachments import Attachment
+from albert.resources.attributes import Attribute
 from albert.resources.btdataset import BTDataset
 from albert.resources.btinsight import BTInsight
 from albert.resources.btmodel import BTModel, BTModelSession
@@ -53,6 +54,7 @@ from albert.resources.users import User
 from albert.resources.workflows import Workflow
 from albert.resources.worksheets import Worksheet
 from tests.seeding import (
+    generate_attribute_seeds,
     generate_btdataset_seed,
     generate_btinsight_seed,
     generate_btmodel_seed,
@@ -460,6 +462,30 @@ def seeded_data_columns(
             NotFoundError, BadRequestError
         ):  # used on deleted InventoryItem properties are blocking. Instead of making static to accomidate the unexpected behavior, doing this instead
             client.data_columns.delete(id=data_column.id)
+
+
+@pytest.fixture(scope="session")
+def seeded_attributes(
+    client: Albert,
+    seed_prefix: str,
+    seeded_data_columns: list[DataColumn],
+) -> Iterator[list[Attribute]]:
+    seeded = []
+    for attribute in generate_attribute_seeds(
+        seed_prefix=seed_prefix,
+        seeded_data_columns=seeded_data_columns,
+    ):
+        created = client.attributes.create(attribute=attribute)
+        seeded.append(created)
+
+    # Avoid race condition while it populates through search DBs
+    time.sleep(1.5)
+
+    yield seeded
+
+    for attribute in seeded:
+        with suppress(NotFoundError, BadRequestError):
+            client.attributes.delete(id=attribute.id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,7 @@ from albert.collections.worksheets import WorksheetCollection
 from albert.core.shared.enums import Status
 from albert.exceptions import BadRequestError, ForbiddenError, NotFoundError
 from albert.resources.attachments import Attachment
+from albert.resources.attributes import Attribute
 from albert.resources.btdataset import BTDataset
 from albert.resources.btinsight import BTInsight
 from albert.resources.btmodel import BTModel, BTModelSession
@@ -53,6 +54,7 @@ from albert.resources.users import User
 from albert.resources.workflows import Workflow
 from albert.resources.worksheets import Worksheet
 from tests.seeding import (
+    generate_attribute_seeds,
     generate_btdataset_seed,
     generate_btinsight_seed,
     generate_btmodel_seed,
@@ -459,6 +461,30 @@ def seeded_data_columns(
             NotFoundError, BadRequestError
         ):  # used on deleted InventoryItem properties are blocking. Instead of making static to accomidate the unexpected behavior, doing this instead
             client.data_columns.delete(id=data_column.id)
+
+
+@pytest.fixture(scope="session")
+def seeded_attributes(
+    client: Albert,
+    seed_prefix: str,
+    seeded_data_columns: list[DataColumn],
+) -> Iterator[list[Attribute]]:
+    seeded = []
+    for attribute in generate_attribute_seeds(
+        seed_prefix=seed_prefix,
+        seeded_data_columns=seeded_data_columns,
+    ):
+        created = client.attributes.create(attribute=attribute)
+        seeded.append(created)
+
+    # Avoid race condition while it populates through search DBs
+    time.sleep(1.5)
+
+    yield seeded
+
+    for attribute in seeded:
+        with suppress(NotFoundError, BadRequestError):
+            client.attributes.delete(id=attribute.id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from albert.core.shared.enums import SecurityClass
 from albert.core.shared.models.base import EntityLink
 from albert.core.shared.types import MetadataItem
+from albert.resources.attributes import Attribute, AttributeCategory, ValidationItem
 from albert.resources.btdataset import BTDataset
 from albert.resources.btinsight import BTInsight, BTInsightCategory
 from albert.resources.btmodel import BTModel, BTModelSession, BTModelSessionCategory, BTModelState
@@ -1901,3 +1902,48 @@ def generate_smart_dataset_seed(
         project_ids=[project.id for project in seeded_projects],
         target_ids=[target.id for target in seeded_targets],
     )
+
+
+def generate_attribute_seeds(
+    seed_prefix: str,
+    seeded_data_columns: list[DataColumn],
+) -> list[Attribute]:
+    """
+    Generates a list of Attribute seed objects for testing.
+
+    Returns
+    -------
+    list[Attribute]
+        A list of Attribute objects with different validation types.
+    """
+    return [
+        # NUMBER validation attribute
+        Attribute(
+            datacolumn_id=seeded_data_columns[0].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-number",
+            validation=[ValidationItem(datatype=DataType.NUMBER)],
+        ),
+        # ENUM validation attribute
+        Attribute(
+            datacolumn_id=seeded_data_columns[1].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-enum",
+            validation=[
+                ValidationItem(
+                    datatype=DataType.ENUM,
+                    value=[
+                        EnumValidationValue(text="Option1"),
+                        EnumValidationValue(text="Option2"),
+                    ],
+                )
+            ],
+        ),
+        # STRING validation attribute (for update tests)
+        Attribute(
+            datacolumn_id=seeded_data_columns[2].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-string",
+            validation=[ValidationItem(datatype=DataType.STRING)],
+        ),
+    ]

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 from albert.core.shared.enums import SecurityClass
 from albert.core.shared.models.base import EntityLink
 from albert.core.shared.types import MetadataItem
+from albert.resources.attributes import Attribute, AttributeCategory, ValidationItem
 from albert.resources.btdataset import BTDataset
 from albert.resources.btinsight import BTInsight, BTInsightCategory
 from albert.resources.btmodel import BTModel, BTModelSession, BTModelSessionCategory, BTModelState
@@ -1909,3 +1910,48 @@ def generate_smart_dataset_seed(
         project_ids=[project.id for project in seeded_projects],
         target_ids=[target.id for target in seeded_targets],
     )
+
+
+def generate_attribute_seeds(
+    seed_prefix: str,
+    seeded_data_columns: list[DataColumn],
+) -> list[Attribute]:
+    """
+    Generates a list of Attribute seed objects for testing.
+
+    Returns
+    -------
+    list[Attribute]
+        A list of Attribute objects with different validation types.
+    """
+    return [
+        # NUMBER validation attribute
+        Attribute(
+            datacolumn_id=seeded_data_columns[0].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-number",
+            validation=[ValidationItem(datatype=DataType.NUMBER)],
+        ),
+        # ENUM validation attribute
+        Attribute(
+            datacolumn_id=seeded_data_columns[1].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-enum",
+            validation=[
+                ValidationItem(
+                    datatype=DataType.ENUM,
+                    value=[
+                        EnumValidationValue(text="Option1"),
+                        EnumValidationValue(text="Option2"),
+                    ],
+                )
+            ],
+        ),
+        # STRING validation attribute (for update tests)
+        Attribute(
+            datacolumn_id=seeded_data_columns[2].id,
+            category=AttributeCategory.PROPERTY,
+            reference_name=f"{seed_prefix}-attr-string",
+            validation=[ValidationItem(datatype=DataType.STRING)],
+        ),
+    ]


### PR DESCRIPTION
## Summary

- Adds `AttributeCollection` (`client.attributes`) with full CRUD (`create`, `get_by_id`, `get_by_ids`, `get_all`, `search`, `update`, `delete`) and reference value methods (`add_values`, `get_values`, `get_bulk_values`, `delete_values`, `clear_values`)
- Introduces `Attribute`, `AttributeScope`, `ValidationItem`, `AttributeValue`, `AttributeValueRange`, `AttributeDefinition`, and `AttributeValuesResponse` resource models
- Deprecates `InventoryCollection.get_specs()` and `add_specs()` via `@deprecated` (removed in 2.0); pins `typing_extensions>=4.6.1` as a direct dependency
- Adds migration guide (`docs/migration/specs-to-attributes.md`) and restructures migration docs into per-topic directory following the substances-v4 pattern

## Notes

- `add_values` is upsert — internally deletes matching attribute IDs before PUT so callers never see duplicate-ID errors
- `GET /attributes/values` (bulk) returns 500 from the backend; test is marked `xfail` pending backend fix
- `typing_extensions.deprecated` chosen over raw `warnings.warn`