### PR TITLE
feat(attachments): add get_jurisdiction_codes and get_language_codes methods

### DIFF
--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -202,9 +202,10 @@ class AttachmentCollection(BaseCollection):
         Parameters
         ----------
         parent_ids : list[str]
-            Parent IDs of the objects to which the attachments are linked. Unlike most
-            other collection methods, these IDs are passed as-is with no validation or
-            normalisation.
+            Parent IDs of the objects to which the attachments are linked. IDs must
+            include the full entity prefix (e.g. ``"INVA123"`` for an inventory item,
+            ``"PRO123"`` for a project). Unlike most other collection methods, no prefix
+            inference or ID normalisation is applied.
 
         Returns
         -------

--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -204,8 +204,7 @@ class AttachmentCollection(BaseCollection):
         parent_ids : list[str]
             Parent IDs of the objects to which the attachments are linked. IDs must
             include the full entity prefix (e.g. ``"INVA123"`` for an inventory item,
-            ``"PRO123"`` for a project). Unlike most other collection methods, no prefix
-            inference or ID normalisation is applied.
+            ``"PRO123"`` for a project).
 
         Returns
         -------

--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -202,7 +202,9 @@ class AttachmentCollection(BaseCollection):
         Parameters
         ----------
         parent_ids : list[str]
-            Parent IDs of the objects to which the attachments are linked.
+            Parent IDs of the objects to which the attachments are linked. Unlike most
+            other collection methods, these IDs are passed as-is with no validation or
+            normalisation.
 
         Returns
         -------

--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -252,6 +252,32 @@ class AttachmentCollection(BaseCollection):
         )
         return self.create(attachment=attachment)
 
+    def get_jurisdiction_codes(self) -> dict[str, str]:
+        """Return available jurisdiction codes.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of jurisdiction name to code (e.g. ``{"Germany": "DE", "USA": "US"}``).
+        """
+        response = self.session.get(
+            f"{self.base_path}/jurisdictionslanguages", params={"type": "jurisdiction"}
+        )
+        return response.json()
+
+    def get_language_codes(self) -> dict[str, str]:
+        """Return available language codes.
+
+        Returns
+        -------
+        dict[str, str]
+            Mapping of language name to code (e.g. ``{"English": "EN", "German": "DE"}``).
+        """
+        response = self.session.get(
+            f"{self.base_path}/jurisdictionslanguages", params={"type": "language"}
+        )
+        return response.json()
+
     @validate_call
     def delete(self, *, id: AttachmentId) -> None:
         """Deletes an attachment by ID.
@@ -364,10 +390,12 @@ class AttachmentCollection(BaseCollection):
             The UN number.
         storage_class : str
             The Storage Class number.
-        jurisdiction_code : str | None, optional
-            Jurisdiction code associated with the SDS (e.g. ``US``).
+        jurisdiction_code : str, optional
+            Jurisdiction code for the SDS (e.g. ``"US"``). Use
+            ``get_jurisdiction_codes()`` to retrieve the full list of available codes.
         language_code : str, optional
-            Language code for the SDS (e.g. ``EN``).
+            Language code for the SDS (e.g. ``"EN"``). Use
+            ``get_language_codes()`` to retrieve the full list of available codes.
         hazard_statements : list[HazardStatement] | None, optional
             Collection of hazard statements.
         hazard_symbols : list[HazardSymbol] | None, optional


### PR DESCRIPTION
## Summary
- Adds `get_jurisdiction_codes()` to `AttachmentCollection` — returns a `dict[str, str]` mapping jurisdiction name to code (e.g. `{"Germany": "DE"}`)
- Adds `get_language_codes()` to `AttachmentCollection` — returns a `dict[str, str]` mapping language name to code (e.g. `{"English": "EN"}`)
- Updates `upload_and_attach_sds_to_inventory_item` docstring to point callers to these methods for discovering available codes