### PR TITLE
feat(parameter_groups): support User-type special parameter values

### DIFF
--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -86,8 +86,8 @@ class ParameterValue(BaseAlbertModel):
         The category of the parameter.
     short_name : str or None
         The short name of the parameter value.
-    value : str or InventoryItem or None
-        The value of the parameter. Can be a plain string or an InventoryItem (e.g. when the parameter represents an instrument choice).
+    value : str or InventoryItem or User or None
+        The value of the parameter. Can be a plain string, an InventoryItem (e.g. when the parameter represents an instrument choice), or a User (e.g. when the parameter represents a user reference such as "Performed By").
     unit : Unit or None
         The unit of measure for the provided parameter value.
     required : bool or None
@@ -104,7 +104,9 @@ class ParameterValue(BaseAlbertModel):
     id: str | None = Field(default=None)
     category: ParameterCategory | None = Field(default=None)
     short_name: str | None = Field(alias="shortName", default=None)
-    value: str | SerializeAsEntityLink[InventoryItem] | None = Field(default=None)
+    value: str | SerializeAsEntityLink[InventoryItem] | SerializeAsEntityLink[User] | None = Field(
+        default=None
+    )
     unit: SerializeAsEntityLink[Unit] | None = Field(alias="Unit", default=None)
     added: AuditFields | None = Field(alias="Added", default=None, exclude=True)
     required: bool | None = Field(default=None)


### PR DESCRIPTION
## Summary
- Adds `User` to the `ParameterValue.value` union type (`str | InventoryItem | User | None`) to support the upcoming User-type special parameter feature
- When a parameter group contains a User-type special parameter (value ID prefixed `USR...`), the SDK now deserialises it as a `User` entity link rather than falling back to a bare `EntityLink`
- No breaking changes — existing INV and TMP special parameters are unaffected
- Matches the API contract documented in the backend solution spec (no new fields; same `{id, name}` wire shape)