### PR TITLE
feat(activities): add search() method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,6 +28,7 @@ Single source of truth for coding-agent guidance in this repo.
 - Collections inherit from `BaseCollection` and accept an `AlbertSession`.
 - Public collection methods use `@validate_call` for runtime validation.
 - Resources use `BaseAlbertModel`/`BaseResource` with Pydantic `Field` and aliases.
+- **Search result models must be named `<Resource>SearchItem`** (e.g. `ActivitySearchItem`, `UserSearchItem`) when the shape returned by the search endpoint differs from the main resource model. Never reuse the main resource model for search results if the fields differ, and never name the search model `<Resource>Item` or anything else.
 - Keep API payloads in wire format (camelCase) via `Field(alias=...)` and `model_dump(by_alias=True, mode="json", exclude_none=True)`.
 - All new public methods and classes must have Numpy-style docstrings:
 
@@ -55,6 +56,8 @@ Many list/search methods use `AlbertPaginator` (`src/albert/core/pagination.py`)
 - **Key** (`PaginationMode.KEY`) — uses `startKey`, expects `lastKey` in response. Do not pass `limit` from the SDK; the backend controls page size.
 
 Expose a `max_items` parameter on public list/search methods where appropriate to allow early stopping.
+
+**`offset` and `limit` are never exposed as method parameters.** They are internal pagination state managed entirely by `AlbertPaginator`. Never add `offset` or `limit` to a public method signature or docstring. Use `max_items` as the only caller-facing pagination control.
 
 ## Testing
 

--- a/src/albert/collections/activities.py
+++ b/src/albert/collections/activities.py
@@ -1,15 +1,41 @@
 from collections.abc import Iterator
 from datetime import date
 
+from pydantic import validate_call
+
 from albert.collections.base import BaseCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.resources.activities import Activity, ActivityAction, ActivityOperationId, ActivityType
+from albert.resources.activities import (
+    Activity,
+    ActivityAction,
+    ActivityOperationId,
+    ActivitySearchItem,
+    ActivityType,
+)
 
 
 class ActivityCollection(BaseCollection):
-    """ActivityCollection is a collection class for managing viewing activities across Albert platform."""
+    """ActivityCollection manages Activity entities in the Albert platform.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The Albert session instance.
+
+    Attributes
+    ----------
+    base_path : str
+        The base URL for activity API requests.
+
+    Methods
+    -------
+    get_all(type, ...) -> Iterator[Activity]
+        Lists activity entities with optional filters.
+    search(...) -> Iterator[ActivitySearchItem]
+        Searches activity records using full-text and filter criteria.
+    """
 
     _api_version = "v3"
 
@@ -83,4 +109,89 @@ class ActivityCollection(BaseCollection):
             params=params,
             max_items=max_items,
             deserialize=lambda items: [Activity(**item) for item in items],
+        )
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        sort_by: str | None = None,
+        order_by: OrderBy | None = None,
+        operation_id: list[str] | None = None,
+        user: list[str] | None = None,
+        user_class: list[str] | None = None,
+        user_role: list[str] | None = None,
+        object_id: list[str] | None = None,
+        object_type: list[str] | None = None,
+        object_class: list[str] | None = None,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        uuid: list[str] | None = None,
+        activity_id: list[str] | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[ActivitySearchItem]:
+        """Searches activity records using full-text and filter criteria.
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text search across activity fields.
+        sort_by : str, optional
+            Field to sort results by. Valid value: ``loggedAt``.
+        order_by : OrderBy, optional
+            Sort direction, ascending or descending.
+        operation_id : list[str], optional
+            Filter by one or more operation IDs.
+        user : list[str], optional
+            Filter by one or more user IDs.
+        user_class : list[str], optional
+            Filter by one or more user class values.
+        user_role : list[str], optional
+            Filter by one or more user roles.
+        object_id : list[str], optional
+            Filter by one or more object IDs.
+        object_type : list[str], optional
+            Filter by one or more object types.
+        object_class : list[str], optional
+            Filter by one or more object class values.
+        start_date : date, optional
+            Start of the date range to filter results.
+        end_date : date, optional
+            End of the date range to filter results.
+        uuid : list[str], optional
+            Filter by one or more activity UUIDs.
+        activity_id : list[str], optional
+            Filter by one or more activity IDs.
+        max_items : int, optional
+            Maximum number of items to return in total. If None, fetches all available items.
+
+        Returns
+        -------
+        Iterator[ActivitySearchItem]
+            An iterator of ActivitySearchItem objects matching the search criteria.
+        """
+        params = {
+            "text": text,
+            "sortBy": sort_by,
+            "orderBy": order_by,
+            "operationId": operation_id,
+            "user": user,
+            "userClass": user_class,
+            "userRole": user_role,
+            "objectId": object_id,
+            "objectType": object_type,
+            "objectClass": object_class,
+            "startDate": start_date,
+            "endDate": end_date,
+            "uuid": uuid,
+            "activityId": activity_id,
+        }
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [ActivitySearchItem(**item) for item in items],
         )

--- a/src/albert/resources/activities.py
+++ b/src/albert/resources/activities.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 from pydantic import Field
 
+from albert.core.base import BaseAlbertModel
 from albert.core.shared.models.base import BaseResource
 
 
@@ -22,6 +23,26 @@ class ActivityType(str, Enum):
     UUID = "uuid"
     DATE = "date"
     DATE_RANGE = "dateRange"
+
+
+class ActivitySearchItemUser(BaseAlbertModel):
+    name: str | None = Field(default=None)
+    id: str | None = Field(default=None)
+    role: str | None = Field(default=None)
+    user_class: str | None = Field(default=None, alias="class")
+
+
+class ActivitySearchItem(BaseAlbertModel):
+    action: str | None = Field(default=None)
+    name: str | None = Field(default=None)
+    pk: str | None = Field(default=None, alias="PK")
+    object_class: str | None = Field(default=None, alias="class")
+    logged_at: str | None = Field(default=None, alias="loggedAt")
+    operation_id: str | None = Field(default=None, alias="operationId")
+    object_id: str | None = Field(default=None, alias="objectId")
+    object_type: str | None = Field(default=None, alias="objectType")
+    activity_id: str | None = Field(default=None, alias="activityId")
+    user: ActivitySearchItemUser | None = Field(default=None)
 
 
 class Activity(BaseResource):

--- a/tests/collections/test_activities.py
+++ b/tests/collections/test_activities.py
@@ -1,7 +1,7 @@
 from datetime import date, timedelta
 
 from albert import Albert
-from albert.resources.activities import Activity, ActivityType
+from albert.resources.activities import Activity, ActivitySearchItem, ActivityType
 
 
 def assert_valid_activity_items(returned_list):
@@ -21,3 +21,19 @@ def test_activity_get_all(client: Albert):
         max_items=10,
     )
     assert_valid_activity_items(simple_list)
+
+
+def test_activity_search(client: Albert):
+    """Test that activity search returns ActivitySearchItem results."""
+    end_date = date.today()
+    start_date = end_date - timedelta(days=7)
+    results = list(
+        client.activities.search(
+            start_date=start_date,
+            end_date=end_date,
+            max_items=10,
+        )
+    )
+    assert results, "Expected at least one search result"
+    for item in results:
+        assert isinstance(item, ActivitySearchItem)


### PR DESCRIPTION
## Summary
- Adds `ActivityCollection.search()` backed by `GET /api/v3/activities/search`
- Adds `ActivitySearchItem` and `ActivitySearchItemUser` resource models for the search response shape (distinct from the existing `Activity` model returned by `get_all`)
- Supports full-text search and filtering by `operation_id`, `user`, `user_class`, `user_role`, `object_id`, `object_type`, `object_class`, `start_date`, `end_date`, `uuid`, and `activity_id`
- Updates AGENTS.md with two new conventions: `offset`/`limit` are internal to `AlbertPaginator` (never exposed as params), and search result models must be named `<Resource>SearchItem`