### PR TITLE
feat(parameter_groups): add required field to ParameterValue with patch support

### DIFF
--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -354,7 +354,7 @@ class DataTemplateCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``description``, ``metadata``, ``name``.
+        The following fields can be updated: ``description``, ``metadata``, ``name``, and per-parameter ``value``, ``unit``, ``required``, ``validation``.
 
         Warnings
         --------

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -270,7 +270,7 @@ class ParameterGroupCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``description``, ``metadata``, ``name``.
+        The following fields can be updated: ``description``, ``metadata``, ``name``, and per-parameter ``value``, ``unit``, ``required``, ``validation``.
         """
         existing = self.get_by_id(id=parameter_group.id)
         path = f"{self.base_path}/{existing.id}"

--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -90,6 +90,8 @@ class ParameterValue(BaseAlbertModel):
         The value of the parameter. Can be a plain string or an InventoryItem (e.g. when the parameter represents an instrument choice).
     unit : Unit or None
         The unit of measure for the provided parameter value.
+    required : bool or None
+        Whether this parameter is required. Defaults to False.
     validation : list[ValueValidation] or None
         Validation rules applied to the parameter value.
     name : str or None
@@ -105,6 +107,7 @@ class ParameterValue(BaseAlbertModel):
     value: str | SerializeAsEntityLink[InventoryItem] | None = Field(default=None)
     unit: SerializeAsEntityLink[Unit] | None = Field(alias="Unit", default=None)
     added: AuditFields | None = Field(alias="Added", default=None, exclude=True)
+    required: bool | None = Field(default=None)
     validation: list[ValueValidation] | None = Field(default_factory=list)
 
     # Read-only fields

--- a/src/albert/utils/_patch.py
+++ b/src/albert/utils/_patch.py
@@ -19,20 +19,6 @@ from albert.resources.parameter_groups import (
 from albert.resources.tags import Tag
 
 
-def _normalize_validation(validation: list[EnumValidationValue]) -> list[EnumValidationValue]:
-    """Normalize validation objects for comparison. Ignore original_text for enum values."""
-    normalized = []
-    for v in validation:
-        if isinstance(v.value, list):
-            normalized_value = [
-                EnumValidationValue(text=enum.text, id=enum.id, original_text=None)
-                for enum in v.value
-            ]
-            v.value = normalized_value
-        normalized.append(v)
-    return normalized
-
-
 def _parameter_unit_patches(
     initial_parameter_value: ParameterValue, updated_parameter_value: ParameterValue
 ) -> PGPatchDatum | None:
@@ -279,6 +265,27 @@ def data_column_curve_data_patches(
         attribute="curveData",
         oldValue=initial_data_column.curve_data,
         newValue=updated_data_column.curve_data,
+    )
+
+
+def _parameter_required_patch(
+    initial_parameter_value: ParameterValue, updated_parameter_value: ParameterValue
+) -> PGPatchDatum | None:
+    """Generate a patch for a parameter required flag."""
+    updated_required = updated_parameter_value.required
+    if updated_required is None:
+        return None
+    initial_required = (
+        initial_parameter_value.required if initial_parameter_value.required is not None else False
+    )
+    if initial_required == updated_required:
+        return None
+    return PGPatchDatum(
+        operation="update",
+        attribute="required",
+        oldValue=initial_required,
+        newValue=updated_required,
+        rowId=updated_parameter_value.sequence,
     )
 
 
@@ -538,12 +545,15 @@ def generate_parameter_patches(
     for existing_param, updated_param in updated_param_pairs:
         unit_patch = _parameter_unit_patches(existing_param, updated_param)
         value_patch = _parameter_value_patches(existing_param, updated_param)
+        required_patch = _parameter_required_patch(existing_param, updated_param)
         validation_patch = parameter_validation_patch(existing_param, updated_param)
 
         if unit_patch:
             parameter_patches.append(unit_patch)
         if value_patch:
             parameter_patches.append(value_patch)
+        if required_patch:
+            parameter_patches.append(required_patch)
         # Check if this parameter will have enum patches
         will_have_enum_patches = (
             updated_param.validation is not None

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -460,3 +460,28 @@ def test_hydrate_data_template(client: Albert):
         # identity checks
         assert hydrated.id == data_template.id
         assert hydrated.name == data_template.name
+
+
+def test_update_required_parameter(
+    client: Albert,
+    seeded_data_templates: list[DataTemplate],
+):
+    """Test setting and unsetting the required flag on a parameter in a data template."""
+    dt = next(
+        (x for x in seeded_data_templates if "Parameters Data Template" in x.name),
+        None,
+    )
+    assert dt is not None and dt.parameter_values
+
+    param = dt.parameter_values[0]
+    assert not param.required
+
+    param.required = True
+    updated_dt = client.data_templates.update(data_template=dt)
+    updated_param = next(x for x in updated_dt.parameter_values if x.id == param.id)
+    assert updated_param.required is True
+
+    updated_param.required = False
+    restored_dt = client.data_templates.update(data_template=updated_dt)
+    restored_param = next(x for x in restored_dt.parameter_values if x.id == param.id)
+    assert not restored_param.required

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -271,3 +271,20 @@ def test_update_units(
     updated_param = updated_pg.parameters[0]
     assert updated_param.unit.id == new_unit.id
     assert updated_param.unit.id != original_unit.id
+
+
+def test_update_required(client: Albert, seeded_parameter_groups: list[ParameterGroup]):
+    """Test setting and unsetting the required flag on a parameter in a parameter group."""
+    pg = client.parameter_groups.get_by_id(id=seeded_parameter_groups[0].id)
+    param = pg.parameters[0]
+    assert not param.required
+
+    param.required = True
+    updated_pg = client.parameter_groups.update(parameter_group=pg)
+    updated_param = next(x for x in updated_pg.parameters if x.id == param.id)
+    assert updated_param.required is True
+
+    updated_param.required = False
+    restored_pg = client.parameter_groups.update(parameter_group=updated_pg)
+    restored_param = next(x for x in restored_pg.parameters if x.id == param.id)
+    assert not restored_param.required


### PR DESCRIPTION
## Summary
- Adds `required: bool | None` field to `ParameterValue` (used by both `ParameterGroup` and `DataTemplate`)
- Adds `_parameter_required_patch()` to `_patch.py` and wires it into `generate_parameter_patches()`, enabling `update()` to set/unset the required flag on parameters in both parameter groups and data templates
- Removes dead `_normalize_validation()` function from `_patch.py`
- Adds integration tests for toggling `required` on parameters in both parameter groups and data templates

Closes #479