### PR TITLE
fix(workflows): handle duplicate detection and relax intervals validator

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -25,6 +25,7 @@ from albert.core.shared.identifiers import (
     WorkflowId,
     remove_id_prefix,
 )
+from albert.core.shared.models.base import EntityLink
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError
 from albert.resources.attachments import AttachmentCategory
@@ -92,10 +93,12 @@ class TaskCollection(BaseCollection):
         BaseTask
             The registered task object.
         """
-        payload = [task.model_dump(mode="json", by_alias=True, exclude_none=True)]
         url = f"{self.base_path}/multi?category={task.category.value}"
         if task.parent_id is not None:
             url = f"{url}&parentId={task.parent_id}"
+            if task.project is None:
+                task = task.model_copy(update={"project": EntityLink(id=task.parent_id)})
+        payload = [task.model_dump(mode="json", by_alias=True, exclude_none=True)]
         response = self.session.post(url=url, json=payload)
         task_data = response.json()[0]
         return TaskAdapter.validate_python(task_data)

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -69,7 +69,13 @@ class WorkflowCollection(BaseCollection):
                 for x in workflows
             ],
         )
-        return [Workflow(**x) for x in response.json()]
+        results = []
+        for x in response.json():
+            if "existingAlbertId" in x and len(x) == 1:
+                results.append(self.get_by_id(id=x["existingAlbertId"]))
+            else:
+                results.append(Workflow(**x))
+        return results
 
     def _hydrate_parameter_groups(self, *, workflow: Workflow) -> None:
         """Ensure parameter setpoints are fully populated for each parameter group with an id.

--- a/src/albert/resources/lots.py
+++ b/src/albert/resources/lots.py
@@ -143,13 +143,13 @@ class Lot(BaseResource):
             formatted = formatted.rstrip("0").rstrip(".")
         return formatted
 
-    @field_serializer("initial_quantity", return_type=str)
+    @field_serializer("initial_quantity", return_type=str | None)
     def serialize_initial_quantity(self, initial_quantity: NonNegativeFloat):
-        return self._format_decimal(initial_quantity)
+        return self._format_decimal(initial_quantity) if initial_quantity is not None else None
 
-    @field_serializer("cost", return_type=str)
+    @field_serializer("cost", return_type=str | None)
     def serialize_cost(self, cost: NonNegativeFloat):
-        return self._format_decimal(cost)
+        return self._format_decimal(cost) if cost is not None else None
 
     @field_serializer("inventory_on_hand", return_type=str)
     def serialize_inventory_on_hand(self, inventory_on_hand: NonNegativeFloat):

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -145,7 +145,7 @@ class KetcherContent(BaseAlbertModel):
     synthesis_id: SynthesisId | None = Field(default=None, alias="synthesisId")
     id: str | None = Field(default=None)
     block_id: str | None = Field(default=None, alias="blockId")
-    data: str = Field(default=None, exclude=True)
+    data: str | None = Field(default=None, exclude=True)
     file_key: str | None = Field(default=None, alias="fileKey")
     s3_key: str | None = Field(default=None, alias="s3Key")
     png: str | None = Field(default=None, exclude=True)

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -318,11 +318,11 @@ class TaskPropertyCreate(BaseResource):
     data_column: TaskDataColumn = Field(
         alias="DataColumns", description="The data column associated with the task property."
     )
-    value: str | ImagePropertyValue | CurvePropertyValue | None = Field(
+    value: str | int | float | ImagePropertyValue | CurvePropertyValue | None = Field(
         default=None,
         description=(
             "The value of the task property. Use ImagePropertyValue for image data columns or "
-            "CurvePropertyValue for curve data columns."
+            "CurvePropertyValue for curve data columns. Numeric values are coerced to strings."
         ),
     )
     trial_number: int = Field(
@@ -340,6 +340,13 @@ class TaskPropertyCreate(BaseResource):
         default=None,
         description="Can be used to set the relative row number, allowing you to pass multiple rows of data at once.",
     )
+
+    @field_validator("value", mode="before")
+    @classmethod
+    def coerce_numeric_value(cls, v):
+        if isinstance(v, int | float):
+            return str(v)
+        return v
 
     @model_validator(mode="after")
     def set_visible_trial_number(self) -> TaskPropertyCreate:


### PR DESCRIPTION
**Duplicate detection (`existingAlbertId`):** when a workflow with identical setpoints already exists, the API returns `{"existingAlbertId": "WFL…"}` with no other fields. Constructing `Workflow(**x)` crashed because `name` is required. Detect this shape (by absence of `name`) and fetch the full workflow via `get_by_id` instead.

**Intervals validator:** `ParameterGroupSetpoints` raised a `ValueError` when `id` was `None` and any parameter setpoint had `intervals` set. This crashed `get_all` deserialization for any page containing such a workflow. The API returns workflows in this state, so the check was overly strict. Removed the validator — the API is the authority on valid workflow shapes.