### PR TITLE
fix(workflows): back-fill prgPrmRowId when user supplies explicit setpoints

### DIFF
--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -72,7 +72,11 @@ class WorkflowCollection(BaseCollection):
         return [Workflow(**x) for x in response.json()]
 
     def _hydrate_parameter_groups(self, *, workflow: Workflow) -> None:
-        """Ensure parameter setpoints are fully populated for each parameter group with an id."""
+        """Ensure parameter setpoints are fully populated for each parameter group with an id.
+
+        When setpoints are user-supplied, missing sequence values are back-filled to prevent
+        mismatches when a parameter appears multiple times within the same group.
+        """
         dt_collection = DataTemplateCollection(session=self.session)
         pg_collection = ParameterGroupCollection(session=self.session)
         for pg_setpoint in workflow.parameter_group_setpoints:

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -72,13 +72,7 @@ class WorkflowCollection(BaseCollection):
         return [Workflow(**x) for x in response.json()]
 
     def _hydrate_parameter_groups(self, *, workflow: Workflow) -> None:
-        """Populate parameter setpoints when only an ID is provided.
-
-        When parameter setpoints are already supplied, the group is still fetched
-        to back-fill any missing ``sequence`` (``prgPrmRowId``) values. This
-        prevents mismatches when a data template has parameters that were deleted
-        and re-added (leaving duplicate PRM ids at different row sequences).
-        """
+        """Ensure parameter setpoints are fully populated for each parameter group with an id."""
         dt_collection = DataTemplateCollection(session=self.session)
         pg_collection = ParameterGroupCollection(session=self.session)
         for pg_setpoint in workflow.parameter_group_setpoints:

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -72,12 +72,16 @@ class WorkflowCollection(BaseCollection):
         return [Workflow(**x) for x in response.json()]
 
     def _hydrate_parameter_groups(self, *, workflow: Workflow) -> None:
-        """Populate parameter setpoints when only an ID is provided."""
+        """Populate parameter setpoints when only an ID is provided.
+
+        When parameter setpoints are already supplied, the group is still fetched
+        to back-fill any missing ``sequence`` (``prgPrmRowId``) values. This
+        prevents mismatches when a data template has parameters that were deleted
+        and re-added (leaving duplicate PRM ids at different row sequences).
+        """
         dt_collection = DataTemplateCollection(session=self.session)
         pg_collection = ParameterGroupCollection(session=self.session)
         for pg_setpoint in workflow.parameter_group_setpoints:
-            if pg_setpoint.parameter_setpoints:
-                continue
             pg_id = pg_setpoint.id
             if pg_id is None:
                 continue
@@ -91,9 +95,16 @@ class WorkflowCollection(BaseCollection):
                 pg_setpoint.parameter_group_name = group.name
                 params = group.parameters or []
 
-            pg_setpoint.parameter_setpoints = [
-                self._parameter_value_to_setpoint(pv) for pv in params
-            ]
+            if pg_setpoint.parameter_setpoints:
+                # User supplied explicit setpoints — only fill in missing sequences.
+                sequence_by_param_id = {pv.id: pv.sequence for pv in params if pv.id}
+                for sp in pg_setpoint.parameter_setpoints:
+                    if sp.sequence is None and sp.parameter_id in sequence_by_param_id:
+                        sp.sequence = sequence_by_param_id[sp.parameter_id]
+            else:
+                pg_setpoint.parameter_setpoints = [
+                    self._parameter_value_to_setpoint(pv) for pv in params
+                ]
 
     @staticmethod
     def _parameter_value_to_setpoint(parameter_value: ParameterValue) -> ParameterSetpoint:


### PR DESCRIPTION
## Summary
- When a data template has a parameter deleted and re-added, the API stores two rows for the same PRM id at different sequences (e.g. ROW1 active, ROW2 deleted)
- Without `prgPrmRowId` in the request, the backend resolves to the deleted row and returns a 400 `Parameter Id mismatch with ParameterGroup` error
- `_hydrate_parameter_groups` now always fetches the group when an `id` is present and back-fills any missing `sequence` values on user-supplied setpoints, without replacing them