### PR TITLE
feat(chats): add TOOL_CALL and ERROR to ChatComponentType [SDK-50]

### DIFF
--- a/src/albert/resources/chats.py
+++ b/src/albert/resources/chats.py
@@ -18,6 +18,8 @@ class ChatComponentType(str, Enum):
     NOTEBOOK_CITATION = "notebook_citation"
     PRODUCT_CARD = "product_card"
     INGREDIENT_CARD = "ingredient_card"
+    TOOL_CALL = "tool_call"
+    ERROR = "error"
 
 
 class ChatUserType(str, Enum):

--- a/src/albert/resources/custom_fields.py
+++ b/src/albert/resources/custom_fields.py
@@ -30,6 +30,7 @@ class ServiceType(str, Enum):
     DATA_TEMPLATES = "datatemplates"
     PARAMETER_GROUPS = "parametergroups"
     CAS = "cas"
+    SUBSTANCES = "substances"
 
 
 class FieldCategory(str, Enum):


### PR DESCRIPTION
## Summary

- Adds `TOOL_CALL` and `ERROR` variants to `ChatComponentType` enum
- Required by the ReAct agent (albert-ai) to persist tool-call and error stream events to chat history

## Context

The `albert-ai` ReAct worker writes chat messages with `component_type=TOOL_CALL` and `component_type=ERROR`. Without these enum values the SDK rejects or silently drops those writes.

## Test plan

- [ ] Confirm `ChatComponentType.TOOL_CALL` and `ChatComponentType.ERROR` are importable from `albert.resources.chats`
- [ ] Confirm existing chat tests still pass: `uv run pytest`