### PR TITLE
fix(data_templates): workaround backend s3key bug in calculation update test

### DIFF
--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -269,16 +269,43 @@ def test_enum_validation_update(client: Albert, seeded_data_templates: list[Data
         assert old in new_options
 
 
-def test_update_calculation(client: Albert, seeded_data_templates: list[DataTemplate]):
-    """Test updating calculation on a data template data column."""
-    dt = next(x for x in seeded_data_templates if "Calculation Template" in x.name)
-    column = next(x for x in dt.data_column_values if x.sequence != "COL0")
+@pytest.fixture
+def calculation_dt(client: Albert, seeded_data_columns: list[DataColumn], seed_prefix: str):
+    from contextlib import suppress
 
-    assert column.calculation is not None
-    updated_calculation = "=COL0 + 1"
+    from albert.exceptions import NotFoundError
+    from albert.resources.data_templates import DataColumnValue
+
+    # Step 1: create without calculation so the backend doesn't lock in validation=[number]
+    dt = client.data_templates.create(
+        data_template=DataTemplate(
+            name=f"{seed_prefix} - Calculation Test",
+            data_column_values=[
+                DataColumnValue(data_column=seeded_data_columns[0]),
+                DataColumnValue(data_column=seeded_data_columns[2]),
+            ],
+        )
+    )
+
+    # Step 2: add calculation via PATCH — backend clears validation to [] on this path
+    col = next(c for c in dt.data_column_values if c.sequence not in ("COL0", "COL1"))
+    col.calculation = "=COL1"
+    dt = client.data_templates.update(data_template=dt)
+
+    yield dt
+
+    with suppress(NotFoundError):
+        client.data_templates.delete(id=dt.id)
+
+
+def test_update_calculation(client: Albert, calculation_dt: DataTemplate):
+    """Test updating calculation on a data template data column."""
+    column = next(x for x in calculation_dt.data_column_values if x.calculation is not None)
+
+    updated_calculation = "=COL1 * 2"
     column.calculation = updated_calculation
 
-    updated_dt = client.data_templates.update(data_template=dt)
+    updated_dt = client.data_templates.update(data_template=calculation_dt)
 
     assert updated_dt is not None
     updated_column = next(

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -288,7 +288,7 @@ def calculation_dt(client: Albert, seeded_data_columns: list[DataColumn], seed_p
     )
 
     # Step 2: add calculation via PATCH — backend clears validation to [] on this path
-    col = next(c for c in dt.data_column_values if c.sequence not in ("COL0", "COL1"))
+    col = next(c for c in dt.data_column_values if c.data_column_id == seeded_data_columns[2].id)
     col.calculation = "=COL1"
     dt = client.data_templates.update(data_template=dt)
 

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -857,23 +857,6 @@ def generate_data_template_seeds(
             ],
             tags=[seeded_tags[0]],
         ),
-        # Data Template with calculations and no validations
-        DataTemplate(
-            name=f"{seed_prefix} - Calculation Template",
-            description="A data template with calculations and no validations.",
-            data_column_values=[
-                DataColumnValue(
-                    data_column=seeded_data_columns[0],
-                    calculation="=COL0 + COL1",
-                    unit=EntityLink(id=seeded_units[0].id),
-                ),
-                DataColumnValue(
-                    data_column=seeded_data_columns[1],
-                    calculation="=COL0",
-                    unit=EntityLink(id=seeded_units[1].id),
-                ),
-            ],
-        ),
         # Data Template with parameters (for PATCH /parameters testing)
         DataTemplate(
             name=f"{seed_prefix} - Parameters Data Template",


### PR DESCRIPTION
## Summary
- Removes the session-scoped "Calculation Template" seed — no test referenced it after the rewrite
- Adds a function-scoped `calculation_dt` fixture in `test_data_templates.py` that owns the full lifecycle: create DT without calculation → add calculation via PATCH → yield → delete
- The two-step create+add approach is required because the backend retains `validation=[number]` on columns created with a calculation in the POST body, which triggers a backend 500 (`s3key` is not a valid attribute) on any subsequent calculation PATCH
- Adding the calculation via a separate PATCH causes the backend to clear `validation` to `[]`, after which further calculation updates succeed