### PR TITLE
fix(custom_fields): correct PATCH operation/oldValue handling for unset fields

### DIFF
--- a/src/albert/collections/entity_types.py
+++ b/src/albert/collections/entity_types.py
@@ -129,6 +129,23 @@ class EntityTypeCollection(BaseCollection):
             List of patch operations for special attributes.
         """
         patches = []
+
+        def _nested_field_patch(attribute: str, old_value, new_value) -> PatchDatum:
+            # A nested key that isn't set yet must be added; the backend rejects
+            # an `update` on a path that does not already exist.
+            if old_value is None:
+                return PatchDatum(
+                    operation=PatchOperation.ADD,
+                    attribute=attribute,
+                    new_value=new_value,
+                )
+            return PatchDatum(
+                operation=PatchOperation.UPDATE,
+                attribute=attribute,
+                new_value=new_value,
+                old_value=old_value,
+            )
+
         if updated.custom_fields is not None and existing.custom_fields is not None:
             patches.append(
                 PatchDatum(
@@ -170,11 +187,8 @@ class EntityTypeCollection(BaseCollection):
                     # Use the field's alias if available, otherwise use the field name
                     attr_name = field.alias or field_name
                     patches.append(
-                        PatchDatum(
-                            operation=PatchOperation.UPDATE,
-                            attribute=f"standardFieldVisibility.{attr_name}",
-                            new_value=new_value,
-                            old_value=old_value,
+                        _nested_field_patch(
+                            f"standardFieldVisibility.{attr_name}", old_value, new_value
                         )
                     )
 
@@ -190,11 +204,8 @@ class EntityTypeCollection(BaseCollection):
                 if new_value != old_value:
                     attr_name = field.alias or field_name
                     patches.append(
-                        PatchDatum(
-                            operation=PatchOperation.UPDATE,
-                            attribute=f"standardFieldRequired.{attr_name}",
-                            new_value=new_value,
-                            old_value=old_value,
+                        _nested_field_patch(
+                            f"standardFieldRequired.{attr_name}", old_value, new_value
                         )
                     )
 
@@ -212,12 +223,7 @@ class EntityTypeCollection(BaseCollection):
                     # Use the field's alias if available, otherwise use the field name
                     attr_name = field.alias or field_name
                     patches.append(
-                        PatchDatum(
-                            operation=PatchOperation.UPDATE,
-                            attribute=f"searchQueryString.{attr_name}",
-                            new_value=new_value,
-                            old_value=old_value,
-                        )
+                        _nested_field_patch(f"searchQueryString.{attr_name}", old_value, new_value)
                     )
 
         return patches

--- a/src/albert/utils/_patch.py
+++ b/src/albert/utils/_patch.py
@@ -276,9 +276,16 @@ def _parameter_required_patch(
     updated_required = updated_parameter_value.required
     if updated_required is None:
         return None
-    initial_required = (
-        initial_parameter_value.required if initial_parameter_value.required is not None else False
-    )
+    initial_required = initial_parameter_value.required
+    # When `required` was never set, it must be added rather than updated; an
+    # `update` is rejected because there is no existing value to match against.
+    if initial_required is None:
+        return PGPatchDatum(
+            operation="add",
+            attribute="required",
+            newValue=updated_required,
+            rowId=updated_parameter_value.sequence,
+        )
     if initial_required == updated_required:
         return None
     return PGPatchDatum(

--- a/src/albert/utils/custom_fields.py
+++ b/src/albert/utils/custom_fields.py
@@ -38,6 +38,9 @@ def _generate_custom_field_patch_payload(
             continue
 
         if old_value is None and new_value is not None:
+            # Scalar attributes use `update` (not `add`, which the backend rejects).
+            # When the attribute is not currently set there is no value to match,
+            # so `oldValue` is omitted entirely.
             operation = (
                 PatchOperation.UPDATE
                 if alias in ("hidden", "search", "lkpColumn", "lkpRow")
@@ -47,7 +50,6 @@ def _generate_custom_field_patch_payload(
                 PatchDatum(
                     attribute=alias,
                     operation=operation,
-                    old_value=False if operation == PatchOperation.UPDATE else None,
                     new_value=new_value,
                 )
             )

--- a/tests/collections/test_custom_fields.py
+++ b/tests/collections/test_custom_fields.py
@@ -297,6 +297,24 @@ def test_update_custom_field_type_list(client: Albert):
             client.custom_fields.delete(id=custom_field.id)
 
 
+def test_update_searchable_on_unset_field(client: Albert):
+    """Test enabling searchable on a field where it was never set."""
+    custom_field = CustomField(
+        name=f"test_searchable_{uuid4().hex[:12]}",
+        field_type=FieldType.STRING,
+        service=ServiceType.PROJECTS,
+        display_name="Searchable Unset Field",
+    )
+    created = client.custom_fields.create(custom_field=custom_field)
+    try:
+        assert not created.searchable
+        created.searchable = True
+        updated = client.custom_fields.update(custom_field=created)
+        assert updated.searchable is True
+    finally:
+        client.custom_fields.delete(id=created.id)
+
+
 def test_delete_custom_field(client: Albert):
     """Test deleting a custom field by ID."""
     custom_field = CustomField(

--- a/tests/collections/test_entity_types.py
+++ b/tests/collections/test_entity_types.py
@@ -1,7 +1,7 @@
 from uuid import uuid4
 
 from albert import Albert
-from albert.resources.entity_types import EntityType
+from albert.resources.entity_types import EntityType, EntityTypeSearchQueryStrings
 
 
 def test_entity_type_get_by_id(client: Albert, seeded_entity_types: list[EntityType]):
@@ -48,3 +48,17 @@ def test_entity_type_update(
     if entity_type.standard_field_required:
         assert updated.standard_field_required is not None
         assert updated.standard_field_required.notes == entity_type.standard_field_required.notes
+
+
+def test_update_adds_unset_search_query_string(
+    client: Albert, seeded_entity_types: list[EntityType]
+):
+    """Test setting a search query string that was not previously configured."""
+    entity_type = client.entity_types.get_by_id(id=seeded_entity_types[0].id)
+    assert entity_type.search_query_string is None
+
+    entity_type.search_query_string = EntityTypeSearchQueryStrings(DAT="status=active")
+    updated = client.entity_types.update(entity_type=entity_type)
+
+    assert updated.search_query_string is not None
+    assert updated.search_query_string.DAT == "status=active"


### PR DESCRIPTION
## Summary
- **custom_fields**: when setting a previously-unset scalar attribute (`search`/`hidden`/`lkpColumn`/`lkpRow`), omit `oldValue` and keep the `update` operation. The backend rejects a fabricated `oldValue` (`OLD_VALUE_MISMATCH` 400) when there is no current value to match — the root cause of being unable to toggle a default custom field's searchable flag.
- **parameter_groups / data_templates**: emit `add` (no `oldValue`) for a parameter's `required` flag when it was never set, and `update` only when a current value exists. Both backends require `add` for an unset field and reject `update` ("required is not set").
- **entity_types**: add unset nested keys (`standardFieldVisibility.*`, `standardFieldRequired.*`, `searchQueryString.*`) instead of updating them — the backend rejects an `update` on a path that does not already exist.

All three are the same class of fix: choosing `add` vs `update` based on whether the value currently exists, verified against the live backend PATCH handlers.