### PR TITLE
feat(smart_dataset): add pagination to get_all

### DIFF
--- a/src/albert/collections/smart_datasets.py
+++ b/src/albert/collections/smart_datasets.py
@@ -102,6 +102,7 @@ class SmartDatasetCollection(BaseCollection):
         )
         return SmartDataset(**response.json())
 
+    @validate_call
     def get_all(
         self,
         *,

--- a/src/albert/collections/smart_datasets.py
+++ b/src/albert/collections/smart_datasets.py
@@ -1,7 +1,11 @@
+from collections.abc import Iterator
+
 from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
+from albert.core.shared.enums import PaginationMode
 from albert.core.shared.identifiers import ProjectId, SmartDatasetId
 from albert.core.shared.models.patch import PatchDatum, PatchOperation, PatchPayload
 from albert.resources.smart_datasets import (
@@ -34,7 +38,7 @@ class SmartDatasetCollection(BaseCollection):
     -------
     create(scope, build=True) -> SmartDataset
         Creates a new smart dataset entity.
-    get_all() -> list[SmartDataset]
+    get_all(max_items=None) -> Iterator[SmartDataset]
         Lists all smart datasets for the tenant.
     get_by_id(id) -> SmartDataset
         Retrieves a smart dataset by its ID.
@@ -98,18 +102,31 @@ class SmartDatasetCollection(BaseCollection):
         )
         return SmartDataset(**response.json())
 
-    def get_all(self) -> list[SmartDataset]:
+    def get_all(
+        self,
+        *,
+        max_items: int | None = None,
+    ) -> Iterator[SmartDataset]:
         """
-        Lists all smart datasets for the tenant.
+        List all smart datasets for the tenant.
+
+        Parameters
+        ----------
+        max_items : int, optional
+            Maximum number of items to return. If None, returns all available items.
 
         Returns
         -------
-        list[SmartDataset]
-            A list of SmartDataset entities.
+        Iterator[SmartDataset]
+            An iterator of SmartDataset entities.
         """
-        response = self.session.get(self.base_path)
-        data = response.json()
-        return [SmartDataset(**item) for item in data.get("Items", [])]
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=self.base_path,
+            session=self.session,
+            max_items=max_items,
+            deserialize=lambda items: [SmartDataset(**item) for item in items],
+        )
 
     @validate_call
     def get_by_id(self, *, id: SmartDatasetId, parent_id: ProjectId | None = None) -> SmartDataset:

--- a/src/albert/collections/smart_datasets.py
+++ b/src/albert/collections/smart_datasets.py
@@ -121,7 +121,7 @@ class SmartDatasetCollection(BaseCollection):
             An iterator of SmartDataset entities.
         """
         return AlbertPaginator(
-            mode=PaginationMode.OFFSET,
+            mode=PaginationMode.KEY,
             path=self.base_path,
             session=self.session,
             max_items=max_items,

--- a/tests/collections/test_smart_datasets.py
+++ b/tests/collections/test_smart_datasets.py
@@ -61,11 +61,17 @@ def test_smart_dataset_create_with_build(
 
 
 def test_smart_dataset_get_all(client: Albert):
-    """Test listing smart datasets."""
-    results = client.smart_datasets.get_all()
-    assert isinstance(results, list)
+    """Test listing smart datasets returns an iterator of SmartDataset entities."""
+    results = list(client.smart_datasets.get_all())
     assert len(results) > 0
     assert all(isinstance(r, SmartDataset) for r in results)
+
+
+def test_smart_dataset_get_all_max_items(client: Albert):
+    """Test that max_items limits the number of results returned."""
+    results = list(client.smart_datasets.get_all(max_items=1))
+    assert len(results) == 1
+    assert isinstance(results[0], SmartDataset)
 
 
 def test_smart_dataset_get_by_id(client: Albert, seeded_smart_dataset: SmartDataset):


### PR DESCRIPTION
Converts `SmartDatasetCollection.get_all()` to use `AlbertPaginator` (consistent with other SDK collections) and adds a `max_items` parameter for early stopping.

- Returns `Iterator[SmartDataset]` instead of `list[SmartDataset]`
- Uses `AlbertPaginator` with `PaginationMode.OFFSET` — stops after one page since the API doesn't return an `offset` field, but will handle multi-page automatically once the API supports it
- Fixes the existing test assertion (`list` → iterator) and adds a `max_items` test

Related: [AF-969](https://linear.app/albert-invent/issue/AF-969/add-parentid-filter-support-to-get-apiv3smartdatasets-list-endpoint) — `parentId` server-side filtering is tracked separately.

This PR contains AI-assisted code generated with Claude Code. The author has reviewed and takes full responsibility for all changes.