### PR TITLE
fix(sheets): fix leftmost_pinned_column causing silent wksSequence drop

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -815,6 +815,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
         starting_position: dict | None = None,
     ) -> list[Column]:
         if starting_position is None:
+            # Ensure pinned-column state is resolved before computing the reference position.
             if self.app_design is not None:
                 _ = self.app_design.grid
             starting_position = {

--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -815,10 +815,6 @@ class Sheet(BaseSessionResource):  # noqa:F811
         starting_position: dict | None = None,
     ) -> list[Column]:
         if starting_position is None:
-            # Load the app-design grid now so leftmost_pinned_column reflects real pinned state.
-            # Without this, _leftmost_pinned_column is None and the server falls back to its
-            # internal defaultAPPCols constant, which may not be present in wksSequence for
-            # every sheet — causing findAndInsertElement to silently skip the column insertion.
             if self.app_design is not None:
                 _ = self.app_design.grid
             starting_position = {

--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -265,13 +265,15 @@ class Design(BaseSessionResource):
 
             records.append(row_cells)
 
-        # Determine the leftmost pinned column
+        # Determine the leftmost pinned column (last pinned col before first unpinned col).
+        # Guard i > 0: if the very first formula is unpinned there are no pinned columns
+        # and Formulas[i - 1] would wrap to the last element (Python negative index).
         for i, fmt in enumerate(grid_response.get("Formulas", [])):
             state = fmt.get("state", {})
             if state.get("pinned") is None:
-                # use the previous formula's colId
-                prev = grid_response["Formulas"][i - 1]
-                self._leftmost_pinned_column = prev["colId"]
+                if i > 0:
+                    prev = grid_response["Formulas"][i - 1]
+                    self._leftmost_pinned_column = prev["colId"]
                 break
 
         return pd.DataFrame.from_records(records, index=index)
@@ -813,6 +815,12 @@ class Sheet(BaseSessionResource):  # noqa:F811
         starting_position: dict | None = None,
     ) -> list[Column]:
         if starting_position is None:
+            # Load the app-design grid now so leftmost_pinned_column reflects real pinned state.
+            # Without this, _leftmost_pinned_column is None and the server falls back to its
+            # internal defaultAPPCols constant, which may not be present in wksSequence for
+            # every sheet — causing findAndInsertElement to silently skip the column insertion.
+            if self.app_design is not None:
+                _ = self.app_design.grid
             starting_position = {
                 "reference_id": self.leftmost_pinned_column,
                 "position": "rightOf",


### PR DESCRIPTION
## Summary
- `add_formulation_columns` was sending `referenceId: null` to the worksheet API because `app_design.grid` was never loaded before accessing `leftmost_pinned_column` — the server fell back to its internal `defaultAPPCols` constant, which may not exist in every sheet's `wksSequence`, causing `findAndInsertElement` to silently skip the column insertion. Formula would be created in inventory but invisible in the worksheet.
- Fix: eagerly load `app_design.grid` inside `add_formulation_columns` (when no explicit `starting_position` is provided) so a real, validated column ID is resolved and sent as `referenceId`.
- Also guard the `Formulas[i - 1]` index in `_grid_to_cell_df` against `i = 0`, which would wrap to the last list element via Python's negative index and return the wrong colId.