### PR TITLE
fix(attachments): accept unknown category values gracefully

### DIFF
--- a/src/albert/resources/attachments.py
+++ b/src/albert/resources/attachments.py
@@ -40,7 +40,7 @@ class Attachment(BaseResource):
     name: str
     key: str
     namespace: str = Field(default="result", alias="nameSpace")
-    category: AttachmentCategory | None = None
+    category: AttachmentCategory | str | None = None
     revision_date: date | None = Field(default=None, alias="revisionDate")
     file_size: int | None = Field(default=None, alias="fileSize", exclude=True, frozen=True)
     mime_type: str | None = Field(default=None, alias="mimeType", exclude=True, frozen=True)

--- a/src/albert/resources/files.py
+++ b/src/albert/resources/files.py
@@ -37,7 +37,7 @@ class FileInfo(BaseAlbertModel):
     name: str
     size: int
     etag: str
-    namespace: FileNamespace | None = Field(default=None)
+    namespace: FileNamespace | str | None = Field(default=None)
     content_type: str = Field(..., alias="contentType")
     last_modified: datetime = Field(..., alias="lastModified")
     metadata: list[dict[str, str]] = Field(..., default_factory=list)


### PR DESCRIPTION
## Summary
- Widens `Attachment.category` from `AttachmentCategory | None` to `AttachmentCategory | str | None
- Fully backwards compatible — existing callers and enum comparisons are unaffected