### PR TITLE
fix(chats): add DOCUMENT_CITATION component type AI-655

### DIFF
--- a/src/albert/resources/chats.py
+++ b/src/albert/resources/chats.py
@@ -16,6 +16,7 @@ class ChatComponentType(str, Enum):
     IMAGE = "image"
     REASONING_BLOCK = "reasoning_block"
     NOTEBOOK_CITATION = "notebook_citation"
+    DOCUMENT_CITATION = "document_citation"
     PRODUCT_CARD = "product_card"
     INGREDIENT_CARD = "ingredient_card"
     TOOL_CALL = "tool_call"


### PR DESCRIPTION
## What

The Albert SDK now exposes the `DOCUMENT_CITATION` component type, allowing the react worker to persist document citation messages (PDFs, attachments, spreadsheets) to api-chat. Previously this enum value was missing, causing the worker's persistence policy to reject these messages before they could be stored.

## Why

The api-chat service already supports `document_citation` in its OpenAPI schema, but the Albert SDK was incomplete. This missing enum value blocks the full citation card persistence flow: document citations stream correctly to the frontend but fail to persist when the page is refreshed.

## How

- Added `DOCUMENT_CITATION = "document_citation"` to `ChatComponentType` enum
- Bumped version from 1.25.1 to 1.25.2 (patch)

## Testing

No SDK tests changed (this is a missing enum value that mirrors api-chat support). The fix is verified end-to-end when deployed alongside:
- PR albert-ai#457 (adds DOCUMENT_CITATION to the readback type map)
- The react worker code that emits document citations (already in PR albert-ai#427)