### PR TITLE
docs(agents): forbid manual version bumps; release-please owns versioning

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,7 +134,7 @@ Run the full suite (`uv run pytest`) if the change is broad.
 
 - Prefer multiple focused commits over one large commit.
 - Use Conventional Commits: `feat(scope): summary`, `fix(scope): summary`, `chore(scope): summary`.
-- Version is defined in `src/albert/__init__.py`. Releases are created by tagging and drafting a GitHub release.
+- **Never bump the version manually.** Version numbers in `src/albert/__init__.py` and `pyproject.toml` are managed exclusively by release-please. PRs that modify the version in either file will be flagged and must not be merged.
 
 Example commit:
 


### PR DESCRIPTION
## Summary
- Replaces the outdated "Releases are created by tagging" note in AGENTS.md with an explicit rule prohibiting manual version bumps
- Version numbers in `src/albert/__init__.py` and `pyproject.toml` are now documented as exclusively managed by release-please
- PRs that manually bump the version should be flagged and blocked from merging