### PR TITLE
feat(session): add configurable request timeout

### DIFF
--- a/src/albert/client.py
+++ b/src/albert/client.py
@@ -81,6 +81,11 @@ class Albert:
         Ignored if `token` is provided.
     retries : int, optional
         Maximum number of retries for failed HTTP requests.
+    timeout : float | tuple[float, float], optional
+        Default timeout in seconds applied to every request. Accepts a single
+        float (applied to both connect and read) or a ``(connect, read)`` tuple.
+        When ``None`` (the default), requests can block indefinitely. Ignored if
+        `session` is provided.
     session : AlbertSession, optional
         A fully configured session instance. If provided, `base_url`, `token`, and `auth_manager`
         are all ignored.
@@ -112,6 +117,7 @@ class Albert:
         token: str | None = None,
         auth_manager: AlbertClientCredentials | AlbertSSOClient | None = None,
         retries: int | None = None,
+        timeout: float | tuple[float, float] | None = None,
         session: AlbertSession | None = None,
     ):
         if auth_manager and base_url and base_url != auth_manager.base_url:
@@ -128,12 +134,19 @@ class Albert:
             token=token or os.getenv("ALBERT_TOKEN"),
             auth_manager=auth_manager,
             retries=retries,
+            timeout=timeout,
         )
 
     @classmethod
-    def from_token(cls, *, base_url: str | None, token: str) -> Albert:
+    def from_token(
+        cls,
+        *,
+        base_url: str | None,
+        token: str,
+        timeout: float | tuple[float, float] | None = None,
+    ) -> Albert:
         """Create an Albert client using a static token for authentication."""
-        return cls(base_url=base_url, token=token)
+        return cls(base_url=base_url, token=token, timeout=timeout)
 
     @classmethod
     def from_sso(
@@ -144,12 +157,13 @@ class Albert:
         port: int = 5000,
         tenant_id: str | None = None,
         retries: int | None = None,
+        timeout: float | tuple[float, float] | None = None,
     ) -> Albert:
         """Create an Albert client using interactive OAuth2 SSO login."""
         resolved_base_url = base_url or default_albert_base_url()
         oauth = AlbertSSOClient(base_url=resolved_base_url, email=email)
         oauth.authenticate(minimum_port=port, tenant_id=tenant_id)
-        return cls(auth_manager=oauth, retries=retries)
+        return cls(auth_manager=oauth, retries=retries, timeout=timeout)
 
     @classmethod
     def from_client_credentials(
@@ -159,6 +173,7 @@ class Albert:
         client_id: str,
         client_secret: str,
         retries: int | None = None,
+        timeout: float | tuple[float, float] | None = None,
     ) -> Albert:
         """Create an Albert client using client credentials authentication."""
         resolved_base_url = base_url or default_albert_base_url()
@@ -167,7 +182,7 @@ class Albert:
             secret=SecretStr(client_secret),
             base_url=resolved_base_url,
         )
-        return cls(auth_manager=creds, retries=retries)
+        return cls(auth_manager=creds, retries=retries, timeout=timeout)
 
     @property
     def projects(self) -> ProjectCollection:

--- a/src/albert/core/session.py
+++ b/src/albert/core/session.py
@@ -27,6 +27,12 @@ class AlbertSession(requests.Session):
         If provided, it overrides `token`.
     retries : int, optional
         The number of automatic retries on failed requests (default is 3).
+    timeout : float | tuple[float, float], optional
+        Default timeout in seconds applied to every request. Accepts a single
+        float (applied to both connect and read) or a ``(connect, read)`` tuple.
+        When ``None`` (the default), requests have no timeout and can block
+        indefinitely. A per-call ``timeout`` passed to a request always takes
+        precedence.
     """
 
     def __init__(
@@ -36,9 +42,11 @@ class AlbertSession(requests.Session):
         token: str | None = None,
         auth_manager: AlbertClientCredentials | AlbertSSOClient | None = None,
         retries: int | None = None,
+        timeout: float | tuple[float, float] | None = None,
     ):
         super().__init__()
         self.base_url = base_url
+        self._timeout = timeout
         self.headers.update(
             {
                 "Content-Type": "application/json",
@@ -76,6 +84,7 @@ class AlbertSession(requests.Session):
 
     def request(self, method: str, path: str, *args, **kwargs) -> requests.Response:
         self.headers["Authorization"] = f"Bearer {self._access_token}"
+        kwargs.setdefault("timeout", self._timeout)
         full_url = urljoin(self.base_url, path) if not path.startswith("http") else path
         params = self._encode_query_params(kwargs.pop("params", None) or {})
         # The requests library internally uses urllib.parse.urlencode() with the quote_via parameter set to quote_plus, which breaks CAS pagination.


### PR DESCRIPTION
## Problem

`AlbertSession` (the sync client's session) makes every request with no timeout, so requests inherit the `requests` default of `None` (block forever). A hung or unreachable backend can therefore block a caller indefinitely, with no way to set a session-wide deadline.

This surfaced from a react-worker investigation (Albert AI, AI-820): the worker runs sync SDK calls on a bounded thread pool, and an unbounded call permanently parks a thread. Milvus calls were bounded directly, but the SDK is the other unbounded blocking surface, and `requests` offers no session-level timeout to fix it from the outside.

## Change

Add an optional `timeout` to `AlbertSession.__init__`, stored as `self._timeout`, and apply it in `request()` via `kwargs.setdefault("timeout", self._timeout)` so an explicit per-call `timeout` still wins. Thread the parameter through `Albert.__init__` and the `from_token`, `from_sso`, and `from_client_credentials` factories, mirroring how `retries` is already plumbed.

The default stays `None`, so behavior is unchanged unless a caller opts in. A consumer can now do:

```python
Albert.from_token(base_url=..., token=..., timeout=30.0)
```

## Why this approach

`requests` has no session-level timeout: `requests.Session()` takes no `timeout` and stores none. `timeout` exists only as a per-request argument. So the idiomatic way to get a session-wide deadline is to hold a default on the session and apply it per request, which is what this does.

## Scope

Sync client only. The async client (`AsyncAlbert`) runs on `httpx`, which already applies a default timeout, so it is bounded. Adding an explicit `timeout` knob there for parity is a reasonable follow-up but is out of scope here.

## Caveat for consumers

The `requests` timeout is per attempt, and the session's retry policy multiplies it. Worst-case wall clock is roughly `(1 + retries) * timeout + backoff`. Verified empirically: a `timeout=2` against an unroutable host with the default 3 retries raised after ~9.8s, not 2s. The call is bounded and self-freeing, just not a flat `timeout`. Pair a lower retry count with the timeout if a tighter ceiling is needed.

## Testing

Repo policy is integration-style tests only (no `FakeAlbertSession` unit tests), and a timeout default is not cleanly assertable against a live API, so no new test is added. The mechanism was verified manually against an unroutable host:
- session-level `timeout` propagates to the socket (raised at the configured per-attempt deadline),
- a per-call `timeout` still overrides the session default.

`ruff format` and `ruff check` pass on the touched files.


---

This PR contains AI-assisted code generated with Claude Code. The author has reviewed and takes full responsibility for all changes.
