### PR TITLE
fix(sheets): add is_column_right field to Sheet model

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -446,6 +446,8 @@ class Sheet(BaseSessionResource):  # noqa:F811
         The name of the sheet.
     hidden : bool
         Whether the sheet is hidden.
+    is_column_right : bool | None
+        When True, copied columns are placed to the right of the source column; when False, to the left.
     designs : list[Design]
         The designs of the sheet.
     project_id : str
@@ -463,6 +465,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
     name: str
     formulations: list[SheetFormulationRef] = Field(default_factory=list, alias="Formulas")
     hidden: bool
+    is_column_right: bool | None = Field(default=None, alias="isColumnRight")
     _app_design: Design = PrivateAttr(default=None)
     _product_design: Design = PrivateAttr(default=None)
     _result_design: Design = PrivateAttr(default=None)


### PR DESCRIPTION
## Summary
- Adds `is_column_right: bool | None` (alias `isColumnRight`) to the `Sheet` model in `src/albert/resources/sheets.py`
- Field was introduced by [api-worksheet PR #350](https://github.com/MoleculeEngineering/api-worksheet/pull/350) — controls whether copied columns are placed to the right or left of the source column
- Defaults to `None` so existing sheets without the field deserialize cleanly