### PR TITLE
chore(deps): remove unused pyjwt dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,6 @@ dependencies = [
     "requests>=2.32.3,<3",
     "pandas>=2.2.2,<3",
     "pydantic[email]>=2.8.2,<3",
-    "pyjwt>=2.10.0,<3",
     "tenacity>=8.2.3",
 ]
 


### PR DESCRIPTION
## Summary

Removes the now-unused `pyjwt` dependency from `pyproject.toml`.

PyJWT was previously used only for local JWT decoding (the `jwt.decode(..., verify_signature=False)` path). That usage was already removed in favor of server-side token validation, but the dependency lingered in the manifest. A security retest flagged it (CVE-2025-45768 — weak encryption, **vendor-disputed**: key length is the consuming app's responsibility). Since the SDK no longer imports `jwt` anywhere, dropping the dependency eliminates the finding entirely.

## Changes
- Remove `pyjwt>=2.10.0,<3` from `[project].dependencies`.

## Verification
- `grep` confirms no `import jwt` / `pyjwt` references remain in `src/` or `tests/`.
- `uv lock` resolves cleanly (pyjwt removed); `import albert` succeeds.