### PR TITLE
fix(inventory): add InventoryMergeModule enum for merge modules parameter

### DIFF
--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -22,6 +22,7 @@ from albert.resources.inventory import (
     ALL_MERGE_MODULES,
     InventoryCategory,
     InventoryItem,
+    InventoryMergeModule,
     InventorySearchItem,
     InventorySpec,
     InventorySpecList,
@@ -65,7 +66,7 @@ class InventoryCollection(BaseCollection):
         *,
         parent_id: InventoryId,
         child_id: InventoryId | list[InventoryId],
-        modules: list[str] | None = None,
+        modules: list[InventoryMergeModule] | None = None,
     ) -> None:
         """
         Merge one or multiple child inventory into a parent inventory item.
@@ -76,8 +77,8 @@ class InventoryCollection(BaseCollection):
             The ID of the parent inventory item.
         child_id : InventoryId | list[InventoryId]
             The ID(s) of the child inventory item(s).
-        modules : list[str], optional
-            The merge modules to use (default is all).
+        modules : list[InventoryMergeModule], optional
+            The merge modules to include. Defaults to all modules.
 
         Returns
         -------

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -33,6 +33,7 @@ class InventoryMergeModule(str, Enum):
     SDS : str
         Safety Data Sheets.
     PD : str
+        Product Design — worksheet column references for this inventory item.
     BD : str
         Batch data.
     LOT : str

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -19,19 +19,49 @@ from albert.resources.locations import Location
 from albert.resources.tagged_base import BaseTaggedResource
 from albert.resources.tags import Tag
 
-ALL_MERGE_MODULES = [
-    "PRICING",
-    "NOTES",
-    "SDS",
-    "PD",
-    "BD",
-    "LOT",
-    "CAS",
-    "TAS",
-    "WFL",
-    "PRG",
-    "PTD",
-]
+
+class InventoryMergeModule(str, Enum):
+    """
+    Modules available for an inventory merge operation.
+
+    Attributes
+    ----------
+    PRICING : str
+        Pricing data.
+    NOTES : str
+        Notes.
+    SDS : str
+        Safety Data Sheets.
+    PD : str
+    BD : str
+    LOT : str
+        Lot data.
+    CAS : str
+        CAS numbers.
+    TAS : str
+        Tasks.
+    WFL : str
+        Workflows.
+    PRG : str
+        Parameter groups.
+    PTD : str
+        Property data.
+    """
+
+    PRICING = "PRICING"
+    NOTES = "NOTES"
+    SDS = "SDS"
+    PD = "PD"
+    BD = "BD"
+    LOT = "LOT"
+    CAS = "CAS"
+    TAS = "TAS"
+    WFL = "WFL"
+    PRG = "PRG"
+    PTD = "PTD"
+
+
+ALL_MERGE_MODULES: list[InventoryMergeModule] = list(InventoryMergeModule)
 """All modules selectable for inventory merge."""
 
 
@@ -336,4 +366,4 @@ class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
 class MergeInventory(BaseAlbertModel):
     parent_id: InventoryId = Field(alias="parentId")
     child_inventories: list[dict[str, InventoryId]] = Field(alias="ChildInventories")
-    modules: list[str] | None = Field(default=None)
+    modules: list[InventoryMergeModule] | None = Field(default=None)

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -34,6 +34,7 @@ class InventoryMergeModule(str, Enum):
         Safety Data Sheets.
     PD : str
     BD : str
+        Batch data.
     LOT : str
         Lot data.
     CAS : str


### PR DESCRIPTION
## Summary
- Adds `InventoryMergeModule` enum with all 11 valid module values (`PRICING`, `NOTES`, `SDS`, `PD`, `BD`, `LOT`, `CAS`, `TAS`, `WFL`, `PRG`, `PTD`)
- Replaces `list[str]` with `list[InventoryMergeModule]` on `MergeInventory.modules` and `InventoryCollection.merge()` — backwards-compatible at runtime via Pydantic coercion
- Closes #541