### PR TITLE
fix(exceptions): make AlbertHTTPError picklable for Ray/multiprocessing contexts

### DIFF
--- a/src/albert/exceptions.py
+++ b/src/albert/exceptions.py
@@ -17,6 +17,20 @@ class AlbertAuthError(AlbertException):
     """Raised when authentication fails (e.g., bad credentials, expired token)."""
 
 
+def _restore_albert_http_error(cls: type, message: str) -> "AlbertHTTPError":
+    """Reconstruct an AlbertHTTPError from a pickled message string.
+
+    Python's default exception pickling stores args and calls __init__(*args)
+    on unpickle. AlbertHTTPError.__init__ expects a requests.Response, not a
+    string, so the default path fails. This function bypasses __init__ and
+    reconstructs the exception from the pre-formatted message alone.
+    """
+    exc = Exception.__new__(cls, message)
+    exc.message = message
+    exc.response = None
+    return exc
+
+
 class AlbertHTTPError(AlbertException):
     """Base class for all erors due to HTTP responses."""
 
@@ -24,6 +38,9 @@ class AlbertHTTPError(AlbertException):
         message = self._format_message(response)
         super().__init__(message)
         self.response = response
+
+    def __reduce__(self) -> tuple:
+        return (_restore_albert_http_error, (type(self), self.message))
 
     @classmethod
     def _format_message(cls, response: requests.Response) -> str:

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -1,0 +1,86 @@
+import json
+import pickle
+
+import pytest
+import requests
+
+from albert.exceptions import (
+    AlbertClientError,
+    AlbertHTTPError,
+    AlbertServerError,
+    BadRequestError,
+    ForbiddenError,
+    InternalServerError,
+    NotFoundError,
+    UnauthorizedError,
+)
+
+
+def _make_not_found_response() -> requests.Response:
+    """Simulate a 404 returned by the Albert API for a missing project resource."""
+    req = requests.PreparedRequest()
+    req.method = "GET"
+    req.url = "https://app.albertinvent.com/api/v3/projects/PRJ0001"
+    req.body = None
+
+    resp = requests.Response()
+    resp.status_code = 404
+    resp.reason = "Not Found"
+    resp.request = req
+    resp._content = json.dumps({"errors": "Not Found"}).encode()
+    resp.encoding = "utf-8"
+    return resp
+
+
+@pytest.mark.parametrize(
+    "exc_cls",
+    [
+        AlbertHTTPError,
+        AlbertClientError,
+        BadRequestError,
+        UnauthorizedError,
+        ForbiddenError,
+        NotFoundError,
+        AlbertServerError,
+        InternalServerError,
+    ],
+)
+def test_albert_http_error_is_picklable(exc_cls):
+    """Test that AlbertHTTPError and all subclasses survive a pickle round-trip.
+
+    Python's default exception pickling stores args and calls __init__(*args) on
+    unpickle. AlbertHTTPError.__init__ expects a requests.Response, not a string,
+    so the default path raises AttributeError. __reduce__ fixes this by
+    reconstructing from the pre-formatted message string instead.
+    """
+    try:
+        raise exc_cls(_make_not_found_response())
+    except exc_cls as exc:
+        original_message = exc.message
+        restored = pickle.loads(pickle.dumps(exc))
+
+    assert type(restored) is exc_cls
+    assert restored.message == original_message
+
+
+def test_pickle_preserves_message_content():
+    """Test that the Albert API URL, status code, and error body survive pickling."""
+    try:
+        raise NotFoundError(_make_not_found_response())
+    except NotFoundError as exc:
+        restored = pickle.loads(pickle.dumps(exc))
+
+    assert "404" in restored.message
+    assert "Not Found" in restored.message
+    assert "/api/v3/projects/PRJ0001" in restored.message
+
+
+def test_pickle_sets_response_to_none():
+    """Test that response is None after pickling — requests.Response is not serializable."""
+    try:
+        raise NotFoundError(_make_not_found_response())
+    except NotFoundError as exc:
+        assert exc.response is not None
+        restored = pickle.loads(pickle.dumps(exc))
+
+    assert restored.response is None


### PR DESCRIPTION
## What

`AlbertHTTPError` and all its subclasses now survive a `pickle` round-trip. The exception's message is preserved; `response` is set to `None` after unpickling (since `requests.Response` is not serializable).

## Why

The breakthrough/Zeus backend dispatches work to remote Ray workers. Ray serializes exceptions across process boundaries using pickle. `AlbertHTTPError.__init__` takes a `requests.Response` object, but Python's default exception pickling stores `args=(message,)` and calls `__init__(message)` on reconstruction -- causing `AttributeError: 'str' object has no attribute 'json'`. This surfaced as a `RaySystemError: Failed to unpickle serialized exception` in CI, masking the real error and blocking recovery in integration tests.

## How

- Added `__reduce__` to `AlbertHTTPError` returning `(_restore_albert_http_error, (type(self), self.message))`. This bypasses `__init__` entirely on unpickle.
- `_restore_albert_http_error` uses `Exception.__new__(cls, message)` to construct the instance without calling `__init__` -- the same pattern already used in `handle_async_http_errors` in the same file.
- All subclasses inherit `__reduce__` and are covered automatically.

## Testing

10 new unit tests in `tests/test_exceptions.py`:

```bash
uv run pytest tests/test_exceptions.py -v
```

Parametrized over all 8 `AlbertHTTPError` subclasses -- each is raised with a realistic 404 response and round-tripped through `pickle.dumps`/`pickle.loads`. Tests verify type is preserved, message content survives, and `response` is `None` after unpickling.