### PR TITLE
fix(session): handle None params in _encode_query_params

### DIFF
--- a/src/albert/core/session.py
+++ b/src/albert/core/session.py
@@ -77,7 +77,7 @@ class AlbertSession(requests.Session):
     def request(self, method: str, path: str, *args, **kwargs) -> requests.Response:
         self.headers["Authorization"] = f"Bearer {self._access_token}"
         full_url = urljoin(self.base_url, path) if not path.startswith("http") else path
-        params = self._encode_query_params(kwargs.pop("params", {}))
+        params = self._encode_query_params(kwargs.pop("params", None) or {})
         # The requests library internally uses urllib.parse.urlencode() with the quote_via parameter set to quote_plus, which breaks CAS pagination.
         # Encoding parameters manually (via quote) to avoid this issue.
         if params:


### PR DESCRIPTION
## Summary
- `requests 2.33.1` changed `Session.get()` to explicitly pass `params=None` to `request()`, exposing a latent crash in `_encode_query_params`
- Any GET call without params (e.g. `get_by_id` across all collections) raised `AttributeError: 'NoneType' object has no attribute 'items'`
- Fix: `kwargs.pop("params", None) or {}` collapses both the missing-key and explicit-`None` cases to an empty dict
- Affects all customers on `requests>=2.33.1` — patch release recommended