### PR TITLE
test(cas,substance): tighten filter and CAS ID assertions

### DIFF
--- a/tests/collections/test_cas.py
+++ b/tests/collections/test_cas.py
@@ -35,6 +35,7 @@ def test_cas_get_all_with_filters(client: Albert):
 
     multi_cas = list(client.cas_numbers.get_all(cas=[existing.number]))
     assert_valid_cas_items(multi_cas)
+    assert any(c.number == existing.number for c in multi_cas)
 
 
 def test_cas_not_found(client: Albert):

--- a/tests/collections/test_substance.py
+++ b/tests/collections/test_substance.py
@@ -23,7 +23,9 @@ def test_get_by_ids(client: Albert):
     ]
     substances = client.substances.get_by_ids(cas_ids=cas_ids)
     assert isinstance(substances, list)
-    assert len(substances) >= len(cas_ids)
+    returned_cas_ids = {s.cas_id for s in substances}
+    for cas_id in cas_ids:
+        assert cas_id in returned_cas_ids
     for substance in substances:
         assert isinstance(substance, SubstanceInfo)
 


### PR DESCRIPTION
## Summary
- `test_cas_get_all_with_filters`: after filtering by CAS number, now asserts the expected number actually appears in results (not just that the list is valid)
- `test_get_by_ids`: replaces loose `>= count` check with a membership check that verifies every requested CAS ID is present in the response