### PR TITLE
feat(tasks): support updating project via tasks.update()

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -723,7 +723,7 @@ class TaskCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``due_date``, ``metadata``, ``name``, ``priority``, ``state``.
+        The following fields can be updated: ``due_date``, ``metadata``, ``name``, ``priority``, ``project``, ``state``.
         """
         existing = self.get_by_id(id=task.id)
         patch_payload = generate_adv_patch_payload(

--- a/src/albert/utils/tasks.py
+++ b/src/albert/utils/tasks.py
@@ -268,6 +268,7 @@ def generate_adv_patch_payload(
         "inventory_information",
         "assigned_to",
         "tags",
+        "project",
     }
     if updated.assigned_to is not None:
         updated.assigned_to = EntityLinkWithName(
@@ -379,6 +380,39 @@ def generate_adv_patch_payload(
                         "operation": PatchOperation.DELETE,
                         "attribute": "tagId",
                         "oldValue": [tag_id],
+                    }
+                )
+
+        if attribute == "project":
+            old_project = getattr(existing, "project", None)
+            new_project = getattr(updated, "project", None)
+            old_id = getattr(old_project, "id", None)
+            new_id = getattr(new_project, "id", None)
+            if new_id == old_id:
+                continue
+            if old_id is None and new_id is not None:
+                base_payload.data.append(
+                    {
+                        "operation": PatchOperation.ADD,
+                        "attribute": "projectId",
+                        "newValue": new_id,
+                    }
+                )
+            elif old_id is not None and new_id is not None:
+                base_payload.data.append(
+                    {
+                        "operation": PatchOperation.UPDATE,
+                        "attribute": "projectId",
+                        "oldValue": old_id,
+                        "newValue": new_id,
+                    }
+                )
+            elif old_id is not None and new_id is None:
+                base_payload.data.append(
+                    {
+                        "operation": PatchOperation.DELETE,
+                        "attribute": "projectId",
+                        "oldValue": old_id,
                     }
                 )
 

--- a/src/albert/utils/tasks.py
+++ b/src/albert/utils/tasks.py
@@ -386,6 +386,10 @@ def generate_adv_patch_payload(
         if attribute == "project":
             old_project = getattr(existing, "project", None)
             new_project = getattr(updated, "project", None)
+            if isinstance(old_project, list) or isinstance(new_project, list):
+                raise ValueError(
+                    "Updating project is not supported for tasks with multiple associated projects."
+                )
             old_id = getattr(old_project, "id", None)
             new_id = getattr(new_project, "id", None)
             if new_id == old_id:


### PR DESCRIPTION
## Summary
- `tasks.update()` previously had no support for changing a task's associated project
- Adds `project` as a patchable field in `generate_adv_patch_payload`, handling all three cases: add (no existing project), update (change project), and delete (remove project)
- Uses the correct API operations: `add` / `update` / `delete` on `attribute: projectId`