### PR TITLE
fix(workflows): allow Special parameters to have Intervals

### DIFF
--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -48,16 +48,22 @@ class IntervalParameter(BaseAlbertModel):
 class Interval(BaseAlbertModel):
     """A Pydantic class representing an interval.
 
-    Attrubutes
+    Attributes
     ----------
     value : str
-        The value of the interval setpoint.
+        The value of the interval setpoint. For Special parameters (Equipment, Consumables,
+        Templates) this is the entity ID (e.g. ``"INVC191778"``). For Normal parameters this
+        is a plain scalar string (e.g. ``"23"``).
+    name : str | None
+        The display name of the interval value. Populated for Special parameters (e.g.
+        ``"Pipette 0.01 -0.1 ml (10 - 100 μl)"``). ``None`` for Normal parameters.
     unit : Unit
         The unit of the related value.
 
     """
 
     value: str | None = Field(default=None)
+    name: str | None = Field(default=None)
     unit: SerializeAsEntityLink[Unit] | None = Field(default=None, alias="Unit")
     row_id: RowId | None = Field(default=None, alias="rowId", exclude=True)
 
@@ -68,6 +74,21 @@ class Interval(BaseAlbertModel):
         if self.unit and not getattr(self.unit, "id", None):
             raise ValueError("Interval: 'Unit.id' is required.")
         return self
+
+
+class IntervalDetail(BaseAlbertModel):
+    """A single parameter's contribution to an interval combination.
+
+    Attributes
+    ----------
+    name : str
+        The parameter name (e.g. ``"Equipment"``).
+    value : str
+        The display value for this interval (e.g. ``"C191778 || Pipette 0.01 -0.1 ml"``).
+    """
+
+    name: str
+    value: str
 
 
 class IntervalCombination(BaseAlbertModel):
@@ -91,11 +112,15 @@ class IntervalCombination(BaseAlbertModel):
         The string representation of the interval combination
         This will have the form "[Parameter Name]: [Parameter Value] [Parameter Unit]"
         for each parameter in the interval combination
+    interval_details : list[IntervalDetail] | None
+        Per-parameter breakdown of the interval combination. Each entry has ``name``
+        (parameter name) and ``value`` (display string, e.g. ``"C191778 || Pipette ..."``)
     """
 
     interval_id: IntervalId | None = Field(default=None, alias="interval")
     interval_params: str | None = Field(default=None, alias="intervalParams")
     interval_string: str | None = Field(default=None, alias="intervalString")
+    interval_details: list[IntervalDetail] | None = Field(default=None, alias="intervalDetails")
 
 
 class ParameterSetpoint(BaseAlbertModel):
@@ -162,7 +187,9 @@ class ParameterSetpoint(BaseAlbertModel):
         # Special Parameters
         if self.category == ParameterCategory.SPECIAL:
             if self.intervals is not None:
-                raise ValueError(f"Parameter {pid}: Special parameters cannot have 'intervals'.")
+                # Intervalized special parameters (Equipment, Consumables, Templates) are valid;
+                # each interval value is a plain entity ID string.
+                return self
             if self.value is None:
                 return self  # presence-only allowed
             if not has_id(self.value):


### PR DESCRIPTION
## Summary
- Removes the validator in `ParameterSetpoint` that incorrectly blocked `category=Special` parameters from having `Intervals` — the backend supports intervalizing Equipment, Consumables, and Template parameters
- Adds `name: str | None` to `Interval` to capture the display name returned for Special parameter interval values (e.g. `"Pipette 0.01 -0.1 ml (10 - 100 μl)"`)
- Adds `IntervalDetail` model and `interval_details` field to `IntervalCombination` to expose the per-parameter breakdown from the `/intervals` endpoint