### PR TITLE
fix(inventory): cast int values to str in InventorySpecValue validator

### DIFF
--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -273,7 +273,7 @@ class InventorySpecValue(BaseAlbertModel):
     @field_validator("min", "max", "reference", mode="before")
     @classmethod
     def cast_float_to_str(cls, v: Any) -> Any:
-        if isinstance(v, float):
+        if isinstance(v, (int, float)):
             return str(v)
         return v
 


### PR DESCRIPTION
## What

`InventorySpecValue` fields (`min`, `max`, `reference`) now correctly accept integer values in addition to floats, casting them to strings before Pydantic validates against `str | None`.

## Why

The existing `cast_float_to_str` before-validator only guarded against `float`. Integer values like `{'reference': 8}` — valid API responses — bypassed the guard and caused a Pydantic `ValidationError`. Discovered when validating an `InventorySpec` payload in the Breakthrough notebook.

## How

- Changed `isinstance(v, float)` to `isinstance(v, (int, float))` in the `InventorySpecValue` before-validator.
- No other logic changed — the `str(v)` cast is the same path for both numeric types.

## Testing

```python
from pydantic import TypeAdapter
from albert.resources.inventory import InventorySpec

payload = {
    'albertId': 'ATR8',
    'name': 'Chain Length',
    'datacolumnId': 'DAC1355',
    'Value': {'reference': 8},
}
ta = TypeAdapter(InventorySpec)
ta.validate_python(payload)  # now succeeds
```