### PR TITLE
fix(property-data): accept numeric values in TaskPropertyCreate.value

### DIFF
--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -347,6 +347,8 @@ class TaskPropertyCreate(BaseResource):
     @field_validator("value", mode="before")
     @classmethod
     def coerce_numeric_value(cls, v):
+        if isinstance(v, bool):
+            raise ValueError("Boolean values are not supported for TaskPropertyCreate.value.")
         if isinstance(v, int | float):
             return str(v)
         return v

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -321,11 +321,11 @@ class TaskPropertyCreate(BaseResource):
     data_column: TaskDataColumn = Field(
         alias="DataColumns", description="The data column associated with the task property."
     )
-    value: str | ImagePropertyValue | CurvePropertyValue | None = Field(
+    value: str | int | float | ImagePropertyValue | CurvePropertyValue | None = Field(
         default=None,
         description=(
             "The value of the task property. Use ImagePropertyValue for image data columns or "
-            "CurvePropertyValue for curve data columns."
+            "CurvePropertyValue for curve data columns. Numeric values are coerced to strings."
         ),
     )
     trial_number: int = Field(
@@ -343,6 +343,13 @@ class TaskPropertyCreate(BaseResource):
         default=None,
         description="Can be used to set the relative row number, allowing you to pass multiple rows of data at once.",
     )
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def coerce_numeric_value(cls, v):
+        if isinstance(v, int | float):
+            return str(v)
+        return v
 
     @model_validator(mode="after")
     def set_visible_trial_number(self) -> TaskPropertyCreate:


### PR DESCRIPTION
`TaskPropertyCreate.value` was typed `str | ImagePropertyValue | CurvePropertyValue | None`, rejecting `int` and `float` inputs at construction time.

The Albert API expects all property values as strings. Numeric inputs are now coerced to `str` via a `field_validator` before validation, so callers can pass `value=42` or `value=3.14` directly without manual conversion.