### PR TITLE
fix(parameter_groups): assign enum IDs and fix search item model

### DIFF
--- a/docs/examples/data_templates.md
+++ b/docs/examples/data_templates.md
@@ -4,12 +4,40 @@ Data Templates in Albert Invent define how results are captured and structured. 
 
 ## Add numeric data column
 
-!!! example "Create a data column, add it, then set NUMBER datatype"
+!!! info "Default validation"
+    Data columns added to a template without explicit validation automatically receive `number` as the default datatype. No additional update step is required for basic numeric columns.
+
+!!! example "Create a data column and add it — defaults to NUMBER datatype"
     ```python
     from albert import Albert
     from albert.resources.data_columns import DataColumn
     from albert.resources.data_templates import DataColumnValue
-    from albert.resources.parameter_groups import DataType, ValueValidation
+
+    client = Albert.from_client_credentials()
+
+    data_template_id = "DT123"
+
+    # 1) Create data column
+    created_column = client.data_columns.create(
+        data_column=DataColumn(name="Viscosity Number"),
+    )
+
+    # 2) Add data column to template — validation defaults to NUMBER
+    dt = client.data_templates.add_data_columns(
+        data_template_id=data_template_id,
+        data_columns=[DataColumnValue(data_column_id=created_column.id)],
+    )
+    print(dt.id)
+    ```
+
+## Add numeric data column with range validation
+
+!!! example "Create a data column with a specific numeric range constraint"
+    ```python
+    from albert import Albert
+    from albert.resources.data_columns import DataColumn
+    from albert.resources.data_templates import DataColumnValue
+    from albert.resources.parameter_groups import DataType, Operator, ValueValidation
 
     client = Albert.from_client_credentials()
 
@@ -26,9 +54,9 @@ Data Templates in Albert Invent define how results are captured and structured. 
         data_columns=[DataColumnValue(data_column_id=created_column.id)],
     )
 
-    # 3) Update template and set NUMBER datatype
+    # 3) Update template with a range constraint (must be between 0 and 100)
     target = next(x for x in (dt.data_column_values or []) if x.data_column_id == created_column.id)
-    target.validation = [ValueValidation(datatype=DataType.NUMBER)]
+    target.validation = [ValueValidation(datatype=DataType.NUMBER, operator=Operator.BETWEEN, min="0", max="100")]
 
     updated_dt = client.data_templates.update(data_template=dt)
     print(updated_dt.id)
@@ -36,7 +64,7 @@ Data Templates in Albert Invent define how results are captured and structured. 
 
 ## Add dropdown data column with validation
 
-!!! example "Add two data columns, then set ENUM and NUMBER validations"
+!!! example "Add two data columns, then set ENUM validation on one"
     ```python
     from albert import Albert
     from albert.resources.data_columns import DataColumn
@@ -59,7 +87,7 @@ Data Templates in Albert Invent define how results are captured and structured. 
         data_column=DataColumn(name="Viscosity Number"),
     )
 
-    # 2) Add both columns to template
+    # 2) Add both columns to template — viscosity defaults to NUMBER validation
     dt = client.data_templates.add_data_columns(
         data_template_id=data_template_id,
         data_columns=[
@@ -72,9 +100,8 @@ Data Templates in Albert Invent define how results are captured and structured. 
         ],
     )
 
-    # 3) Update template with dropdown (enum) + number validations
+    # 3) Update appearance column with dropdown (enum) validation
     appearance = next(x for x in (dt.data_column_values or []) if x.data_column_id == appearance_column.id)
-    viscosity = next(x for x in (dt.data_column_values or []) if x.data_column_id == viscosity_column.id)
 
     appearance.validation = [
         ValueValidation(
@@ -86,7 +113,6 @@ Data Templates in Albert Invent define how results are captured and structured. 
             ],
         )
     ]
-    viscosity.validation = [ValueValidation(datatype=DataType.NUMBER)]
 
     updated_dt = client.data_templates.update(data_template=dt)
     print(updated_dt.id)

--- a/docs/examples/parameter_groups.md
+++ b/docs/examples/parameter_groups.md
@@ -1,0 +1,49 @@
+# Parameter Groups
+
+Parameter Groups in Albert Invent define reusable sets of parameters that can be attached to inventory items, projects, and other entities to capture structured measurements or attributes.
+
+## Add a parameter with dropdown (ENUM) validation
+
+!!! example "Append a new parameter with predefined enum options to an existing parameter group"
+    ```python
+    from albert import Albert
+    from albert.resources.parameter_groups import (
+        DataType,
+        EnumValidationValue,
+        ParameterValue,
+        ValueValidation,
+    )
+    from albert.resources.parameters import Parameter
+
+    client = Albert.from_client_credentials()
+
+    parameter_group_id = "PRG123"
+
+    # 1) Fetch the existing parameter group
+    pg = client.parameter_groups.get_by_id(id=parameter_group_id)
+
+    # 2) Create or retrieve the parameter to add
+    parameter = client.parameters.get_or_create(
+        parameter=Parameter(name="Appearance"),
+    )
+
+    # 3) Append the parameter with ENUM validation
+    pg.parameters.append(
+        ParameterValue(
+            parameter=parameter,
+            validation=[
+                ValueValidation(
+                    datatype=DataType.ENUM,
+                    value=[
+                        EnumValidationValue(text="Clear"),
+                        EnumValidationValue(text="Cloudy"),
+                        EnumValidationValue(text="Opaque"),
+                    ],
+                )
+            ],
+        )
+    )
+
+    updated_pg = client.parameter_groups.update(parameter_group=pg)
+    print(updated_pg.id)
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -239,6 +239,7 @@ nav:
       - Data Templates: examples/data_templates.md
       - Inventory: examples/inventory.md
       - Notebooks: examples/notebook.md
+      - Parameter Groups: examples/parameter_groups.md
       - Property Data: examples/property_data.md
       - Projects: examples/projects.md
       - Tasks: examples/tasks.md

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -26,9 +26,13 @@ from albert.resources.data_templates import (
     ParameterValue,
 )
 from albert.resources.parameter_groups import DataType, EnumValidationValue, ValueValidation
-from albert.utils._patch import build_acl_patch_payload, generate_data_template_patches
+from albert.utils._patch import (
+    build_acl_patch_payload,
+    create_data_columns_with_enums,
+    create_parameters_with_enums,
+    generate_data_template_patches,
+)
 from albert.utils.data_template import (
-    add_parameter_enums,
     build_curve_example,
     build_image_example,
     get_target_data_column,
@@ -177,29 +181,12 @@ class DataTemplateCollection(BaseCollection):
         DataTemplate
             The updated DataTemplate object.
         """
-        # if there are enum values, we need to add them as an allowed enum
-        for column in data_columns:
-            if (
-                column.validation
-                and len(column.validation) > 0
-                and isinstance(column.validation[0].value, list)
-            ):
-                for enum_value in column.validation[0].value:
-                    self.session.put(
-                        f"{self.base_path}/{data_template_id}/datacolumns/{column.sequence}/enums",
-                        json=[
-                            enum_value.model_dump(mode="json", by_alias=True, exclude_none=True)
-                        ],
-                    )
-
-        payload = {
-            "DataColumns": [
-                x.model_dump(mode="json", by_alias=True, exclude_none=True) for x in data_columns
-            ]
-        }
-        self.session.put(
-            f"{self.base_path}/{data_template_id}/datacolumns",
-            json=payload,
+        data_template_url = f"{self.base_path}/{data_template_id}"
+        create_data_columns_with_enums(
+            session=self.session,
+            data_columns_base_url=f"{data_template_url}/datacolumns",
+            data_template_url=data_template_url,
+            data_columns=data_columns,
         )
         return self.get_by_id(id=data_template_id)
 
@@ -221,44 +208,16 @@ class DataTemplateCollection(BaseCollection):
         DataTemplate
             The updated DataTemplate object.
         """
-        # make sure the parameter values have a default validaion of string type.
-        initial_enum_values = {}  # use parameter ID to track the enum values
-        cleaned_params = []
         if parameters is None or len(parameters) == 0:
             return self.get_by_id(id=data_template_id)
-        for param in parameters:
-            if (
-                param.validation
-                and len(param.validation) > 0
-                and param.validation[0].datatype == DataType.ENUM
-            ):
-                initial_enum_values[param.id] = param.validation[0].value
-                param.validation[0].value = None
-                param.validation[0].datatype = DataType.STRING
-            cleaned_params.append(param)
 
-        payload = {
-            "Parameters": [
-                x.model_dump(mode="json", by_alias=True, exclude_none=True) for x in cleaned_params
-            ]
-        }
-        # if there are enum values, we need to add them as an allowed enum
-        response = self.session.put(
-            f"{self.base_path}/{data_template_id}/parameters",
-            json=payload,
+        parameters_url = f"{self.base_path}/{data_template_id}/parameters"
+        create_parameters_with_enums(
+            session=self.session,
+            parameters_base_url=parameters_url,
+            patch_url=parameters_url,
+            parameters=parameters,
         )
-        returned_parameters = [ParameterValue(**x) for x in response.json()["Parameters"]]
-        for param in returned_parameters:
-            if param.id in initial_enum_values:
-                param.validation[0].value = initial_enum_values[param.id]
-                param.validation[0].datatype = DataType.ENUM
-                add_parameter_enums(
-                    session=self.session,
-                    base_path=self.base_path,
-                    data_template_id=data_template_id,
-                    new_parameters=[param],
-                )
-
         return self.get_by_id(id=data_template_id)
 
     @validate_call
@@ -383,14 +342,11 @@ class DataTemplateCollection(BaseCollection):
         )
 
         if len(new_data_columns) > 0:
-            self.session.put(
-                f"{self.base_path}/{existing.id}/datacolumns",
-                json={
-                    "DataColumns": [
-                        x.model_dump(mode="json", by_alias=True, exclude_none=True)
-                        for x in new_data_columns
-                    ],
-                },
+            create_data_columns_with_enums(
+                session=self.session,
+                data_columns_base_url=f"{path}/datacolumns",
+                data_template_url=path,
+                data_columns=new_data_columns,
             )
         existing_columns_by_sequence = {
             x.sequence: x for x in (existing.data_column_values or []) if x.sequence is not None
@@ -413,43 +369,12 @@ class DataTemplateCollection(BaseCollection):
                     json=enum_patches,  # these are simple dicts for now
                 )
         if len(new_parameters) > 0:
-            # remove enum types, will become enums after enum adds
-            initial_enum_values = {}  # track original enum values by index
-            no_enum_params = []
-            for i, p in enumerate(new_parameters):
-                if (
-                    p.validation
-                    and len(p.validation) > 0
-                    and p.validation[0].datatype == DataType.ENUM
-                ):
-                    initial_enum_values[i] = p.validation[0].value
-                    p.validation[0].datatype = DataType.STRING
-                    p.validation[0].value = None
-                no_enum_params.append(p)
-
-            response = self.session.put(
-                f"{self.base_path}/{existing.id}/parameters",
-                json={
-                    "Parameters": [
-                        x.model_dump(mode="json", by_alias=True, exclude_none=True)
-                        for x in no_enum_params
-                    ],
-                },
-            )
-
-            # Get returned parameters with sequences and restore enum values
-            returned_parameters = [ParameterValue(**x) for x in response.json()["Parameters"]]
-            for i, param in enumerate(returned_parameters):
-                if i in initial_enum_values:
-                    param.validation[0].value = initial_enum_values[i]
-                    param.validation[0].datatype = DataType.ENUM  # Add this line
-
-            # Add enum values to newly created parameters
-            add_parameter_enums(
+            parameters_url = f"{path}/parameters"
+            create_parameters_with_enums(
                 session=self.session,
-                base_path=self.base_path,
-                data_template_id=existing.id,
-                new_parameters=returned_parameters,
+                parameters_base_url=parameters_url,
+                patch_url=parameters_url,
+                parameters=new_parameters,
             )
         enum_sequences = {}
         if len(parameter_enum_patches) > 0:

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -17,7 +17,10 @@ from albert.resources.parameter_groups import (
     ParameterGroupSearchItem,
     PGType,
 )
-from albert.utils._patch import generate_parameter_group_patches
+from albert.utils._patch import (
+    create_parameters_with_enums,
+    generate_parameter_group_patches,
+)
 
 DEFAULT_ADDITIONAL_FIELDS = [
     "acl",
@@ -286,27 +289,25 @@ class ParameterGroupCollection(BaseCollection):
         )
 
         # add new parameters
-        new_param_url = f"{self.base_path}/{parameter_group.id}/parameters"
         if len(new_parameter_values) > 0:
-            self.session.put(
-                url=new_param_url,
-                json={
-                    "Parameters": [
-                        x.model_dump(mode="json", by_alias=True, exclude_none=True)
-                        for x in new_parameter_values
-                    ],
-                },
+            create_parameters_with_enums(
+                session=self.session,
+                parameters_base_url=f"{self.base_path}/{parameter_group.id}/parameters",
+                patch_url=f"{self.base_path}/{parameter_group.id}",
+                parameters=new_parameter_values,
             )
+
+        # new_parameter_values have sequence=None before being sent, so this
+        # guard never matches in practice — enum updates on new params are
+        # handled above by create_parameters_with_enums.
         new_param_sequences = [x.sequence for x in new_parameter_values]
-        # handle enum updates
+        # handle enum updates for existing parameters
         for sequence, ep in enum_patches.items():
             if sequence in new_param_sequences:
-                # we don't need to handle enum updates for new parameters
                 continue
             if len(ep) > 0:
-                enum_url = f"{self.base_path}/{parameter_group.id}/parameters/{sequence}/enums"
                 self.session.put(
-                    url=enum_url,
+                    url=f"{self.base_path}/{parameter_group.id}/parameters/{sequence}/enums",
                     json=ep,
                 )
         if len(general_patches.data) > 0:

--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -161,7 +161,7 @@ class ParameterGroup(BaseTaggedResource):
 
 
 class ParameterSearchItemParameter(BaseAlbertModel):
-    name: str
+    name: str | None = None
     id: str
     localized_names: LocalizedNames = Field(alias="localizedNames")
 

--- a/src/albert/utils/_patch.py
+++ b/src/albert/utils/_patch.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from albert.core.session import AlbertSession
 from albert.core.shared.models.patch import (
     DTPatchDatum,
     GeneralPatchDatum,
@@ -699,6 +700,155 @@ def build_acl_patch_payload(
     return GeneralPatchPayload(
         data=[GeneralPatchDatum(attribute="ACL", operation=operation, **datum_kwargs)]
     )
+
+
+def create_parameters_with_enums(
+    *,
+    session: AlbertSession,
+    parameters_base_url: str,
+    patch_url: str,
+    parameters: list[ParameterValue],
+) -> list[ParameterValue]:
+    """Create parameters, including any ENUM validation options.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The active session.
+    parameters_base_url : str
+        Base URL for the parameters resource.
+    patch_url : str
+        URL of the parent resource to patch after enum options are registered.
+    parameters : list[ParameterValue]
+        Parameters to create.
+
+    Returns
+    -------
+    list[ParameterValue]
+        The created parameters with sequences assigned.
+    """
+    if not parameters:
+        return []
+
+    pending: dict[str, list[EnumValidationValue]] = {}
+    payloads: list[dict] = []
+    for p in parameters:
+        d = p.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if (
+            p.id is not None
+            and p.validation
+            and p.validation[0].datatype == DataType.ENUM
+            and isinstance(p.validation[0].value, list)
+        ):
+            pending[p.id] = p.validation[0].value
+            d["validation"] = [{"datatype": DataType.STRING}]
+        payloads.append(d)
+
+    response = session.put(parameters_base_url, json={"Parameters": payloads})
+    returned = [ParameterValue(**x) for x in response.json()["Parameters"]]
+
+    for param in returned:
+        enum_values = pending.get(param.id)
+        if not enum_values or param.sequence is None:
+            continue
+        enum_ops = [{"operation": "add", "text": v.text} for v in enum_values]
+        returned_enums = session.put(
+            f"{parameters_base_url}/{param.sequence}/enums",
+            json=enum_ops,
+        ).json()
+        patch_payload = PGPatchPayload(
+            data=[
+                PGPatchDatum(
+                    operation="update",
+                    attribute="enumSequence",
+                    rowId=param.sequence,
+                    new_value=[{"id": e["id"]} for e in returned_enums],
+                )
+            ]
+        )
+        session.patch(
+            patch_url,
+            json=patch_payload.model_dump(mode="json", by_alias=True, exclude_none=True),
+        )
+
+    return returned
+
+
+def create_data_columns_with_enums(
+    *,
+    session: AlbertSession,
+    data_columns_base_url: str,
+    data_template_url: str,
+    data_columns: list[DataColumnValue],
+) -> list[DataColumnValue]:
+    """Create data columns, including any ENUM validation options.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The active session.
+    data_columns_base_url : str
+        Base URL for the data columns resource.
+    data_template_url : str
+        URL of the parent data template.
+    data_columns : list[DataColumnValue]
+        Data columns to create.
+
+    Returns
+    -------
+    list[DataColumnValue]
+        The created data columns with sequences assigned.
+    """
+    if not data_columns:
+        return []
+
+    pending: dict[str, list[EnumValidationValue]] = {}
+    payloads: list[dict] = []
+    for col in data_columns:
+        d = col.model_dump(mode="json", by_alias=True, exclude_none=True)
+        if (
+            col.data_column_id is not None
+            and col.validation
+            and col.validation[0].datatype == DataType.ENUM
+            and isinstance(col.validation[0].value, list)
+        ):
+            pending[col.data_column_id] = col.validation[0].value
+            d["validation"] = [{"datatype": DataType.STRING}]
+        payloads.append(d)
+
+    response = session.put(data_columns_base_url, json={"DataColumns": payloads})
+    returned = [DataColumnValue(**x) for x in response.json()["DataColumns"]]
+
+    for col in returned:
+        enum_values = pending.get(col.data_column_id)
+        if not enum_values or col.sequence is None:
+            continue
+        enum_ops = [{"operation": "add", "text": v.text} for v in enum_values]
+        returned_enums = session.put(
+            f"{data_columns_base_url}/{col.sequence}/enums",
+            json=enum_ops,
+        ).json()
+        patch_payload = GeneralPatchPayload(
+            data=[
+                GeneralPatchDatum(
+                    attribute="datacolumn",
+                    colId=col.sequence,
+                    actions=[
+                        PatchDatum(
+                            operation="update",
+                            attribute="enumSequence",
+                            new_value=[{"id": e["id"]} for e in returned_enums],
+                        )
+                    ],
+                )
+            ]
+        )
+        session.patch(
+            data_template_url,
+            json=patch_payload.model_dump(mode="json", by_alias=True, exclude_none=True),
+        )
+
+    return returned
 
 
 def generate_parameter_group_patches(

--- a/src/albert/utils/data_template.py
+++ b/src/albert/utils/data_template.py
@@ -24,8 +24,6 @@ from albert.resources.data_templates import DataColumnValue, DataTemplate, Impor
 from albert.resources.files import FileNamespace
 from albert.resources.parameter_groups import (
     DataType,
-    EnumValidationValue,
-    ParameterValue,
     ValueValidation,
 )
 from albert.resources.tasks import CsvCurveInput, CsvCurveResponse, TaskMetadata
@@ -483,97 +481,6 @@ def build_curve_import_patch_payload(
             )
         ]
     )
-
-
-def add_parameter_enums(
-    *,
-    session: AlbertSession,
-    base_path: str,
-    data_template_id: DataTemplateId,
-    new_parameters: list[ParameterValue],
-) -> dict[str, list[EnumValidationValue]]:
-    """Add enum values to newly created parameters and return updated enum sequences."""
-
-    data_template = DataTemplate(**session.get(f"{base_path}/{data_template_id}").json())
-    existing_parameters = data_template.parameter_values or []
-    enums_by_sequence: dict[str, list[EnumValidationValue]] = {}
-    for parameter in new_parameters:
-        this_sequence = next(
-            (
-                p.sequence
-                for p in existing_parameters
-                if p.id == parameter.id and p.short_name == parameter.short_name
-            ),
-            None,
-        )
-        enum_patches: list[dict[str, str]] = []
-        if (
-            parameter.validation
-            and len(parameter.validation) > 0
-            and isinstance(parameter.validation[0].value, list)
-        ):
-            existing_validation = (
-                [x for x in existing_parameters if x.sequence == parameter.sequence]
-                if existing_parameters
-                else []
-            )
-            existing_enums = (
-                [
-                    x
-                    for x in existing_validation[0].validation[0].value
-                    if isinstance(x, EnumValidationValue) and x.id is not None
-                ]
-                if (
-                    existing_validation
-                    and len(existing_validation) > 0
-                    and existing_validation[0].validation
-                    and len(existing_validation[0].validation) > 0
-                    and existing_validation[0].validation[0].value
-                    and isinstance(existing_validation[0].validation[0].value, list)
-                )
-                else []
-            )
-            updated_enums = (
-                [x for x in parameter.validation[0].value if isinstance(x, EnumValidationValue)]
-                if parameter.validation[0].value
-                else []
-            )
-
-            deleted_enums = [
-                x for x in existing_enums if x.id not in [y.id for y in updated_enums]
-            ]
-
-            new_enums = [x for x in updated_enums if x.id not in [y.id for y in existing_enums]]
-
-            matching_enums = [x for x in updated_enums if x.id in [y.id for y in existing_enums]]
-
-            for new_enum in new_enums:
-                enum_patches.append({"operation": "add", "text": new_enum.text})
-            for deleted_enum in deleted_enums:
-                enum_patches.append({"operation": "delete", "id": deleted_enum.id})
-            for matching_enum in matching_enums:
-                if (
-                    matching_enum.text
-                    != [x for x in existing_enums if x.id == matching_enum.id][0].text
-                ):
-                    enum_patches.append(
-                        {
-                            "operation": "update",
-                            "id": matching_enum.id,
-                            "text": matching_enum.text,
-                        }
-                    )
-
-            if enum_patches and this_sequence:
-                enum_response = session.put(
-                    f"{base_path}/{data_template_id}/parameters/{this_sequence}/enums",
-                    json=enum_patches,
-                )
-                enums_by_sequence[this_sequence] = [
-                    EnumValidationValue(**x) for x in enum_response.json()
-                ]
-
-    return enums_by_sequence
 
 
 def upload_image_example_attachment(

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -512,3 +512,44 @@ def test_update_required_parameter(
     restored_dt = client.data_templates.update(data_template=updated_dt)
     restored_param = next(x for x in restored_dt.parameter_values if x.id == param.id)
     assert not restored_param.required
+
+
+def test_add_parameters_enum_ids_populated(
+    client: Albert,
+    seeded_data_templates: list[DataTemplate],
+    seeded_parameters: list[Parameter],
+):
+    """Test that enum IDs are assigned when parameters with ENUM validation are added via add_parameters."""
+    dt = next(
+        (x for x in seeded_data_templates if "Parameters Data Template" in x.name),
+        None,
+    )
+    assert dt is not None
+
+    updated_dt = client.data_templates.add_parameters(
+        data_template_id=dt.id,
+        parameters=[
+            ParameterValue(
+                id=seeded_parameters[3].id,
+                validation=[
+                    ValueValidation(
+                        datatype=DataType.ENUM,
+                        value=[
+                            EnumValidationValue(text="EnumA"),
+                            EnumValidationValue(text="EnumB"),
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+
+    added_param = next(
+        (p for p in updated_dt.parameter_values if p.id == seeded_parameters[3].id),
+        None,
+    )
+    assert added_param is not None
+    assert added_param.validation[0].datatype == DataType.ENUM
+    assert len(added_param.validation[0].value) == 2
+    for v in added_param.validation[0].value:
+        assert v.id is not None, f"Enum value '{v.text}' has no ID"

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -8,6 +8,7 @@ from albert.resources.parameter_groups import (
     EnumValidationValue,
     ParameterGroup,
     ParameterGroupSearchItem,
+    ParameterValue,
     ValueValidation,
 )
 from albert.resources.tags import Tag
@@ -288,3 +289,35 @@ def test_update_required(client: Albert, seeded_parameter_groups: list[Parameter
     restored_pg = client.parameter_groups.update(parameter_group=updated_pg)
     restored_param = next(x for x in restored_pg.parameters if x.id == param.id)
     assert not restored_param.required
+
+
+def test_new_parameter_enum_ids_populated(
+    client: Albert,
+    seeded_parameter_groups: list[ParameterGroup],
+    seeded_parameters,
+):
+    """Test that enum IDs are assigned when a new parameter with ENUM validation is added via update."""
+    pg = [x for x in seeded_parameter_groups if "Enums Parameter Group" in x.name][0]
+    pg = client.parameter_groups.get_by_id(id=pg.id)
+
+    pg.parameters.append(
+        ParameterValue(
+            parameter=seeded_parameters[4],
+            validation=[
+                ValueValidation(
+                    datatype=DataType.ENUM,
+                    value=[
+                        EnumValidationValue(text="EnumRepro1"),
+                        EnumValidationValue(text="EnumRepro2"),
+                    ],
+                )
+            ],
+        )
+    )
+    updated_pg = client.parameter_groups.update(parameter_group=pg)
+
+    new_param = next(p for p in updated_pg.parameters if p.id == seeded_parameters[4].id)
+    assert new_param.validation[0].datatype == DataType.ENUM
+    assert len(new_param.validation[0].value) == 2
+    for v in new_param.validation[0].value:
+        assert v.id is not None, f"Enum value '{v.text}' has no ID"


### PR DESCRIPTION
## Summary
- When a `ParameterValue` with `DataType.ENUM` validation is added to a parameter group via `update()`, enum options are now assigned server-side IDs (two-step PUT + `/enums` flow)
- Extracted `strip_new_parameter_enums`, `restore_new_parameter_enums`, and `push_new_parameter_enums` into `utils/_patch.py`, shared by both `ParameterGroupCollection` and `DataTemplateCollection`
- `ParameterSearchItemParameter.name` is now `str | None` — the API does not always include it in search results (spec defines it as non-required)