### PR TITLE
fix(tasks): add property blocks support to BatchTask

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -104,7 +104,7 @@ class TaskCollection(BaseCollection):
     def add_block(
         self, *, task_id: TaskId, data_template_id: DataTemplateId, workflow_id: WorkflowId
     ) -> None:
-        """Add a block to a Property task.
+        """Add a block to a Property or Batch task.
 
         Parameters
         ----------
@@ -160,15 +160,15 @@ class TaskCollection(BaseCollection):
 
         Notes
         -----
-        - The method asserts that the retrieved task is an instance of `PropertyTask`.
+        - The method requires the task to be a PropertyTask or BatchTask.
         - If the block's current workflow matches the new workflow ID, no update is performed.
         - The method handles the case where the block has a default workflow named "No Parameter Group".
         """
         url = f"{self.base_path}/{task_id}"
         task = self.get_by_id(id=task_id)
-        if not isinstance(task, PropertyTask):
-            logger.error(f"Task {task_id} is not an instance of PropertyTask")
-            raise TypeError(f"Task {task_id} is not an instance of PropertyTask")
+        if not isinstance(task, PropertyTask | BatchTask):
+            logger.error(f"Task {task_id} is not a PropertyTask or BatchTask")
+            raise TypeError(f"Task {task_id} is not a PropertyTask or BatchTask")
         for b in task.blocks:
             if b.id != block_id:
                 continue
@@ -198,7 +198,7 @@ class TaskCollection(BaseCollection):
 
     @validate_call
     def remove_block(self, *, task_id: TaskId, block_id: BlockId) -> None:
-        """Remove a block from a Property task.
+        """Remove a block from a Property or Batch task.
 
         Parameters
         ----------

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -355,11 +355,9 @@ class BatchTask(BaseTask):
     qc_task: bool | None = Field(alias="qcTask", default=None)
     batch_task_id: str | None = Field(alias="batchTaskId", default=None)
     target: str | None = Field(default=None)
-    target: str | None = Field(default=None)
     qc_task_data: list[QCTaskData] | None = Field(alias="QCTaskData", default=None)
-    workflows: list[SerializeAsEntityLink[Workflow]] | None = Field(
-        alias="Workflow", default=None
-    )  # not sure what QuantityUsed in the API docs means here.
+    workflows: list[SerializeAsEntityLink[Workflow]] | None = Field(alias="Workflow", default=None)
+    blocks: list[Block] | None = Field(alias="Blocks", default=None)
 
 
 class GeneralTask(BaseTask):

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -3,6 +3,7 @@ from albert.resources.lists import ListItem
 from albert.resources.tags import Tag
 from albert.resources.tasks import (
     BaseTask,
+    BatchTask,
     PropertyTask,
     TaskCategory,
     TaskSearchItem,
@@ -121,6 +122,53 @@ def test_update_block_workflow(
     assert len(updated_task.blocks) == starting_blocks
     updated_block = [x for x in updated_task.blocks if x.id == block_id][0]
     assert new_workflow.id in [x.id for x in updated_block.workflow]
+
+
+def test_add_block_to_batch_task(
+    client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
+):
+    """Test that a property block can be added to a batch task."""
+    task = next(x for x in seeded_tasks if isinstance(x, BatchTask) and x.blocks is not None)
+    task = client.tasks.get_by_id(id=task.id)
+    starting_blocks = len(task.blocks)
+    client.tasks.add_block(
+        task_id=task.id,
+        data_template_id=seeded_data_templates[0].id,
+        workflow_id=seeded_workflows[0].id,
+    )
+    updated_task = client.tasks.get_by_id(id=task.id)
+    assert len(updated_task.blocks) == starting_blocks + 1
+
+
+def test_update_block_workflow_on_batch_task(
+    client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
+):
+    """Test that the workflow of a block on a batch task can be updated."""
+    task = next(x for x in seeded_tasks if isinstance(x, BatchTask) and x.blocks is not None)
+    task = client.tasks.get_by_id(id=task.id)
+    starting_blocks = len(task.blocks)
+    block_id = task.blocks[0].id
+    current_workflow_id = task.blocks[0].workflow[0].id
+    new_workflow = next(x for x in seeded_workflows if x.id != current_workflow_id)
+    client.tasks.update_block_workflow(
+        task_id=task.id, block_id=block_id, workflow_id=new_workflow.id
+    )
+    updated_task = client.tasks.get_by_id(id=task.id)
+    assert len(updated_task.blocks) == starting_blocks
+    updated_block = next(x for x in updated_task.blocks if x.id == block_id)
+    assert new_workflow.id in [x.id for x in updated_block.workflow]
+
+
+def test_remove_block_from_batch_task(client: Albert, seeded_tasks, seeded_workflows):
+    """Test that a property block can be removed from a batch task."""
+    task = next(x for x in seeded_tasks if isinstance(x, BatchTask) and x.blocks is not None)
+    task = client.tasks.get_by_id(id=task.id)
+    starting_blocks = len(task.blocks)
+    block_id = task.blocks[0].id
+    client.tasks.remove_block(task_id=task.id, block_id=block_id)
+    updated_task = client.tasks.get_by_id(id=task.id)
+    assert len(updated_task.blocks) == starting_blocks - 1
+    assert block_id not in [x.id for x in (updated_task.blocks or [])]
 
 
 def test_task_get_history(client: Albert, seeded_tasks):

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -1693,6 +1693,30 @@ def generate_task_seeds(
             start_date="2024-10-01",
             due_date="2024-10-31",
         ),
+        # Batch Task with property blocks
+        BatchTask(
+            name=f"{seed_prefix} - Batch Task With Blocks",
+            category=TaskCategory.BATCH,
+            batch_size_unit=BatchSizeUnit.GRAMS,
+            inventory_information=[
+                TaskInventoryInformation(
+                    inventory_id=seeded_products[0].id,
+                    batch_size=50.0,
+                )
+            ],
+            location=seeded_locations[0],
+            priority=TaskPriority.LOW,
+            project=formulation_proj,
+            parent_id=formulation_proj.id,
+            assigned_to=user,
+            due_date="2024-10-31",
+            blocks=[
+                Block(
+                    workflow=[seeded_workflows[0]],
+                    data_template=[seeded_data_templates[0]],
+                )
+            ],
+        ),
     ]
 
 


### PR DESCRIPTION
## Summary
- Add `blocks: list[Block] | None` field to `BatchTask` — the API has returned property blocks on batch task responses since the Connected Batch and Property Tasks GA release, but the SDK was silently dropping them
- Fix `update_block_workflow` to accept `BatchTask` in addition to `PropertyTask` (the hard `isinstance` guard was incorrectly restricting it)
- Update `add_block` and `remove_block` docstrings to reflect batch task support
- Seed a `BatchTask` with a property block and add three integration tests covering `add_block`, `update_block_workflow`, and `remove_block` on batch tasks