### PR TITLE
test(chats): skip tests until Chat API is deployed on prod

### DIFF
--- a/tests/collections/test_chats.py
+++ b/tests/collections/test_chats.py
@@ -15,7 +15,7 @@ from albert.resources.chats import (
     ChatUserType,
 )
 
-pytestmark = pytest.mark.skip(reason="Chat API is not yet deployed on prod.")
+pytestmark = pytest.mark.skip(reason="Chats API is not yet available in the test environment.")
 
 # ---------------------------------------------------------------------------
 # Chat folders

--- a/tests/collections/test_chats.py
+++ b/tests/collections/test_chats.py
@@ -15,7 +15,7 @@ from albert.resources.chats import (
     ChatUserType,
 )
 
-pytestmark = pytest.mark.xfail(reason="Chat API is not deployed yet.")
+pytestmark = pytest.mark.skip(reason="Chat API is not yet deployed on prod.")
 
 # ---------------------------------------------------------------------------
 # Chat folders


### PR DESCRIPTION
Changes `xfail` to `skip` on the chat test module — the Chat API is not yet deployed on prod so the tests should be skipped entirely rather than run and expected to fail.