### PR TITLE
docs(resources): add and fix Numpy-style docstrings across all resource models

### DIFF
--- a/src/albert/resources/activities.py
+++ b/src/albert/resources/activities.py
@@ -6,16 +6,22 @@ from albert.core.shared.models.base import BaseResource
 
 
 class ActivityOperationId(str, Enum):
+    """Operation identifiers for activity log entries."""
+
     POST_SDS = "post.sds"
     POST_LABEL = "post.label"
 
 
 class ActivityAction(str, Enum):
+    """Action type recorded in an activity log entry."""
+
     READ = "read"
     WRITE = "write"
 
 
 class ActivityType(str, Enum):
+    """Filter type used when querying activity logs."""
+
     ENTITY_ID = "entityId"
     USER_ID = "userId"
     PARENT_ID = "parentId"
@@ -25,6 +31,38 @@ class ActivityType(str, Enum):
 
 
 class Activity(BaseResource):
+    """An activity log entry recorded by the Albert platform.
+
+    Attributes
+    ----------
+    id : str | None
+        The Albert ID of the activity entry.
+    activity_id : str | None
+        The unique activity identifier.
+    action : str | None
+        The action taken (e.g. ``"read"`` or ``"write"``).
+    operation_id : str | None
+        The operation identifier associated with the activity.
+    data : dict | None
+        Payload data associated with the activity.
+    env : str | None
+        The environment in which the activity occurred.
+    name : str | None
+        The name of the entity involved in the activity.
+    module : str | None
+        The module that generated the activity.
+    sub_module : str | None
+        The sub-module that generated the activity.
+    uri : str | None
+        The URI of the resource involved in the activity.
+    uuid : str | None
+        A UUID for the activity record.
+    expires_at : float | None
+        Unix timestamp when this activity record expires.
+    region : str | None
+        The region where the activity occurred.
+    """
+
     id: str | None = Field(default=None, alias="albertId")
     activity_id: str | None = Field(default=None, alias="activityId")
     action: str | None = Field(default=None)

--- a/src/albert/resources/attachments.py
+++ b/src/albert/resources/attachments.py
@@ -17,6 +17,36 @@ class AttachmentCategory(str, Enum):
 
 
 class AttachmentMetadata(BaseAlbertModel):
+    """Supplemental metadata stored with an attachment.
+
+    Attributes
+    ----------
+    symbols : list[HazardSymbol] | None
+        Hazard pictogram symbols associated with the attachment.
+    un_number : str | None
+        UN number for hazardous-material documents.
+    storage_class : str | None
+        Storage class identifier.
+    storage_class_name : str | None
+        Human-readable name of the storage class. Read-only.
+    hazard_statement : list[HazardStatement] | None
+        Hazard statements associated with the attachment.
+    jurisdiction : str | None
+        Jurisdiction for the document. Read-only.
+    language : str | None
+        Language of the document. Read-only.
+    jurisdiction_code : str | None
+        Machine-readable jurisdiction code.
+    language_code : str | None
+        Machine-readable language code.
+    wgk : str | None
+        German Water Hazard Class (WGK) value.
+    description : str | None
+        Description of the attachment content.
+    extensions : list[EntityLinkWithName] | None
+        Additional entity links associated with this attachment.
+    """
+
     symbols: list[HazardSymbol] | None = Field(default=None, alias="Symbols")
     un_number: str | None = Field(default=None, alias="unNumber")
     storage_class: str | None = Field(default=None, alias="storageClass")
@@ -32,8 +62,36 @@ class AttachmentMetadata(BaseAlbertModel):
 
 
 class Attachment(BaseResource):
-    """Used for attching files to Notes on Tasks, Projects, Inventory, etc.
-    Key should match File.name"""
+    """A file attached to an entity such as a Note, Task, Project, or Inventory item.
+
+    Attributes
+    ----------
+    id : AttachmentId | None
+        The Albert ID of the attachment.
+    parent_id : str
+        The Albert ID of the entity this attachment belongs to.
+    name : str
+        The display name of the attachment.
+    key : str
+        The storage key of the attached file. Must match the ``name`` of the corresponding
+        uploaded File.
+    namespace : str
+        The file namespace. Defaults to ``"result"``.
+    category : AttachmentCategory | None
+        The category of the attachment (e.g. ``SDS``, ``Label``, ``Script``, ``Other``).
+    revision_date : date | None
+        The revision date of the attached document.
+    file_size : int | None
+        The size of the file in bytes. Read-only.
+    mime_type : str | None
+        The MIME type of the file. Read-only.
+    signed_url : str | None
+        A pre-signed download URL for the file. Read-only.
+    signed_url_v2 : str | None
+        An alternate pre-signed download URL. Read-only.
+    metadata : AttachmentMetadata | None
+        Additional metadata (e.g. hazard symbols for SDS attachments).
+    """
 
     id: AttachmentId | None = Field(default=None, alias="albertId")
     parent_id: str = Field(..., alias="parentId")

--- a/src/albert/resources/batch_data.py
+++ b/src/albert/resources/batch_data.py
@@ -11,6 +11,22 @@ from albert.core.shared.models.base import BaseResource
 
 
 class BatchValuePatchDatum(BaseAlbertModel):
+    """A single change descriptor in a batch value patch operation.
+
+    Attributes
+    ----------
+    attribute : str
+        The attribute being patched. Defaults to ``"lotId"``.
+    lot_id : str | None
+        The lot ID associated with this change.
+    new_value : str | None
+        The new value to set.
+    old_value : str | None
+        The previous value being replaced.
+    operation : str
+        The patch operation type (e.g. ``"update"``, ``"add"``, ``"delete"``).
+    """
+
     attribute: str = Field(default="lotId")
     lot_id: str | None = Field(default=None, alias="lotId")
     new_value: str | None = Field(default=None, alias="newValue")
@@ -19,21 +35,67 @@ class BatchValuePatchDatum(BaseAlbertModel):
 
 
 class BatchValueId(BaseAlbertModel):
+    """Identifies a cell in a batch data grid by column and row.
+
+    Attributes
+    ----------
+    col_id : str | None
+        The column identifier.
+    row_id : str
+        The row identifier.
+    """
+
     col_id: str | None = Field(default=None, alias="colId")
     row_id: str = Field(alias="rowId")
 
 
 class BatchValuePatchPayload(BaseAlbertModel):
+    """Payload for patching a single batch data cell.
+
+    Attributes
+    ----------
+    id : BatchValueId
+        The cell coordinates (column and row).
+    data : list[BatchValuePatchDatum]
+        The list of change descriptors to apply.
+    lot_id : str | None
+        The lot ID to associate with this patch.
+    """
+
     id: BatchValueId = Field(alias="Id")
     data: list[BatchValuePatchDatum] = Field(default_factory=list)
     lot_id: str | None = Field(default=None, alias="lotId")
 
 
 class BatchDataType(str, Enum):
+    """Type identifier used in batch data queries."""
+
     TASK_ID = "taskId"
 
 
 class BatchDataValue(BaseAlbertModel):
+    """A single cell value within a batch data row.
+
+    Attributes
+    ----------
+    id : str | None
+        The identifier of the value entry.
+    col_id : str | None
+        The column identifier.
+    type : str | None
+        The data type of the value.
+    name : str | None
+        The display name of the column.
+    value : str | None
+        The cell value.
+    is_editable : bool | None
+        Whether the cell is editable.
+    unit_category : str | None
+        The unit category for the value.
+    reference_value : str | None
+        The reference value for comparison purposes.
+    """
+
     id: str | None = Field(default=None)
     col_id: str | None = Field(default=None, alias="colId")
     type: str | None = Field(default=None)
@@ -45,6 +107,34 @@ class BatchDataValue(BaseAlbertModel):
 
 
 class BatchDataRow(BaseAlbertModel):
+    """A row of data in a batch task result.
+
+    Attributes
+    ----------
+    id : str | None
+        The identifier of the row entity.
+    row_id : str | None
+        The row identifier within the batch grid.
+    type : str | None
+        The row type (e.g. inventory category).
+    name : str | None
+        The display name of the row.
+    manufacturer : str | None
+        The manufacturer name, for inventory rows.
+    unit_category : str | None
+        The unit category used by this row.
+    category : str | None
+        The inventory category of the row.
+    is_formula : bool | None
+        Whether the row represents a formula inventory item.
+    is_lot_parent : bool | None
+        Whether this row is the parent of lot sub-rows.
+    values : list[BatchDataValue]
+        The cell values for this row.
+    child_rows : list[BatchDataRow]
+        Nested child rows (e.g. lot rows under a parent inventory row).
+    """
+
     id: str | None = Field(default=None)
     row_id: str | None = Field(default=None, alias="rowId")
     type: str | None = Field(default=None)
@@ -60,6 +150,32 @@ class BatchDataRow(BaseAlbertModel):
 
 class BatchDataColumn(BaseAlbertModel):
     # TODO: Once SignatureOverrideMeta removed, use BaseAlbertModel instead of BaseModel
+    """A column in the batch data product grid, optionally containing lot sub-columns.
+
+    Attributes
+    ----------
+    id : str | None
+        The identifier of the inventory item for this column.
+    name : str | None
+        The display name of the column.
+    col_id : str | None
+        The column identifier within the batch grid.
+    batch_total : str | None
+        The total batch amount for this column.
+    reference_total : str | None
+        The reference total for this column.
+    status : Status | None
+        The status of the column.
+    product_total : float | None
+        The computed product total for this column.
+    parent_id : str | None
+        The parent column identifier, for lot sub-columns.
+    design_col_id : str | None
+        The design column identifier linking back to the worksheet.
+    lots : list[BatchDataColumn]
+        Lot-level sub-columns nested under this column.
+    """
+
     id: str | None = Field(default=None)
     name: str | None = Field(default=None)
     col_id: str | None = Field(default=None, alias="colId")
@@ -73,6 +189,22 @@ class BatchDataColumn(BaseAlbertModel):
 
 
 class BatchData(BaseResource):
+    """The full batch data payload for a task, containing product columns and ingredient rows.
+
+    Attributes
+    ----------
+    id : TaskId | None
+        The Albert ID of the task this batch data belongs to.
+    size : int | None
+        The total number of items in this page of results.
+    last_key : str | None
+        Pagination cursor for fetching the next page.
+    product : list[BatchDataColumn] | None
+        The formulation columns (products) in the batch grid.
+    rows : list[BatchDataRow] | None
+        The ingredient rows in the batch grid.
+    """
+
     id: TaskId | None = Field(default=None, alias="albertId")
     size: int | None = Field(default=None)
     last_key: str | None = Field(default=None, alias="lastKey")

--- a/src/albert/resources/btdataset.py
+++ b/src/albert/resources/btdataset.py
@@ -8,6 +8,20 @@ from albert.core.shared.models.base import BaseResource, EntityLink
 
 
 class BTDatasetReferences(BaseAlbertModel):
+    """Scope references used to build a Breakthrough dataset.
+
+    Attributes
+    ----------
+    project_ids : list[str]
+        The project IDs included in the dataset.
+    data_column_ids : list[str]
+        The data column IDs included in the dataset.
+    sheet_ids : list[str] | None
+        The sheet IDs to restrict the dataset to. If None, all sheets are included.
+    filter : dict[str, Any] | None
+        Additional filter criteria applied when building the dataset.
+    """
+
     project_ids: list[str]
     data_column_ids: list[str]
     sheet_ids: list[str] | None = Field(default=None)
@@ -15,6 +29,26 @@ class BTDatasetReferences(BaseAlbertModel):
 
 
 class BTDataset(BaseResource):
+    """A Breakthrough dataset built from project and column references.
+
+    Attributes
+    ----------
+    name : str
+        The name of the dataset.
+    id : BTDatasetId | None
+        The Albert ID of the dataset.
+    parent_id : ProjectId | None
+        The ID of the project this dataset belongs to.
+    key : str | None
+        The storage key for the dataset file.
+    file_name : str | None
+        The file name of the dataset.
+    report : EntityLink | None
+        A link to the report generated from this dataset.
+    references : BTDatasetReferences | None
+        The scope references used to build this dataset.
+    """
+
     name: str
     id: BTDatasetId | None = Field(default=None, alias="albertId")
     parent_id: ProjectId | None = Field(default=None, alias="parentId")

--- a/src/albert/resources/btinsight.py
+++ b/src/albert/resources/btinsight.py
@@ -49,6 +49,46 @@ class BTInsightRegistry(BaseAlbertModel):
 
 
 class BTInsight(BaseResource, protected_namespaces=()):
+    """A Breakthrough insight result generated from a model or optimization run.
+
+    Attributes
+    ----------
+    name : str
+        The name of the insight.
+    category : BTInsightCategory
+        The category of the insight (e.g. Optimizer, Impact Chart, Smart DOE).
+    metadata : dict[str, Any] | None
+        Metadata associated with the insight run.
+    state : BTInsightState | None
+        The current state of the insight (e.g. Queued, Building Models, Complete, Error).
+    id : BTInsightId | None
+        The Albert ID of the insight.
+    parent_id : ProjectId | None
+        The ID of the project this insight belongs to.
+    dataset_id : BTDatasetId | None
+        The ID of the dataset used to generate this insight.
+    model_session_id : BTModelSessionId | None
+        The ID of the model session associated with this insight.
+    model_id : BTModelId | None
+        The ID of the model used to generate this insight.
+    output_key : str | None
+        The storage key for the insight output file.
+    start_time : str | None
+        The time the insight run started.
+    end_time : str | None
+        The time the insight run finished.
+    total_time : str | None
+        The total elapsed time for the insight run.
+    raw_payload : dict[str, Any] | None
+        The raw result payload from the insight run.
+    payload_type : BTInsightPayloadType | None
+        The type of payload (Breakthrough or Alberto).
+    registry : BTInsightRegistry | None
+        Build logs, metrics, and settings for the insight.
+    content_edited : bool | None
+        Whether the insight content has been manually edited.
+    """
+
     name: str
     category: BTInsightCategory
     metadata: dict[str, Any] | None = Field(default=None, alias="Metadata")

--- a/src/albert/resources/btmodel.py
+++ b/src/albert/resources/btmodel.py
@@ -30,23 +30,23 @@ class BTModelSession(BaseResource, protected_namespaces=()):
     name : str
         The name of the model session.
     category : BTModelSessionCategory
-        The category of the model session (e.g., userModel, albertModel).
+        The category of the model session (e.g. userModel, albertModel).
     id : BTModelSessionId | None
         The unique identifier for the model session.
     dataset_id : BTDatasetId
         The identifier for the dataset associated with the model session.
     default_model : str | None
-        The default model name for the session, if applicable.
+        The default model name for the session.
     total_time : str | None
-        The total time taken for the session, if applicable.
+        The total elapsed time for the session.
     model_count : int | None
-        The number of models in the session, if applicable.
+        The number of models in the session.
     target : list[str] | None
-        The target variables for the models in the session, if applicable.
+        The target variable names for the models in this session.
     registry : BTModelRegistry | None
-        The registry containing build logs and metrics for the session, if applicable.
+        Build logs and metrics for the session.
     albert_model_details : dict[str, Any] | None
-        Details specific to the Albert model, if applicable.
+        Details specific to the Albert-generated model.
     """
 
     name: str
@@ -82,7 +82,7 @@ class BTModelState(str, Enum):
 class BTModel(BaseResource, protected_namespaces=()):
     """A single Breakthrough model.
 
-    A BTModel may have a `parent_id` or be a detached, standalone model.
+    A BTModel may belong to a parent session or be a detached standalone model.
 
     Attributes
     ----------
@@ -91,25 +91,25 @@ class BTModel(BaseResource, protected_namespaces=()):
     id : BTModelId | None
         The unique identifier for the model.
     dataset_id : BTDatasetId | None
-        The identifier for the dataset associated with the model.
+        The identifier for the dataset used to train this model.
     parent_id : BTModelSessionId | None
-        The identifier for the parent model session, if applicable.
+        The identifier for the parent model session, if this model belongs to a session.
     metadata : dict[str, Any] | None
-        Metadata associated with the model, if applicable.
+        Metadata associated with the model.
     type : BTModelType | None
-        The type of the model (e.g., Session, Detached).
+        The type of the model (Session or Detached).
     state : BTModelState | None
-        The current state of the model (e.g., Queued, Building Models, Complete).
+        The current state of the model (e.g. Queued, Building Models, Complete, Error).
     target : list[str] | None
-        The target variables for the model, if applicable.
+        The target variable names for this model.
     start_time : str | None
-        The start time of the model creation, if applicable.
+        The time the model build started.
     end_time : str | None
-        The end time of the model creation, if applicable.
+        The time the model build finished.
     total_time : str | None
-        The total time taken for the model creation, if applicable.
+        The total elapsed time for the model build.
     model_binary_key : str | None
-        The storage key for the model data, if applicable.
+        The storage key for the serialised model binary.
     """
 
     name: str

--- a/src/albert/resources/cas.py
+++ b/src/albert/resources/cas.py
@@ -31,7 +31,43 @@ class Hazard(BaseAlbertModel):
 
 
 class Cas(BaseResource):
-    """Represents a CAS entity."""
+    """A CAS (Chemical Abstracts Service) registry entry.
+
+    Attributes
+    ----------
+    number : str
+        The CAS registry number (e.g. ``"7732-18-5"``).
+    name : str | None
+        The primary name of the chemical.
+    description : str | None
+        An additional description or alternate name.
+    notes : str | None
+        Free-text notes about the CAS entry.
+    category : CasCategory | None
+        The category of the CAS entry (e.g. User, Verisk, TSCA - Public).
+    smiles : str | None
+        SMILES notation for the chemical structure.
+    inchi_key : str | None
+        InChIKey for the chemical structure.
+    iupac_name : str | None
+        IUPAC name of the chemical.
+    id : str | None
+        The Albert ID of the CAS entry.
+    hazards : list[Hazard] | None
+        Hazard classifications associated with the chemical.
+    wgk : str | None
+        German Water Hazard Class (WGK) number.
+    ec_number : str | None
+        European Community (EC) inventory number.
+    type : str | None
+        Internal classification type reference.
+    classification_type : str | None
+        Classification type of the CAS entry.
+    order : str | None
+        Sort order of the CAS entry.
+    metadata : dict[str, MetadataItem]
+        Custom metadata attached to the CAS entry.
+    """
 
     number: str = Field(..., description="The CAS number.")
     name: str | None = Field(None, description="Name of the CAS.")

--- a/src/albert/resources/custom_fields.py
+++ b/src/albert/resources/custom_fields.py
@@ -74,16 +74,46 @@ class CustomFieldAPI(BaseAlbertModel):
 
 
 class ListDefaultValue(BaseAlbertModel):
+    """An item from a list-type custom field used as a default value.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the list item.
+    name : str
+        The display name of the list item.
+    """
+
     id: str = Field(alias="albertId")
     name: str
 
 
 class StringDefault(BaseAlbertModel):
+    """A default value for a string-type custom field.
+
+    Attributes
+    ----------
+    type : FieldType
+        Always ``FieldType.STRING``.
+    value : str
+        The default string value.
+    """
+
     type: Literal[FieldType.STRING] = FieldType.STRING
     value: str
 
 
 class NumberDefault(BaseAlbertModel):
+    """A default value for a number-type custom field.
+
+    Attributes
+    ----------
+    type : FieldType
+        Always ``FieldType.NUMBER``.
+    value : int | float
+        The default numeric value.
+    """
+
     type: Literal[FieldType.NUMBER] = FieldType.NUMBER
     value: int | float
 
@@ -105,51 +135,52 @@ Default = Annotated[
 
 
 class CustomField(BaseResource):
-    """A custom field for an entity in Albert.
+    """A custom field that can be attached as metadata to an entity in Albert.
 
-    Returns
-    -------
-    CustomField
-        A CustomField that can be used to attach Metadata to an entity in Albert.
     Attributes
-    ------
+    ----------
     name : str
-        The name of the custom field. Cannot contain spaces.
+        The internal name of the custom field. Cannot contain spaces.
     id : str | None
         The Albert ID of the custom field.
     field_type : FieldType
-        The type of the custom field. Allowed values are `list`, `string`, and `number`.
-        `string` and `list` fields are searchable; `number` fields are not searchable.
+        The data type of the field. Allowed values are ``list``, ``string``, and ``number``.
+        ``string`` and ``list`` fields are searchable; ``number`` fields are not.
     display_name : str
-        The display name of the custom field. Can contain spaces.
+        The human-readable label for the field. Can contain spaces (max 40 chars).
     searchable : bool | None
-        Whether the custom field is searchable, optional. Defaults to False. This is supported
-        for `list` and `string` fields; `number` fields can not be searchable.
+        Whether the field is searchable. Supported for ``list`` and ``string`` fields only.
     service : ServiceType
-        The service type the custom field is associated with.
+        The entity type this field is associated with (e.g. inventories, lots, tasks).
     hidden : bool | None
-        Whether the custom field is hidden, optional. Defaults to False.
+        Whether the field is hidden in the UI.
     lookup_column : bool | None
-        Whether the custom field is a lookup column, optional. Defaults to False. Only allowed for inventories.
+        Whether the field is a lookup column. Only allowed for inventories.
     lookup_row : bool | None
-        Whether the custom field is a lookup row, optional. Defaults to False. Only allowed for formulas in inventories.
+        Whether the field is a lookup row. Only allowed for formula inventories.
     category : FieldCategory | None
-        The category of the custom field, optional. Defaults to None. Required for list fields. Allowed values are `businessDefined` and `userDefined`.
+        The ACL category of the field. Required for ``list`` fields.
     min : int | float | None
-        The minimum value of the custom field, optional. Defaults to None.
+        The minimum allowed value for number fields.
     max : int | float | None
-        The maximum value of the custom field, optional. Defaults to None.
+        The maximum allowed value for number fields.
     entity_categories : list[EntityCategory] | None
-        The entity categories of the custom field, optional. Defaults to None. Required for lookup row fields. Allowed values are `Formulas`, `RawMaterials`, `Consumables`, `Equipment`, `Property`, `Batch`, and `General`.
+        The entity categories where this field applies. Required for lookup row fields.
     custom_entity_categories : list[str] | None
-        Custom entity categories that define where the field is valid.
+        Custom entity category names where the field is valid.
     ui_components : list[UIComponent] | None
-        The UI components available to the custom field, optional. Defaults to None. Allowed values are `create` and `details`.
-    default: Default | None
-        The default value of the custom field, optional. Defaults to None.
-    editable: bool | None
-        Decides whether the field should be editable on UI or not.
-    api: CustomFieldAPI | None
+        The UI contexts where this field appears (e.g. ``create``, ``details``).
+    required : bool | None
+        Whether the field is required when creating an entity.
+    multiselect : bool | None
+        Whether multiple values can be selected for list fields.
+    editable : bool | None
+        Whether the field is editable in the UI.
+    pattern : str | None
+        A validation regex pattern for string fields.
+    default : Default | None
+        The default value for the field.
+    api : CustomFieldAPI | None
         API configuration for fields backed by remote data sources.
     """
 

--- a/src/albert/resources/custom_templates.py
+++ b/src/albert/resources/custom_templates.py
@@ -20,11 +20,37 @@ from albert.resources.users import User, UserClass
 
 
 class CustomTemplateInventoryLot(BaseAlbertModel):
+    """A lot reference within a custom template inventory entry.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the lot.
+    barcode : str | None
+        The barcode of the lot.
+    """
+
     id: str
     barcode: str | None = None
 
 
 class DataTemplateInventory(EntityLink):
+    """An inventory item reference within a custom template, with batch and lot details.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the inventory item.
+    batch_size : float | None
+        The batch size to use for this inventory item.
+    sheet : list[Sheet | EntityLink] | None
+        Sheets associated with this inventory item in the template.
+    category : InventoryCategory | None
+        The inventory category of the item.
+    lots : list[CustomTemplateInventoryLot] | None
+        Lots associated with this inventory item in the template.
+    """
+
     batch_size: float | None = Field(default=None, alias="batchSize")
     sheet: list[Sheet | EntityLink] | None = Field(default=None)
     category: InventoryCategory | None = Field(default=None)
@@ -32,10 +58,30 @@ class DataTemplateInventory(EntityLink):
 
 
 class DesignLink(EntityLink):
+    """A link to a worksheet design with its type.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the design.
+    type : DesignType
+        The design type (apps, products, results, or process).
+    """
+
     type: DesignType
 
 
 class TemplateEntityType(BaseAlbertModel):
+    """The entity type associated with a custom template.
+
+    Attributes
+    ----------
+    id : EntityTypeId | None
+        The Albert ID of the entity type.
+    custom_category : str | None
+        A custom category name for the entity type.
+    """
+
     id: EntityTypeId | None = Field(default=None)
     custom_category: str | None = Field(default=None, alias="customCategory")
 
@@ -77,12 +123,40 @@ class JobStatus(str, Enum):
 
 
 class SamInput(BaseResource):
+    """An input parameter for a SAM (Sample Analysis Module) configuration.
+
+    Attributes
+    ----------
+    value : str | None
+        The value of the input parameter.
+    unit : str | None
+        The unit of the input parameter.
+    name : str
+        The name of the input parameter.
+    """
+
     value: str | None = Field(alias="Value", default=None)
     unit: str | None = Field(alias="Unit", default=None)
     name: str = Field(alias="Name")
 
 
 class SamConfig(BaseResource):
+    """A SAM (Sample Analysis Module) machine configuration.
+
+    Attributes
+    ----------
+    configuration_name : str
+        The name of the configuration.
+    configurationId : str
+        The identifier of the configuration.
+    machineId : str | None
+        The identifier of the machine.
+    input : list[SamInput] | None
+        The input parameters for this configuration.
+    job_status : JobStatus | None
+        The status of the SAM job.
+    """
+
     configuration_name: str = Field(alias="configurationName")
     configurationId: str
     machineId: str | None = Field(default=None)
@@ -91,6 +165,18 @@ class SamConfig(BaseResource):
 
 
 class Workflow(BaseResource):
+    """A workflow reference within a custom template.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the workflow.
+    name : str | None
+        The name of the workflow.
+    sam_config : list[SamConfig] | None
+        SAM configurations associated with this workflow, if any.
+    """
+
     id: str
     name: str | None = Field(default=None)
     # Some workflows may have SamConfig
@@ -189,6 +275,16 @@ ACLEntry = Annotated[TeamACL | OwnerACL | MemberACL | ViewerACL, Field(discrimin
 
 
 class TemplateACL(BaseResource):
+    """Access control settings for a custom template.
+
+    Attributes
+    ----------
+    fgclist : list[ACLEntry]
+        The list of access control entries (team, owner, member, viewer).
+    acl_class : str | None
+        The default access class for the template.
+    """
+
     fgclist: list[ACLEntry] = Field(default=None)
     acl_class: str | None = Field(default=None, alias="class")
 

--- a/src/albert/resources/data_columns.py
+++ b/src/albert/resources/data_columns.py
@@ -5,6 +5,20 @@ from albert.core.shared.types import MetadataItem
 
 
 class DataColumn(BaseResource):
+    """A data column definition used in data templates.
+
+    Attributes
+    ----------
+    name : str
+        The name of the data column.
+    defalt : bool
+        Whether this column is the default column. Defaults to ``False``.
+    metadata : dict[str, MetadataItem] | None
+        Custom metadata attached to the data column.
+    id : str
+        The Albert ID of the data column.
+    """
+
     name: str
     defalt: bool = False
     metadata: dict[str, MetadataItem] | None = Field(alias="Metadata", default=None)

--- a/src/albert/resources/data_templates.py
+++ b/src/albert/resources/data_templates.py
@@ -27,6 +27,16 @@ from albert.resources.users import User
 
 
 class CSVMapping(BaseAlbertModel):
+    """A mapping between CSV column headers and data column IDs.
+
+    Attributes
+    ----------
+    map_id : str | None
+        A compact mapping string (e.g. ``"Header1:DAC2900#Header2:DAC4707"``).
+    map_data : dict[str, str] | None
+        A dictionary mapping CSV header names to data column IDs.
+    """
+
     map_id: str | None = Field(
         alias="mapId", default=None, examples="Header1:DAC2900#Header2:DAC4707"
     )
@@ -41,11 +51,39 @@ class Axis(str, Enum):
 
 
 class CurveDBMetadata(BaseAlbertModel):
+    """Database metadata for a curve data column result.
+
+    Attributes
+    ----------
+    table_name : str | None
+        The Athena/database table name storing the curve data.
+    partition_key : str | None
+        The partition key for the curve data table.
+    """
+
     table_name: str | None = Field(default=None, alias="tableName")
     partition_key: str | None = Field(default=None, alias="partitionKey")
 
 
 class StorageKeyReference(BaseAlbertModel):
+    """S3 storage key references for a data column file result.
+
+    Attributes
+    ----------
+    rawfile : str | None
+        The raw file storage key.
+    s3_input : str | None
+        The S3 key for the input file.
+    s3_output : str | None
+        The S3 key for the processed output file.
+    preview : str | None
+        The S3 key for a preview image.
+    thumb : str | None
+        The S3 key for a thumbnail image.
+    original : str | None
+        The S3 key for the original file.
+    """
+
     rawfile: str | None = None
     s3_input: str | None = Field(default=None, alias="s3Input")
     s3_output: str | None = Field(default=None, alias="s3Output")
@@ -55,17 +93,79 @@ class StorageKeyReference(BaseAlbertModel):
 
 
 class JobSummary(BaseAlbertModel):
+    """A brief summary of a background processing job.
+
+    Attributes
+    ----------
+    id : str | None
+        The job identifier.
+    state : str | None
+        The current state of the job.
+    """
+
     id: str | None = None
     state: str | None = None
 
 
 class CurveDataEntityLink(EntityLinkWithName):
+    """A link to a data column that provides one axis of a curve dataset.
+
+    Attributes
+    ----------
+    id : DataColumnId
+        The data column ID.
+    axis : Axis | None
+        Which axis this column represents (X or Y).
+    unit : Unit | None
+        The unit of measure for this axis.
+    """
+
     id: DataColumnId
     axis: Axis | None = Field(default=None)
     unit: SerializeAsEntityLink[Unit] | None = Field(default=None, alias="Unit")
 
 
 class DataColumnValue(BaseResource):
+    """A single data column entry within a data template, holding its configuration and value.
+
+    Attributes
+    ----------
+    data_column : DataColumn | None
+        The full DataColumn object. Provide either this or ``data_column_id``.
+    data_column_id : DataColumnId | None
+        The Albert ID of the data column. Provide either this or ``data_column``.
+    name : str | None
+        The display name of the column in this template context.
+    original_name : str | None
+        The original name of the column before any rename. Read-only.
+    value : str | None
+        The default or stored value for this column.
+    hidden : bool
+        Whether the column is hidden. Defaults to ``False``.
+    unit : Unit | None
+        The unit of measure for this column's values.
+    calculation : str | None
+        A formula or calculation expression for computed columns.
+    sequence : str | None
+        The display order of this column within the template.
+    script : bool | None
+        Whether this column uses a script for data import.
+    db_metadata : CurveDBMetadata | None
+        Database/Athena metadata for curve-type columns.
+    storage_key_reference : StorageKeyReference | None
+        S3 storage key references for file-backed column results.
+    job : JobSummary | None
+        Summary of the last background processing job for this column.
+    csv_mapping : dict[str, str] | CSVMapping | None
+        CSV header-to-column mapping for CSV import columns.
+    validation : list[ValueValidation] | None
+        Validation rules applied to values in this column.
+    curve_data : list[CurveDataEntityLink] | None
+        Axis column links for curve-type data columns.
+    created : AuditFields | None
+        Audit fields recording when this column value was created.
+    """
+
     data_column: DataColumn | None = Field(exclude=True, default=None)
     data_column_id: DataColumnId | None = Field(alias="id", default=None)
     name: str | None = None
@@ -111,6 +211,38 @@ class DataColumnValue(BaseResource):
 
 
 class DataTemplate(BaseTaggedResource):
+    """A data template defining data columns and parameters for measurement tasks.
+
+    Attributes
+    ----------
+    name : str
+        The name of the data template.
+    id : DataTemplateId | None
+        The Albert ID of the data template.
+    description : str | None
+        A description of the data template.
+    security_class : SecurityClass | None
+        The security classification of the data template.
+    verified : bool
+        Whether the data template has been verified. Defaults to ``False``.
+    users_with_access : list[User] | None
+        Users who have explicit access to this data template.
+    data_column_values : list[DataColumnValue] | None
+        The data column definitions included in this template.
+    parameter_values : list[ParameterValue] | None
+        The parameter definitions included in this template.
+    deleted_parameters : list[ParameterValue] | None
+        Parameters that have been removed from this template. Read-only.
+    metadata : dict[str, MetadataItem] | None
+        Custom metadata attached to the data template.
+    documents : list[EntityLink]
+        Documents linked to this data template. Read-only.
+    original_name : str | None
+        The original name before any rename. Read-only.
+    full_name : str | None
+        The fully qualified name including any parent context. Read-only.
+    """
+
     name: str
     id: DataTemplateId | None = Field(None, alias="albertId")
     description: str | None = None
@@ -181,12 +313,52 @@ class ImageExample(BaseAlbertModel):
 
 
 class DataTemplateSearchItemDataColumn(BaseAlbertModel):
+    """A lightweight data column reference within a data template search result.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the data column.
+    name : str | None
+        The name of the data column.
+    localized_names : LocalizedNames
+        Localized name variants for the data column.
+    """
+
     id: str
     name: str | None = None
     localized_names: LocalizedNames = Field(alias="localizedNames")
 
 
 class DataTemplateSearchItem(BaseAlbertModel, HydrationMixin[DataTemplate]):
+    """Lightweight representation of a DataTemplate returned from search.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the data template.
+    name : str
+        The name of the data template.
+    data_columns : list[DataTemplateSearchItemDataColumn] | None
+        The data column summaries included in the template.
+    owner : list[User] | None
+        The owners of the data template.
+    tags : list[User] | None
+        Tags associated with the data template.
+    acl : list[User] | None
+        Users with explicit access to the data template.
+    created_at : str | None
+        ISO 8601 timestamp of when the template was created.
+    created_by_name : str | None
+        The name of the user who created the template.
+    metadata : dict[str, Any] | None
+        Custom metadata attached to the template.
+    team : list[User] | None
+        Team members associated with the template.
+    standards : list[dict[str, Any]] | None
+        Standards linked to the template.
+    """
+
     id: str = Field(alias="albertId")
     name: str
     data_columns: list[DataTemplateSearchItemDataColumn] | None = Field(

--- a/src/albert/resources/facet.py
+++ b/src/albert/resources/facet.py
@@ -10,11 +10,35 @@ class FacetType(str, Enum):
 
 
 class FacetValue(BaseAlbertModel):
+    """A single value within a search facet, with its occurrence count.
+
+    Attributes
+    ----------
+    name : str
+        The facet value label.
+    count : int
+        The number of results that have this facet value.
+    """
+
     name: str
     count: int
 
 
 class FacetItem(BaseAlbertModel):
+    """A search facet grouping related filter values.
+
+    Attributes
+    ----------
+    name : str
+        The display name of the facet.
+    parameter : str
+        The query parameter name used to filter by this facet.
+    type : FacetType
+        The data type of the facet values.
+    value : list[FacetValue]
+        The individual values within this facet and their counts.
+    """
+
     name: str
     parameter: str
     type: FacetType

--- a/src/albert/resources/files.py
+++ b/src/albert/resources/files.py
@@ -21,6 +21,24 @@ class FileCategory(str, Enum):
 
 
 class SignURLPOSTFile(BaseAlbertModel):
+    """Descriptor for a single file to be uploaded via a pre-signed URL.
+
+    Attributes
+    ----------
+    name : str
+        The file name to use in storage.
+    namespace : FileNamespace
+        The storage namespace for the file.
+    content_type : str
+        The MIME type of the file.
+    metadata : list[dict[str, str]] | None
+        Additional key-value metadata to attach to the file.
+    category : FileCategory | None
+        The file category (e.g. ``SDS``, ``Other``).
+    url : str | None
+        The pre-signed upload URL returned by the server.
+    """
+
     name: str
     namespace: FileNamespace
     content_type: str = Field(..., alias="contentType")
@@ -30,10 +48,38 @@ class SignURLPOSTFile(BaseAlbertModel):
 
 
 class SignURLPOST(BaseAlbertModel):
+    """Request payload for obtaining pre-signed upload URLs for one or more files.
+
+    Attributes
+    ----------
+    files : list[SignURLPOSTFile]
+        The files to request upload URLs for.
+    """
+
     files: list[SignURLPOSTFile]
 
 
 class FileInfo(BaseAlbertModel):
+    """Metadata about a file stored in Albert.
+
+    Attributes
+    ----------
+    name : str
+        The file name.
+    size : int
+        The file size in bytes.
+    etag : str
+        The ETag of the stored file.
+    namespace : FileNamespace | None
+        The storage namespace the file belongs to.
+    content_type : str
+        The MIME type of the file.
+    last_modified : datetime
+        The timestamp when the file was last modified.
+    metadata : list[dict[str, str]]
+        Key-value metadata attached to the file.
+    """
+
     name: str
     size: int
     etag: str

--- a/src/albert/resources/hazards.py
+++ b/src/albert/resources/hazards.py
@@ -24,12 +24,30 @@ class HazardSymbolStatus(str, Enum):
 
 
 class HazardSymbol(EntityLinkWithName):
-    """Model representing a hazard symbol."""
+    """A GHS hazard pictogram symbol.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the hazard symbol.
+    name : str | None
+        The display name of the hazard symbol.
+    status : HazardSymbolStatus | None
+        Whether the symbol is active, inactive, or manually added.
+    """
 
     status: HazardSymbolStatus | None = Field(default=None)
 
 
 class HazardStatement(EntityLinkWithName):
-    """Model representing a hazard statement."""
+    """A GHS hazard statement (H-statement) linked to a chemical or SDS.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the hazard statement.
+    name : str | None
+        The hazard statement text (e.g. ``"H301: Toxic if swallowed"``).
+    """
 
     pass

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -268,6 +268,20 @@ class InventoryItem(BaseTaggedResource):
 
 
 class InventorySpecValue(BaseAlbertModel):
+    """The target value bounds for an inventory specification.
+
+    Attributes
+    ----------
+    min : str | None
+        The minimum acceptable value.
+    max : str | None
+        The maximum acceptable value.
+    reference : str | None
+        The reference (target) value.
+    comparison_operator : str | None
+        The comparison operator for the specification (e.g. ``"between"``, ``"gt"``).
+    """
+
     min: str | None = Field(default=None)
     max: str | None = Field(default=None)
     reference: str | None = Field(default=None)
@@ -276,12 +290,42 @@ class InventorySpecValue(BaseAlbertModel):
     @field_validator("min", "max", "reference", mode="before")
     @classmethod
     def cast_float_to_str(cls, v: Any) -> Any:
-        if isinstance(v, (int, float)):
+        if isinstance(v, int | float):
             return str(v)
         return v
 
 
 class InventorySpec(BaseAlbertModel):
+    """A quality specification attached to an inventory item.
+
+    Attributes
+    ----------
+    id : str | None
+        The Albert ID of the specification.
+    name : str
+        The display name of the specification.
+    data_column_id : str
+        The Albert ID of the data column this spec measures.
+    data_column_name : str | None
+        The name of the data column.
+    data_template_id : str | None
+        The Albert ID of the data template this spec belongs to.
+    data_template_name : str | None
+        The name of the data template.
+    unit_id : str | None
+        The Albert ID of the unit of measure.
+    unit_name : str | None
+        The name of the unit of measure.
+    workflow_id : str | None
+        The Albert ID of the workflow this spec is tied to.
+    workflow_name : str | None
+        The name of the workflow.
+    spec_config : str | None
+        Additional specification configuration string.
+    value : InventorySpecValue | None
+        The target value bounds for this specification.
+    """
+
     id: str | None = Field(default=None, alias="albertId")
     name: str
     data_column_id: str = Field(..., alias="datacolumnId")
@@ -297,6 +341,16 @@ class InventorySpec(BaseAlbertModel):
 
 
 class InventorySpecList(BaseAlbertModel):
+    """A collection of quality specifications for an inventory item.
+
+    Attributes
+    ----------
+    parent_id : str
+        The Albert ID of the inventory item these specs belong to.
+    specs : list[InventorySpec]
+        The list of specifications.
+    """
+
     parent_id: str = Field(..., alias="parentId")
     specs: list[InventorySpec] = Field(..., alias="Specs")
 
@@ -305,6 +359,18 @@ class InventorySpecList(BaseAlbertModel):
 # and see if this is unique to the search endpoint or a
 # common resource
 class InventorySearchPictogramItem(BaseAlbertModel):
+    """A hazard pictogram entry within an inventory search result.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the pictogram.
+    name : str
+        The display name of the pictogram.
+    status : str | None
+        The status of the pictogram (e.g. active or inactive).
+    """
+
     id: str
     name: str
     status: str | None = Field(default=None)
@@ -315,6 +381,22 @@ class InventorySearchPictogramItem(BaseAlbertModel):
 # if UnNumber doesn't require all fields we can
 # merge these two classes together
 class InventorySearchSDSItem(BaseAlbertModel):
+    """SDS (Safety Data Sheet) summary within an inventory search result.
+
+    Attributes
+    ----------
+    un_number : str | None
+        The UN number for the hazardous material.
+    storage_class_name : str | None
+        The name of the storage class.
+    shipping_description : str | None
+        The shipping description for the material.
+    storage_class_number : str | None
+        The storage class number.
+    un_classification : str | None
+        The UN classification of the material.
+    """
+
     un_number: str | None = Field(default=None, alias="unNumber")
     storage_class_name: str | None = Field(default=None, alias="storageClassName")
     shipping_description: str | None = Field(default=None, alias="shippingDescription")
@@ -323,6 +405,32 @@ class InventorySearchSDSItem(BaseAlbertModel):
 
 
 class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
+    """Lightweight representation of an InventoryItem returned from search.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the inventory item.
+    name : str
+        The name of the inventory item.
+    description : str
+        The description of the inventory item.
+    category : InventoryCategory
+        The inventory category (RawMaterials, Consumables, Equipment, Formulas).
+    unit : InventoryUnitCategory
+        The unit category used by this inventory item.
+    lots : list[dict[str, Any]]
+        Summary information about lots associated with this item.
+    tags : list[Tag]
+        Tags associated with this inventory item.
+    pictogram : list[InventorySearchPictogramItem]
+        Hazard pictograms for this inventory item.
+    inventory_on_hand : float
+        The total quantity currently on hand across all lots.
+    sds : InventorySearchSDSItem | None
+        SDS summary for this inventory item, if available.
+    """
+
     id: str = Field(alias="albertId")
     name: str = Field(default="")
     description: str = Field(default="")
@@ -337,6 +445,19 @@ class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
 
 
 class MergeInventory(BaseAlbertModel):
+    """Payload for merging one or more inventory items into a parent item.
+
+    Attributes
+    ----------
+    parent_id : InventoryId
+        The Albert ID of the target parent inventory item to merge into.
+    child_inventories : list[dict[str, InventoryId]]
+        The inventory items to be merged into the parent.
+    modules : list[str] | None
+        The data modules to copy during the merge (e.g. ``"SDS"``, ``"LOT"``).
+        Defaults to all modules when ``None``.
+    """
+
     parent_id: InventoryId = Field(alias="parentId")
     child_inventories: list[dict[str, InventoryId]] = Field(alias="ChildInventories")
     modules: list[str] | None = Field(default=None)

--- a/src/albert/resources/lots.py
+++ b/src/albert/resources/lots.py
@@ -157,7 +157,31 @@ class Lot(BaseResource):
 
 
 class LotSearchItem(BaseAlbertModel, HydrationMixin[Lot]):
-    """Lightweight representation of a Lot returned from search()."""
+    """Lightweight representation of a Lot returned from search.
+
+    Attributes
+    ----------
+    id : LotId
+        The Albert ID of the lot.
+    inventory_id : InventoryId | None
+        The Albert ID of the inventory item this lot belongs to.
+    parent_name : str | None
+        The name of the parent inventory item.
+    parent_unit : str | None
+        The unit category of the parent inventory item.
+    parent_category : InventoryCategory | None
+        The inventory category of the parent item.
+    task_id : str | None
+        The Albert ID of the task that created this lot.
+    barcode_id : str | None
+        The barcode identifier of the lot.
+    expiration_date : str | None
+        The expiration date of the lot (YYYY-MM-DD format).
+    manufacturer_lot_number : str | None
+        The manufacturer-assigned lot number.
+    lot_number : str | None
+        The internal lot number.
+    """
 
     id: LotId = Field(alias="albertId")
     inventory_id: InventoryId | None = Field(default=None, alias="parentId")

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -232,6 +232,24 @@ NotebookBlock = Annotated[_NotebookBlockUnion, Field(discriminator="type")]
 
 
 class Notebook(BaseResource):
+    """A notebook entity belonging to a project, task, or template.
+
+    Attributes
+    ----------
+    id : NotebookId | None
+        The Albert ID of the notebook.
+    name : str
+        The display name of the notebook. Defaults to ``"Untitled Notebook"``.
+    parent_id : ProjectId | TaskId | CustomTemplateId
+        The Albert ID of the entity this notebook belongs to.
+    version : datetime | None
+        The last-modified timestamp of the notebook.
+    blocks : list[NotebookBlock]
+        The ordered list of content blocks in the notebook.
+    links : list[NotebookLink] | None
+        Entity links referenced within the notebook.
+    """
+
     id: NotebookId | None = Field(default=None, alias="albertId")
     name: str = Field(default="Untitled Notebook")
     parent_id: ProjectId | TaskId | CustomTemplateId = Field(..., alias="parentId")

--- a/src/albert/resources/notes.py
+++ b/src/albert/resources/notes.py
@@ -4,7 +4,21 @@ from albert.core.shared.models.base import BaseResource, EntityLinkWithName
 
 
 class NoteAttachmentEntityLink(EntityLinkWithName):
-    """Entity link for a note attachment w/ an optional signed download URL."""
+    """An entity link to a file attachment on a note, including download metadata.
+
+    Attributes
+    ----------
+    id : str
+        The Albert ID of the attachment.
+    name : str | None
+        The display name of the attachment.
+    key : str | None
+        The storage key of the attached file.
+    file_size : int | None
+        The size of the file in bytes.
+    signed_url : str | None
+        A pre-signed download URL for the attachment.
+    """
 
     key: str | None = None
     file_size: int | None = Field(default=None, alias="fileSize")
@@ -12,8 +26,21 @@ class NoteAttachmentEntityLink(EntityLinkWithName):
 
 
 class Note(BaseResource):
-    """Represents a Note on the Albert Platform. Users can be mentioned in notes by using f-string and the User.to_note_mention() method.
-    This allows for easy tagging and referencing of users within notes. example: f"Hello {tagged_user.to_note_mention()}!"
+    """A note attached to an entity such as a Task, Project, or Inventory item.
+
+    Users can be @-mentioned by embedding ``User.to_note_mention()`` in the note text,
+    for example: ``f"Hello {user.to_note_mention()}!"``.
+
+    Attributes
+    ----------
+    parent_id : str
+        The Albert ID of the entity this note belongs to.
+    note : str
+        The note content. May contain @-mention markers.
+    id : str | None
+        The Albert ID of the note.
+    attachments : list[NoteAttachmentEntityLink] | None
+        Files attached to this note. Read-only.
     """
 
     parent_id: str = Field(..., alias="parentId")

--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -65,6 +65,22 @@ class EnumValidationValue(BaseAlbertModel):
 
 
 class ValueValidation(BaseAlbertModel):
+    """A validation rule applied to a parameter or data column value.
+
+    Attributes
+    ----------
+    datatype : DataType
+        The data type the validation applies to.
+    value : str | list[EnumValidationValue] | None
+        The allowed value or list of allowed enum values.
+    min : str | None
+        The minimum allowed value (for range validations).
+    max : str | None
+        The maximum allowed value (for range validations).
+    operator : Operator | None
+        The comparison operator for the validation rule.
+    """
+
     # We may want to abstract this out if we end up reusing on Data Templates
     datatype: DataType = Field(...)
     value: str | list[EnumValidationValue] | None = Field(default=None)
@@ -144,7 +160,33 @@ class ParameterValue(BaseAlbertModel):
 
 
 class ParameterGroup(BaseTaggedResource):
-    """Use 'Standards' key in metadata to store standards"""
+    """A group of parameters defining the conditions for a measurement workflow.
+
+    Use the ``"Standards"`` key in ``metadata`` to store associated standards.
+
+    Attributes
+    ----------
+    name : str
+        The name of the parameter group.
+    type : PGType | None
+        The type of parameter group (general, batch, or property).
+    id : str | None
+        The Albert ID of the parameter group.
+    description : str | None
+        A description of the parameter group.
+    security_class : SecurityClass
+        The security classification. Defaults to ``RESTRICTED``.
+    acl : list[User] | None
+        Users with explicit access to this parameter group.
+    metadata : dict[str, MetadataItem]
+        Custom metadata attached to the parameter group.
+    parameters : list[ParameterValue]
+        The parameter definitions and their values/intervals.
+    verified : bool
+        Whether the parameter group has been verified. Read-only.
+    documents : list[EntityLink]
+        Documents linked to this parameter group. Read-only.
+    """
 
     name: str
     type: PGType | None = Field(default=None)
@@ -161,13 +203,53 @@ class ParameterGroup(BaseTaggedResource):
 
 
 class ParameterSearchItemParameter(BaseAlbertModel):
+    """A lightweight parameter reference within a parameter group search result.
+
+    Attributes
+    ----------
+    name : str | None
+        The name of the parameter.
+    id : str
+        The Albert ID of the parameter.
+    localized_names : LocalizedNames
+        Localized name variants for the parameter.
+    """
+
     name: str | None = None
     id: str
     localized_names: LocalizedNames = Field(alias="localizedNames")
 
 
 class ParameterGroupSearchItem(BaseAlbertModel, HydrationMixin[ParameterGroup]):
-    """Lightweight representation of a ParameterGroup returned from unhydrated search()."""
+    """Lightweight representation of a ParameterGroup returned from search.
+
+    Attributes
+    ----------
+    name : str
+        The name of the parameter group.
+    type : PGType | None
+        The type of parameter group.
+    id : str | None
+        The Albert ID of the parameter group.
+    description : str | None
+        A description of the parameter group.
+    parameters : list[ParameterSearchItemParameter]
+        Summary of the parameters in the group.
+    owner : list[User] | None
+        Owners of the parameter group.
+    tags : list[User] | None
+        Tags associated with the parameter group.
+    acl : list[User] | None
+        Users with explicit access to the parameter group.
+    created_at : str | None
+        ISO 8601 timestamp of when the parameter group was created.
+    created_by_name : str | None
+        The name of the user who created the parameter group.
+    metadata : dict[str, MetadataItem] | None
+        Custom metadata attached to the parameter group.
+    team : list[User] | None
+        Team members associated with the parameter group.
+    """
 
     name: str
     type: PGType | None = Field(default=None)

--- a/src/albert/resources/parameters.py
+++ b/src/albert/resources/parameters.py
@@ -14,18 +14,25 @@ class ParameterCategory(str, Enum):
 
 
 class Parameter(BaseResource):
-    """A parameter in Albert.
+    """A parameter definition in Albert.
+
+    Parameters are named variables used in workflows and parameter groups to describe
+    experimental conditions. Names must be unique.
 
     Attributes
     ----------
     name : str
-        The name of the parameter. Names must be unique.
+        The name of the parameter. Must be unique across the tenant.
     id : str | None
-        The Albert ID of the parameter. Set when the parameter is retrieved from Albert.
-    category : ParameterCategory
-        The category of the parameter. Allowed values are `Normal` and `Special`. Read-only.
-    rank : int
-        The rank of the returned parameter. Read-only.
+        The Albert ID of the parameter.
+    metadata : dict[str, MetadataItem] | None
+        Custom metadata attached to the parameter.
+    category : ParameterCategory | None
+        The parameter category (Normal or Special). Read-only.
+    rank : int | None
+        The sort rank returned from a search. Read-only.
+    required : bool | None
+        Whether the parameter is required in its context. Read-only.
     """
 
     name: str

--- a/src/albert/resources/product_design.py
+++ b/src/albert/resources/product_design.py
@@ -4,12 +4,38 @@ from albert.core.base import BaseAlbertModel
 
 
 class CasLevelSubstance(BaseAlbertModel):
+    """A CAS-level substance reference within a product design.
+
+    Attributes
+    ----------
+    cas_primary_key_id : str | None
+        The primary key ID of the CAS entry.
+    cas_id : str | None
+        The Albert ID of the CAS entry.
+    amount : float | None
+        The amount of this substance in the formulation.
+    """
+
     cas_primary_key_id: str | None = Field(default=None, alias="casPrimaryKeyId")
     cas_id: str | None = Field(default=None, alias="casID")
     amount: float | None = Field(default=None)
 
 
 class NormalizedCAS(BaseAlbertModel):
+    """A normalized CAS entry with computed amount within a product design.
+
+    Attributes
+    ----------
+    name : str | None
+        The name of the CAS substance.
+    value : float | None
+        The normalized amount value.
+    albert_id : str | None
+        The Albert ID of the CAS entry.
+    smiles : str | None
+        The SMILES notation for the substance.
+    """
+
     name: str | None = Field(default=None)
     value: float | None = Field(default=None)
     albert_id: str | None = Field(default=None, alias="albertId")
@@ -17,6 +43,20 @@ class NormalizedCAS(BaseAlbertModel):
 
 
 class UnpackedInventorySDS(BaseAlbertModel):
+    """SDS summary for an inventory item within an unpacked product design.
+
+    Attributes
+    ----------
+    albert_id : str | None
+        The Albert ID of the inventory item.
+    value : float | None
+        The amount of this item in the formulation.
+    sds_class : str | None
+        The SDS/storage class identifier.
+    un_number : str | None
+        The UN number for hazardous materials.
+    """
+
     albert_id: str | None = Field(default=None, alias="albertId")
     value: float | None = Field(default=None)
     sds_class: str | None = Field(default=None, alias="class")
@@ -24,6 +64,26 @@ class UnpackedInventorySDS(BaseAlbertModel):
 
 
 class UnpackedCasInfo(BaseAlbertModel):
+    """CAS composition information for an ingredient in an unpacked product design.
+
+    Attributes
+    ----------
+    id : str | None
+        The Albert ID of the CAS entry.
+    name : str | None
+        The name of the CAS substance.
+    min : float | None
+        The minimum amount of this CAS in the formulation.
+    max : float | None
+        The maximum amount of this CAS in the formulation.
+    number : str | None
+        The CAS registry number.
+    cas_average : float | None
+        The average computed CAS amount.
+    cas_sum : float | None
+        The summed CAS amount across all occurrences.
+    """
+
     id: str | None = Field(default=None)
     name: str | None = Field(default=None)
     min: float | None = Field(default=None)
@@ -34,6 +94,24 @@ class UnpackedCasInfo(BaseAlbertModel):
 
 
 class UnpackedInventoryListItem(BaseAlbertModel):
+    """A single cell reference in an unpacked product design grid.
+
+    Attributes
+    ----------
+    row_inventory_id : str | None
+        The inventory ID of the row.
+    value : float | None
+        The cell value.
+    column_id : str | None
+        The column identifier in the design grid.
+    column_inventory_id : str | None
+        The inventory ID of the column (formulation).
+    parent_id : str | None
+        The parent design identifier.
+    row_id : str | None
+        The row identifier in the design grid.
+    """
+
     row_inventory_id: str | None = Field(default=None, alias="rowInventoryId")
     value: float | None = Field(default=None)
     column_id: str | None = Field(default=None, alias="colId")
@@ -43,6 +121,26 @@ class UnpackedInventoryListItem(BaseAlbertModel):
 
 
 class UnpackedInventory(UnpackedInventoryListItem):
+    """An ingredient row in an unpacked product design, with SDS and CAS details.
+
+    Attributes
+    ----------
+    id : str | None
+        The Albert ID of the inventory item.
+    name : str | None
+        The name of the inventory item.
+    rsn_number : str | None
+        The RSN (regulatory substance) number.
+    total_cas_sum : float | None
+        The total sum of all CAS amounts for this ingredient.
+    value : float | None
+        The amount of this ingredient in the formulation.
+    sds_info : UnpackedInventorySDS | None
+        SDS information for this ingredient.
+    cas_info : list[UnpackedCasInfo] | None
+        CAS composition details for this ingredient.
+    """
+
     id: str | None = Field(default=None)
     name: str | None = Field(default=None)
     rsn_number: str | None = Field(default=None, alias="rsnNumber")
@@ -53,6 +151,22 @@ class UnpackedInventory(UnpackedInventoryListItem):
 
 
 class UnpackedProductDesign(BaseAlbertModel):
+    """The fully expanded product design data, including ingredient and CAS breakdowns.
+
+    Attributes
+    ----------
+    inventories : list[UnpackedInventory] | None
+        The ingredient rows with SDS and CAS details.
+    inventory_list : list[UnpackedInventoryListItem] | None
+        Raw grid cell references for all inventory items.
+    inventory_sds_list : list[UnpackedInventorySDS] | None
+        SDS summaries for all inventory items in the design.
+    cas_level_substances : list[CasLevelSubstance] | None
+        CAS-level substance entries computed from the formulation.
+    normalized_cas_list : list[NormalizedCAS] | None
+        Normalized CAS amounts computed across the formulation.
+    """
+
     inventories: list[UnpackedInventory] | None = Field(default=None, alias="Inventories")
     inventory_list: list[UnpackedInventoryListItem] | None = Field(
         default=None, alias="inventoryList"

--- a/src/albert/resources/projects.py
+++ b/src/albert/resources/projects.py
@@ -129,13 +129,49 @@ class Project(BaseSessionResource):
 
 
 class ProjectSearchItem(BaseAlbertModel, HydrationMixin[Project]):
+    """Lightweight representation of a Project returned from search.
+
+    Attributes
+    ----------
+    id : ProjectId | None
+        The Albert ID of the project.
+    description : str
+        The name/description of the project.
+    status : str | None
+        The status of the project. Read-only.
+    """
+
     id: ProjectId | None = Field(None, alias="albertId")
     description: str = Field(min_length=1, max_length=2000)
     status: str | None = Field(default=None, exclude=True, frozen=True)
 
 
 class DocumentSearchItem(BaseAlbertModel):
-    """A document (attachment) search result item from a project."""
+    """A document (attachment) search result item from a project.
+
+    Attributes
+    ----------
+    id : AttachmentId | None
+        The Albert ID of the attachment.
+    name : str | None
+        The file name of the document.
+    mime_type : str | None
+        The MIME type of the document.
+    file_size : int | None
+        The file size in bytes.
+    project_id : str | None
+        The Albert ID of the project this document belongs to.
+    key : str | None
+        The storage key of the document.
+    source : str | None
+        The source namespace or origin of the document.
+    created_by : str | None
+        The Albert ID of the user who uploaded the document.
+    created_by_name : str | None
+        The display name of the user who uploaded the document.
+    created_at : str | None
+        ISO 8601 timestamp of when the document was uploaded.
+    """
 
     id: AttachmentId | None = Field(None, alias="albertId")
     name: str | None = None

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -56,6 +56,28 @@ class PropertyDataStorageKey(BaseAlbertModel):
 
 
 class PropertyData(BaseAlbertModel):
+    """A stored property data value for a single data column result.
+
+    Attributes
+    ----------
+    id : PropertyDataId | None
+        The Albert ID of the property data entry.
+    value : str | None
+        The stored value.
+    value_type : str | None
+        The data type of the stored value.
+    storage_key : PropertyDataStorageKey | dict | None
+        S3 storage keys for file-backed results (e.g. images or curves).
+    job : dict[str, Any] | None
+        Background job information for async data processing.
+    csv_mapping : dict[str, str] | None
+        CSV column-to-data-column mapping for CSV-imported results.
+    curve_remarks : dict[str, Any] | None
+        Additional remarks or metadata for curve data results.
+    athena : dict[str, Any] | None
+        Athena/database metadata for curve data results.
+    """
+
     id: PropertyDataId | None = Field(default=None)
     value: str | None = Field(default=None)
     value_type: str | None = Field(default=None, alias="valueType")
@@ -126,6 +148,24 @@ class PropertyDataInventoryInformation(BaseAlbertModel):
 
 
 class CheckPropertyData(BaseResource):
+    """Response from checking whether property data exists for a given combination.
+
+    Attributes
+    ----------
+    block_id : str | None
+        The block ID that was checked.
+    interval_id : str | None
+        The interval ID that was checked.
+    inventory_id : str | None
+        The inventory ID that was checked.
+    lot_id : str | None
+        The lot ID that was checked.
+    data_exists : bool | None
+        Whether property data exists for the given combination.
+    message : str | None
+        An informational message about the check result.
+    """
+
     block_id: str | None = Field(default=None, alias="blockId")
     interval_id: str | None = Field(default=None, alias="interval")
     inventory_id: str | None = Field(default=None, alias="inventoryId")
@@ -135,6 +175,20 @@ class CheckPropertyData(BaseResource):
 
 
 class InventoryPropertyData(BaseResource):
+    """All property data associated with a specific inventory item.
+
+    Attributes
+    ----------
+    inventory_id : str
+        The Albert ID of the inventory item.
+    inventory_name : str | None
+        The name of the inventory item.
+    task_property_data : list[TaskData]
+        Property data collected via tasks.
+    custom_property_data : list[CustomData]
+        Property data entered directly without a task.
+    """
+
     inventory_id: str = Field(alias="inventoryId")
     inventory_name: str | None = Field(default=None, alias="inventoryName")
     task_property_data: list[TaskData] = Field(default_factory=list, alias="Task")

--- a/src/albert/resources/reports.py
+++ b/src/albert/resources/reports.py
@@ -10,6 +10,20 @@ ReportItem = dict[str, Any] | list[dict[str, Any]] | None
 
 
 class ReportInfo(BaseAlbertModel):
+    """Summary metadata about a report type available in Albert.
+
+    Attributes
+    ----------
+    report_type_id : str
+        The unique identifier of the report type.
+    report_type : str
+        The name of the report type.
+    category : str
+        The category the report type belongs to.
+    items : list[ReportItem]
+        The report data items.
+    """
+
     report_type_id: str = Field(..., alias="reportTypeId")
     report_type: str = Field(..., alias="reportType")
     category: str

--- a/src/albert/resources/roles.py
+++ b/src/albert/resources/roles.py
@@ -6,18 +6,20 @@ from albert.core.shared.models.base import BaseResource
 
 
 class Role(BaseResource):
-    """A role in Albert. Note: Roles are not currently creatable via the SDK.
+    """A role in Albert. Roles are not currently creatable via the SDK.
 
     Attributes
     ----------
+    id : str | None
+        The Albert ID of the role.
     name : str
         The name of the role.
-    id : str
-        The Albert ID of the role. Set when the role is retrieved from Albert.
     policies : list[Any] | None
         The policies associated with the role.
     tenant : str
-        The tenant ID of the role.
+        The tenant ID the role belongs to.
+    visibility : bool | None
+        Whether the role is visible to users.
     """
 
     id: str | None = Field(default=None, alias="albertId")

--- a/src/albert/resources/smart_projects.py
+++ b/src/albert/resources/smart_projects.py
@@ -17,7 +17,13 @@ _PROJECTS_BASE_PATH = "/api/v3/projects"
 
 
 class SmartProjectScope(BaseAlbertModel):
-    """Scope of a smart project. This is the default state used to build a smart dataset."""
+    """Scope of a smart project, defining which targets drive its smart dataset.
+
+    Attributes
+    ----------
+    targets : list[TargetId]
+        The target IDs that are part of this smart project scope.
+    """
 
     targets: list[TargetId] = Field(default_factory=list, alias="targetIds")
 

--- a/src/albert/resources/storage_classes.py
+++ b/src/albert/resources/storage_classes.py
@@ -4,12 +4,36 @@ from albert.core.base import BaseAlbertModel
 
 
 class StorageCompatibilityMatrix(BaseAlbertModel):
+    """Compatibility rules between storage classes.
+
+    Attributes
+    ----------
+    allowed : list[str] | None
+        Storage class names or numbers that can be co-stored together.
+    not_allowed : list[str] | None
+        Storage class names or numbers that must not be co-stored.
+    warnings : dict[str, list[str]] | None
+        Storage class combinations that require caution, with warning messages.
+    """
+
     allowed: list[str] | None = Field(default_factory=list, alias="Allowed")
     not_allowed: list[str] | None = Field(default_factory=list, alias="NotAllowed")
     warnings: dict[str, list[str]] | None = Field(default_factory=dict, alias="Warnings")
 
 
 class StorageClass(BaseAlbertModel):
+    """A chemical storage class with its compatibility rules.
+
+    Attributes
+    ----------
+    storage_class_name : str | None
+        The human-readable name of the storage class.
+    storage_class_number : str | None
+        The numeric identifier of the storage class.
+    storage_compatibility : StorageCompatibilityMatrix | None
+        Compatibility rules with other storage classes.
+    """
+
     storage_class_name: str | None = Field(default=None, alias="storageClassName")
     storage_class_number: str | None = Field(default=None, alias="storageClassNumber")
     storage_compatibility: StorageCompatibilityMatrix | None = Field(

--- a/src/albert/resources/synthesis.py
+++ b/src/albert/resources/synthesis.py
@@ -10,6 +10,22 @@ from albert.core.shared.models.base import AuditFields
 
 
 class ColumnDescriptor(BaseAlbertModel):
+    """A descriptor for a column in a synthesis reaction table.
+
+    Attributes
+    ----------
+    id : str
+        The column identifier.
+    label : str | None
+        The display label for the column.
+    category : str | None
+        The category of the column.
+    default : Any | None
+        The default value for the column.
+    type : str | None
+        The data type of the column.
+    """
+
     id: str
     label: str | None = None
     category: str | None = None
@@ -18,16 +34,52 @@ class ColumnDescriptor(BaseAlbertModel):
 
 
 class ColumnSequence(BaseAlbertModel):
+    """The ordered column layout for reactants and products in a synthesis table.
+
+    Attributes
+    ----------
+    reactants : list[ColumnDescriptor]
+        Column descriptors for the reactant side of the reaction.
+    products : list[ColumnDescriptor]
+        Column descriptors for the product side of the reaction.
+    """
+
     reactants: list[ColumnDescriptor] = Field(default_factory=list)
     products: list[ColumnDescriptor] = Field(default_factory=list)
 
 
 class RowSequence(BaseAlbertModel):
+    """The ordered row layout for reactants and products in a synthesis table.
+
+    Attributes
+    ----------
+    reactants : list[str]
+        Row IDs for the reactant rows.
+    products : list[str]
+        Row IDs for the product rows.
+    """
+
     reactants: list[str] = Field(default_factory=list)
     products: list[str] = Field(default_factory=list)
 
 
 class ReactionParticipant(BaseAlbertModel):
+    """A single reactant or product entry in a synthesis reaction.
+
+    Attributes
+    ----------
+    row_id : str
+        The row identifier within the synthesis table.
+    smiles : str | None
+        The SMILES notation for the chemical structure.
+    values : dict[str, Any] | None
+        The stoichiometric and property values for this participant.
+    type : str | None
+        The participant type (e.g. reactant or product).
+    limiting_reagent : str | bool | None
+        Whether this participant is the limiting reagent.
+    """
+
     row_id: str = Field(alias="rowId")
     smiles: str | None = None
     values: dict[str, Any] | None = None
@@ -36,6 +88,44 @@ class ReactionParticipant(BaseAlbertModel):
 
 
 class Synthesis(BaseAlbertModel):
+    """A synthesis reaction record embedded within a notebook block.
+
+    Attributes
+    ----------
+    id : SynthesisId
+        The Albert ID of the synthesis.
+    parent_id : NotebookId | str | None
+        The Albert ID of the parent notebook.
+    name : str | None
+        The name of the synthesis.
+    status : str | None
+        The status of the synthesis.
+    block_id : str | None
+        The notebook block ID containing this synthesis.
+    inventory_id : str | None
+        The inventory item ID associated with the product of this synthesis.
+    hide_reaction_worksheet : str | bool | None
+        Whether the reaction worksheet is hidden in the UI.
+    s3_key : str | None
+        The S3 storage key for the Ketcher canvas data file.
+    canvas_data : dict[str, Any] | None
+        The Ketcher canvas state for the reaction drawing.
+    smiles : list[str | None]
+        SMILES strings extracted from the reaction.
+    reactants : list[ReactionParticipant]
+        The reactant entries in the synthesis reaction.
+    products : list[ReactionParticipant]
+        The product entries in the synthesis reaction.
+    column_sequence : ColumnSequence | None
+        The column layout for the synthesis table.
+    row_sequence : RowSequence | None
+        The row layout for the synthesis table.
+    created : AuditFields | None
+        Audit fields for when the synthesis was created.
+    updated : AuditFields | None
+        Audit fields for the last update.
+    """
+
     id: SynthesisId = Field(alias="albertId")
     parent_id: NotebookId | str | None = Field(default=None, alias="parentId")
     name: str | None = None
@@ -55,6 +145,20 @@ class Synthesis(BaseAlbertModel):
 
 
 class ReactantValues(BaseAlbertModel):
+    """Stoichiometric values for a reactant in a synthesis calculation.
+
+    Attributes
+    ----------
+    mass : float | None
+        The mass of the reactant.
+    moles : float | None
+        The moles of the reactant.
+    eq : float | None
+        The equivalents relative to the limiting reagent.
+    concentration : float | int | None
+        The concentration of the reactant in solution.
+    """
+
     mass: float | None = None
     moles: float | None = None
     eq: float | None = None

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -195,7 +195,57 @@ class TaskEntityType(BaseAlbertModel):
 
 
 class BaseTask(BaseTaggedResource):
-    """Base class for all task types. Use PropertyTask, BatchTask, or GeneralTask for specific task types."""
+    """Base class for all task types. Use ``PropertyTask``, ``BatchTask``, or ``GeneralTask`` for specific task types.
+
+    Attributes
+    ----------
+    id : str | None
+        The Albert ID of the task.
+    name : str
+        The name of the task.
+    category : TaskCategory
+        The task category (Property, Batch, General, or BatchWithQC).
+    parent_id : str | None
+        The Albert ID of the project this task belongs to.
+    metadata : dict[str, MetadataItem]
+        Custom metadata attached to the task.
+    sources : list[TaskSource] | None
+        The templates or tasks this task was created from.
+    inventory_information : list[TaskInventoryInformation]
+        Inventory items associated with the task.
+    location : Location | None
+        The location where the task is performed.
+    priority : TaskPriority | None
+        The priority of the task (High, Medium, Low).
+    security_class : SecurityClass | None
+        The security classification of the task.
+    pass_fail : bool | None
+        Whether the task is evaluated as pass/fail.
+    notes : str | None
+        Free-text notes on the task.
+    start_date : str | None
+        The start date of the task (YYYY-MM-DD). Read-only.
+    due_date : str | None
+        The due date of the task (YYYY-MM-DD).
+    claimed_date : str | None
+        The date the task was claimed. Read-only.
+    completed_date : str | None
+        The date the task was completed. Read-only.
+    closed_date : str | None
+        The date the task was closed. Read-only.
+    result : str | None
+        The result of the task (e.g. pass/fail).
+    state : TaskState | None
+        The current state of the task.
+    project : Project | list[Project] | None
+        The project(s) this task is associated with.
+    assigned_to : User | Team | None
+        The user or team assigned to this task.
+    page_state : PageState | None
+        The UI page state for the task.
+    entity_type : TaskEntityType | None
+        The entity type associated with this task.
+    """
 
     id: str | None = Field(alias="albertId", default=None)
     name: str
@@ -361,6 +411,14 @@ class BatchTask(BaseTask):
 
 
 class GeneralTask(BaseTask):
+    """A general-purpose task not tied to a specific batch or property workflow.
+
+    Attributes
+    ----------
+    category : TaskCategory
+        Always ``TaskCategory.GENERAL``.
+    """
+
     category: Literal[TaskCategory.GENERAL] = TaskCategory.GENERAL
 
 

--- a/src/albert/resources/units.py
+++ b/src/albert/resources/units.py
@@ -79,25 +79,22 @@ class UnitCategory(str, Enum):
 
 
 class Unit(BaseResource):
-    """
-    Unit is a Pydantic model representing a unit entity.
+    """A unit of measure in Albert.
 
     Attributes
     ----------
     id : str | None
-        The Albert ID of the unit. Set when the unit is retrieved from Albert.
+        The Albert ID of the unit.
     name : str
-        The name of the unit.
+        The name of the unit (e.g. ``"kilogram"``).
     symbol : str | None
-        The symbol of the unit.
-    synonyms : List[str] | None
-        The list of synonyms for the unit.
-    category : UnitCategory
-        The category of the unit.
+        The symbol for the unit (e.g. ``"kg"``).
+    synonyms : list[str] | None
+        Alternative names or abbreviations for the unit.
+    category : UnitCategory | None
+        The measurement category (e.g. Mass, Volume, Temperature).
     verified : bool | None
-        Whether the unit is verified.
-    status : Status | None
-        The status of the unit. Allowed values are `active`, and `inactive`
+        Whether the unit has been verified. Read-only.
     """
 
     id: str | None = Field(None, alias="albertId")

--- a/src/albert/resources/users.py
+++ b/src/albert/resources/users.py
@@ -27,23 +27,24 @@ class UserFilterType(str, Enum):
 
 
 class User(BaseResource):
-    """Represents a User on the Albert Platform
+    """A user on the Albert platform.
 
     Attributes
     ----------
     name : str
-        The name of the user.
+        The display name of the user.
     id : str | None
-        The Albert ID of the user. Set when the user is retrieved from Albert.
+        The Albert ID of the user.
     location : Location | None
-        The location of the user.
+        The physical location associated with the user.
     email : EmailStr | None
-        The email of the user.
+        The email address of the user.
     roles : list[Role]
-        The roles of the user.
+        The roles assigned to the user (max one role).
     user_class : UserClass
-        The ACL class level of the user.
-    metadata : dict[str, str | list[EntityLink] | EntityLink] | None
+        The ACL class level of the user. Defaults to ``standard``.
+    metadata : dict[str, MetadataItem] | None
+        Custom metadata attached to the user.
     """
 
     name: str
@@ -68,12 +69,44 @@ class User(BaseResource):
 
 
 class UserSearchRoleItem(BaseAlbertModel):
+    """A role summary within a user search result.
+
+    Attributes
+    ----------
+    roleId : str
+        The Albert ID of the role.
+    roleName : str
+        The display name of the role.
+    """
+
     roleId: str
     roleName: str
 
 
 class UserSearchItem(BaseAlbertModel, HydrationMixin[User]):
-    """Partial user entity as returned by the search."""
+    """Lightweight representation of a User returned from search.
+
+    Attributes
+    ----------
+    name : str
+        The display name of the user.
+    id : UserId | None
+        The Albert ID of the user.
+    email : EmailStr | None
+        The email address of the user.
+    user_class : UserClass
+        The ACL class level of the user.
+    last_login_time : datetime | None
+        The timestamp of the user's last login.
+    location : str | None
+        The location name associated with the user.
+    location_id : str | None
+        The Albert ID of the user's location.
+    roles : list[UserSearchRoleItem]
+        The roles assigned to the user (max one).
+    subscription : str | None
+        The subscription type of the user.
+    """
 
     name: str
     id: UserId | None = Field(None, alias="albertId")

--- a/src/albert/resources/worker_jobs.py
+++ b/src/albert/resources/worker_jobs.py
@@ -31,6 +31,26 @@ WORKER_JOB_TERMINAL_STATES: set[WorkerJobState] = {
 
 
 class WorkerJobMetadata(BaseAlbertModel):
+    """Metadata describing the context of a worker job.
+
+    Attributes
+    ----------
+    parent_type : str | None
+        The entity type this job operates on (e.g. ``"inventory"``).
+    parent_id : str | None
+        The Albert ID of the entity this job is associated with.
+    table_name : str | None
+        The database table name relevant to the job.
+    mapping : dict[str, str] | None
+        Column or field mapping used by the job.
+    namespace : str | None
+        The file namespace for job inputs/outputs.
+    s3_input_key : str | None
+        The S3 key for the job's input file.
+    s3_output_key : str | None
+        The S3 key for the job's output file.
+    """
+
     parent_type: str | None = Field(default=None, alias="parentType")
     parent_id: str | None = Field(default=None, alias="parentId")
     table_name: str | None = Field(default=None, alias="tableName")
@@ -41,11 +61,51 @@ class WorkerJobMetadata(BaseAlbertModel):
 
 
 class WorkerJobCreateRequest(BaseAlbertModel):
+    """Request payload for creating a new worker job.
+
+    Attributes
+    ----------
+    job_type : str
+        The type of job to create (e.g. ``"importCSV"``).
+    metadata : WorkerJobMetadata
+        Metadata describing the job context.
+    """
+
     job_type: str = Field(alias="jobType")
     metadata: WorkerJobMetadata
 
 
 class WorkerJob(BaseAlbertModel):
+    """A background worker job running on the Albert platform.
+
+    Attributes
+    ----------
+    job_type : str
+        The type of the job.
+    metadata : WorkerJobMetadata
+        Metadata describing the job context.
+    status : Status | str | None
+        The status of the job.
+    state : WorkerJobState
+        The current state of the job (e.g. inProgress, successful, failed).
+    state_message : str | None
+        An optional message describing the current state or error.
+    albert_id : str | None
+        The Albert ID assigned to the job.
+    created : datetime | None
+        The timestamp when the job was created.
+    modified : datetime | None
+        The timestamp when the job was last modified.
+    created_audit : AuditFields | None
+        Audit fields for job creation.
+    updated_audit : AuditFields | None
+        Audit fields for the last job update.
+    started_audit : AuditFields | None
+        Audit fields for when the job started.
+    completed_audit : AuditFields | None
+        Audit fields for when the job completed.
+    """
+
     job_type: str = Field(alias="jobType")
     metadata: WorkerJobMetadata
     status: Status | str | None = None

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -262,18 +262,27 @@ class ParameterGroupSetpoints(BaseAlbertModel):
 
 
 class Workflow(BaseResource):
-    """A Pydantic Class representing a workflow in Albert.
+    """A workflow in Albert, combining parameter groups and their setpoints.
 
-    Workflows are combinations of Data Templates and Parameter groups and their associated setpoints.
+    Workflows define the measurement conditions for property tasks. They link
+    parameter groups with specific setpoints (values or intervals) to create
+    reproducible experimental conditions.
 
     Attributes
     ----------
     name : str
         The name of the workflow.
     parameter_group_setpoints : list[ParameterGroupSetpoints]
-        The setpoints to apply to the parameter groups in the workflow.
+        The parameter groups and their associated setpoints for this workflow.
+    interval_combinations : list[IntervalCombination] | None
+        The interval combinations present in this workflow, representing the
+        Cartesian product of intervalized parameters.
     id : str | None
-        The AlbertID of the workflow. This is set when a workflow is retrived from the platform.
+        The Albert ID of the workflow. Excluded from serialization.
+    block_mapping : str | None
+        Internal block mapping identifier.
+    category : str | None
+        The category of the workflow. Read-only.
     """
 
     name: str


### PR DESCRIPTION
## Summary

- Added Numpy-style docstrings with `Attributes` sections to 80+ resource classes across 33 files that were entirely missing them (e.g. `Activity`, `BatchData`, `BTDataset`, `BTInsight`, `DataColumn`, `DataTemplate`, `Synthesis`, `WorkerJob`, and many more)
- Fixed incorrect or incomplete existing docstrings: removed stale `Returns` sections from `CustomField`, replaced vague one-liners with full attribute listings, added missing fields (`Parameter.metadata`, `Role.visibility`, `Workflow.interval_combinations`, etc.)
- Cleaned up style issues: removed "Enumeration of" prefixes from enum docstrings, updated `List[X]` → `list[x]` notation, and eliminated references to internal implementation details
- Also fixed a pre-existing ruff `UP038` violation in `inventory.py` (`isinstance(v, (int, float))` → `isinstance(v, int | float)`)