### PR TITLE
docs(enums): document shared enums and add to SDK reference

### DIFF
--- a/docs/resources/enums.md
+++ b/docs/resources/enums.md
@@ -1,0 +1,1 @@
+::: albert.core.shared.enums

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -200,6 +200,7 @@ nav:
           - Data Columns: resources/data_columns.md
           - Data Templates: resources/data_templates.md
           - Entity Types: resources/entity_types.md
+          - Enums: resources/enums.md
           - Files: resources/files.md
           - Hazards: resources/hazards.md
           - Identifiers: resources/identifiers.md

--- a/src/albert/core/shared/enums.py
+++ b/src/albert/core/shared/enums.py
@@ -2,27 +2,66 @@ from enum import Enum
 
 
 class OrderBy(str, Enum):
+    """Sort direction for list and search results.
+
+    Attributes
+    ----------
+    DESCENDING : str
+        Reverse chronological or reverse alphabetical order (Z→A, newest→oldest).
+    ASCENDING : str
+        Chronological or alphabetical order (A→Z, oldest→newest).
+    """
+
     DESCENDING = "desc"
     ASCENDING = "asc"
 
 
 class Status(str, Enum):
-    """The status of a resource"""
+    """The status of a resource.
+
+    Attributes
+    ----------
+    ACTIVE : str
+        The resource is fully operational and visible in normal operations.
+    INACTIVE : str
+        The resource is hidden from normal operations and disabled from use.
+    """
 
     ACTIVE = "active"
     INACTIVE = "inactive"
 
 
 class SecurityClass(str, Enum):
-    """The security class of a resource"""
+    """The security (access control) class of a resource.
+
+    Attributes
+    ----------
+    SHARED : str
+        Accessible to all members of the tenant.
+    RESTRICTED : str
+        Access is restricted to specific teams or users.
+    CONFIDENTIAL : str
+        Access is limited to designated users only.
+    PRIVATE : str
+        Visible only to the owner. Used by Projects.
+    """
 
     SHARED = "shared"
     RESTRICTED = "restricted"
     CONFIDENTIAL = "confidential"
-    # only used by "PROJECTS"
     PRIVATE = "private"
 
 
 class PaginationMode(str, Enum):
+    """Internal pagination strategy used by the SDK.
+
+    Attributes
+    ----------
+    OFFSET : str
+        Offset-based pagination using a numeric skip value.
+    KEY : str
+        Cursor-based pagination using an opaque ``startKey`` / ``lastKey`` pair.
+    """
+
     OFFSET = "offset"
     KEY = "key"


### PR DESCRIPTION
## Summary
- Adds `docs/resources/enums.md` rendering `albert.core.shared.enums` via mkdocstrings, giving `Status`, `OrderBy`, `SecurityClass`, and `PaginationMode` a published docs page
- Adds the page to `mkdocs.yml` nav under Resources → Enums (alphabetical)
- Adds Numpy-style `Attributes` docstrings to all four enums so the rendered page shows type and description for every member
- Fixes the unresolvable `signature_crossrefs` links from collection method signatures (e.g. `get_all(status: Status)`) that previously had no target to link to

Closes #489