### PR TITLE
feat(chats): add TOOL_CALL and ERROR to ChatComponentType

### DIFF
--- a/src/albert/resources/chats.py
+++ b/src/albert/resources/chats.py
@@ -18,6 +18,8 @@ class ChatComponentType(str, Enum):
     NOTEBOOK_CITATION = "notebook_citation"
     PRODUCT_CARD = "product_card"
     INGREDIENT_CARD = "ingredient_card"
+    TOOL_CALL = "tool_call"
+    ERROR = "error"
 
 
 class ChatUserType(str, Enum):

--- a/src/albert/resources/custom_fields.py
+++ b/src/albert/resources/custom_fields.py
@@ -30,6 +30,7 @@ class ServiceType(str, Enum):
     DATA_TEMPLATES = "datatemplates"
     PARAMETER_GROUPS = "parametergroups"
     CAS = "cas"
+    SUBSTANCES = "substances"
 
 
 class FieldCategory(str, Enum):


### PR DESCRIPTION
## Summary

- Adds `TOOL_CALL` and `ERROR` variants to `ChatComponentType` enum in `chats.py` to match the component types emitted by the ReAct worker
- Adds `SUBSTANCES` to `ServiceType` enum in `custom_fields.py`

## Test plan

- [ ] Verify `ChatComponentType.TOOL_CALL` and `ChatComponentType.ERROR` are importable and serialise to the correct string values
- [ ] Confirm no existing enum consumers are broken by the additions (additive change only)

This PR contains AI-assisted code generated with Claude Code. The author has reviewed and takes full responsibility for all changes.