### PR TITLE
fix(metadata): replace list-valued metadata in a single update

### DIFF
--- a/src/albert/collections/base.py
+++ b/src/albert/collections/base.py
@@ -72,28 +72,30 @@ class BaseCollection:
                         )
                     )
                 elif isinstance(updated_metadata[key], list):
-                    existing_id = {v.id for v in value} if isinstance(value, list) else {value.id}
-                    updated_id = {v.id for v in updated_metadata[key]}
-                    to_add = list(updated_id - existing_id)
-                    to_remove = list(existing_id - updated_id)
-                    if len(to_add + to_remove) == 0:  # if there are no changes, skip
+                    existing_ids = [v.id for v in value] if isinstance(value, list) else [value.id]
+                    updated_ids = [v.id for v in updated_metadata[key]]
+                    if set(existing_ids) == set(updated_ids):  # no membership change, skip
                         continue
 
-                    # Handle additions and removals separately to avoid conflicts
-
-                    if len(to_remove) > 0:
+                    if len(updated_ids) == 0:
+                        # Clearing the value entirely.
                         data.append(
                             PatchDatum(
                                 attribute=attribute,
                                 operation=PatchOperation.DELETE,
-                                old_value=to_remove,
+                                old_value=existing_ids,
                             )
                         )
-
-                    if len(to_add) > 0:
+                    else:
+                        # Replace the whole list in a single update. Emitting a
+                        # delete followed by an add would briefly leave the field
+                        # empty, which the backend rejects for required fields.
                         data.append(
                             PatchDatum(
-                                attribute=attribute, operation=PatchOperation.ADD, new_value=to_add
+                                attribute=attribute,
+                                operation=PatchOperation.UPDATE,
+                                old_value=existing_ids,
+                                new_value=updated_ids,
                             )
                         )
                 else:

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -100,7 +100,7 @@ def test_update_list_metadata_reassignment(
     static_lists: list[ListItem],
 ):
     """Test reassigning a list-valued metadata field to a different EntityLink."""
-    task = [x for x in seeded_tasks if "metadata" in x.name.lower()][0]
+    task = [x for x in seeded_tasks if "list metadata reassignment" in x.name.lower()][0]
 
     # Find a list-valued metadata key (value is a list of EntityLinks).
     list_key = next(

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -94,6 +94,32 @@ def test_update(
     make_metadata_update_assertions(new_metadata=new_metadata, updated_object=updated_task)
 
 
+def test_update_list_metadata_reassignment(
+    client: Albert,
+    seeded_tasks,
+    static_lists: list[ListItem],
+):
+    """Test reassigning a list-valued metadata field to a different EntityLink."""
+    task = [x for x in seeded_tasks if "metadata" in x.name.lower()][0]
+
+    # Find a list-valued metadata key (value is a list of EntityLinks).
+    list_key = next(
+        key for key, value in task.metadata.items() if isinstance(value, list) and value
+    )
+    current_ids = {link.id for link in task.metadata[list_key]}
+
+    # Swap in a different list item of the same list type.
+    replacement = next(
+        item for item in static_lists if item.list_type == list_key and item.id not in current_ids
+    )
+    task.metadata[list_key] = [replacement.to_entity_link()]
+
+    updated_task = client.tasks.update(task=task)
+
+    updated_ids = {link.id for link in updated_task.metadata[list_key]}
+    assert updated_ids == {replacement.id}
+
+
 def test_add_block(client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates):
     task = [x for x in seeded_tasks if isinstance(x, PropertyTask)][0]
     starting_blocks = len(task.blocks)

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -1658,7 +1658,21 @@ def generate_task_seeds(
             priority=TaskPriority.HIGH,
             due_date="2024-10-31",
             location=seeded_locations[1],
-            metadata=faux_metadata,
+            metadata=dict(faux_metadata),
+        ),
+        # General Task 2 - dedicated to list-metadata reassignment testing
+        GeneralTask(
+            name=f"{seed_prefix} - General Task with list metadata reassignment",
+            category=TaskCategory.GENERAL,
+            inventory_information=[
+                TaskInventoryInformation(
+                    inventory_id=seeded_inventory[2].id,
+                )
+            ],
+            priority=TaskPriority.HIGH,
+            due_date="2024-10-31",
+            location=seeded_locations[1],
+            metadata=dict(faux_metadata),
         ),
         # Batch Task 1
         # Use the Formulations used in #tests/resources/test_sheets/py defined as seeded_products


### PR DESCRIPTION
## Summary
- Reassigning a list-valued metadata key (e.g. a `List[EntityLink]`) previously emitted a `delete` followed by an `add`. The intermediate `delete` briefly empties the field, which the backend rejects for **required** custom fields (`"<field> is a required field and should have some value"`) — so the value could not be changed via `update()`.
- Now a changed list is sent as a single `update` (full old list → full new list), matching what the UI does. Clearing to empty still uses `delete`; a brand-new key still uses `add`; an unchanged set is skipped.
- Verified against all metadata-bearing collection backends (tasks, cas, inventory, lots, projects, users, parameter_groups, data_templates, data_columns, parameters): `update` of `Metadata.<key>` is a full value replace with no oldValue-mismatch check. The fix sends the full old list as `oldValue`, satisfying the only two backends that require it to be present (cas, lots).