### PR TITLE
fix(sheets): add colSizeMode field to Sheet model

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -448,6 +448,9 @@ class Sheet(BaseSessionResource):  # noqa:F811
         Whether the sheet is hidden.
     is_column_right : bool | None
         When True, copied columns are placed to the right of the source column; when False, to the left.
+    col_size_mode : str | None
+        Column width sizing mode. Allowed values are ``"minimum"`` and ``"fitToColumn"``.
+        ``None`` resets to the default grid width.
     designs : list[Design]
         The designs of the sheet.
     project_id : str
@@ -466,6 +469,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
     formulations: list[SheetFormulationRef] = Field(default_factory=list, alias="Formulas")
     hidden: bool
     is_column_right: bool | None = Field(default=None, alias="isColumnRight")
+    col_size_mode: str | None = Field(default=None, alias="colSizeMode")
     _app_design: Design = PrivateAttr(default=None)
     _product_design: Design = PrivateAttr(default=None)
     _result_design: Design = PrivateAttr(default=None)


### PR DESCRIPTION
## Summary
- Adds `col_size_mode: str | None` (alias `colSizeMode`) to the `Sheet` resource model
- Surfaces the new field introduced in [api-worksheet#352](https://github.com/MoleculeEngineering/api-worksheet/pull/352) which adds sheet-level column width sizing mode
- Allowed values: `"minimum"`, `"fitToColumn"`, or `None` to reset to default grid width