### PR TITLE
fix(workflows): handle duplicate detection and relax intervals validator

### DIFF
--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -69,7 +69,13 @@ class WorkflowCollection(BaseCollection):
                 for x in workflows
             ],
         )
-        return [Workflow(**x) for x in response.json()]
+        results = []
+        for x in response.json():
+            if "existingAlbertId" in x and len(x) == 1:
+                results.append(self.get_by_id(id=x["existingAlbertId"]))
+            else:
+                results.append(Workflow(**x))
+        return results
 
     def _hydrate_parameter_groups(self, *, workflow: Workflow) -> None:
         """Ensure parameter setpoints are fully populated for each parameter group with an id.

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -71,7 +71,7 @@ class WorkflowCollection(BaseCollection):
         )
         results = []
         for x in response.json():
-            if "existingAlbertId" in x and len(x) == 1:
+            if "existingAlbertId" in x and "name" not in x:
                 results.append(self.get_by_id(id=x["existingAlbertId"]))
             else:
                 results.append(Workflow(**x))

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -250,14 +250,6 @@ class ParameterGroupSetpoints(BaseAlbertModel):
         if self.parameter_group is not None and self.id is None:
             object.__setattr__(self, "id", self.parameter_group.id)
 
-        if self.id is None:
-            # For workflows created without a PRG/DT id, intervals are not allowed.
-            for sp in self.parameter_setpoints:
-                if sp.intervals is not None:
-                    raise ValueError(
-                        f"Parameter {sp.parameter_id}: Intervals are not allowed when the Parameter Group has no 'id'."
-                    )
-
         return self
 
 


### PR DESCRIPTION
**Duplicate detection (`existingAlbertId`):** when a workflow with identical setpoints already exists, the API returns `{"existingAlbertId": "WFL…"}` with no other fields. Constructing `Workflow(**x)` crashed because `name` is required. Detect this shape (by absence of `name`) and fetch the full workflow via `get_by_id` instead.

**Intervals validator:** `ParameterGroupSetpoints` raised a `ValueError` when `id` was `None` and any parameter setpoint had `intervals` set. This crashed `get_all` deserialization for any page containing such a workflow. The API returns workflows in this state, so the check was overly strict. Removed the validator — the API is the authority on valid workflow shapes.