### PR TITLE
fix(inventory): expose inventory_on_hand on InventoryItem

### DIFF
--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -203,6 +203,8 @@ class InventoryItem(BaseTaggedResource):
         The formula ID associated with the InventoryItem. Read Only.
     tags : list[str|Tag] | None
         The tags associated with the InventoryItem. Optional. If a string is provided, a Tag object with the name of the provided string will be first-or-created.
+    inventory_on_hand : float
+        The total amount of this item currently on hand across all lots. Read Only.
     """
 
     name: str | None = None
@@ -221,6 +223,7 @@ class InventoryItem(BaseTaggedResource):
     acls: list[ACL] = Field(default_factory=list, alias="ACL")
 
     # Read-only fields
+    inventory_on_hand: float = Field(default=0.0, alias="onHand", exclude=True, frozen=True)
     task_config: list[dict] | None = Field(
         default=None, alias="TaskConfig", exclude=True, frozen=True
     )


### PR DESCRIPTION
## Summary
- Adds `inventory_on_hand: float` (alias `onHand`) to `InventoryItem` as a read-only field
- The field is already present in the API response for `GET /inventories/{id}` but was previously silently dropped
- Matches the existing `inventory_on_hand` naming on `InventorySearchItem` (which aliases `inventoryOnHand`) for a consistent caller experience

Closes #533