### PR TITLE
fix(tasks): mirror parent_id to Project body on create when absent

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -96,7 +96,7 @@ class TaskCollection(BaseCollection):
         url = f"{self.base_path}/multi?category={task.category.value}"
         if task.parent_id is not None:
             url = f"{url}&parentId={task.parent_id}"
-        if isinstance(task, BatchTask) and task.parent_id is not None and "Project" not in payload:
+        if task.parent_id is not None:
             payload["Project"] = {"id": task.parent_id}
         response = self.session.post(url=url, json=[payload])
         task_data = response.json()[0]

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -92,11 +92,13 @@ class TaskCollection(BaseCollection):
         BaseTask
             The registered task object.
         """
-        payload = [task.model_dump(mode="json", by_alias=True, exclude_none=True)]
+        payload = task.model_dump(mode="json", by_alias=True, exclude_none=True)
         url = f"{self.base_path}/multi?category={task.category.value}"
         if task.parent_id is not None:
             url = f"{url}&parentId={task.parent_id}"
-        response = self.session.post(url=url, json=payload)
+        if isinstance(task, BatchTask) and task.parent_id is not None and "Project" not in payload:
+            payload["Project"] = {"id": task.parent_id}
+        response = self.session.post(url=url, json=[payload])
         task_data = response.json()[0]
         return TaskAdapter.validate_python(task_data)
 

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -96,7 +96,11 @@ class TaskCollection(BaseCollection):
         url = f"{self.base_path}/multi?category={task.category.value}"
         if task.parent_id is not None:
             url = f"{url}&parentId={task.parent_id}"
-        if task.parent_id is not None:
+        if (
+            task.parent_id is not None
+            and "Project" not in payload
+            and task.parent_id.startswith("PRO")
+        ):
             payload["Project"] = {"id": task.parent_id}
         response = self.session.post(url=url, json=[payload])
         task_data = response.json()[0]

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -247,7 +247,7 @@ class PropertyTask(BaseTask):
     location : SerializeAsEntityLink[Location]
         The location where the property task is performed.
     parent_id : str
-        The ID of the parent project.
+        The ID of the parent inventory item.
     blocks : list[Block]
         A list of blocks associated with the property task.
     id : str, optional

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -247,7 +247,7 @@ class PropertyTask(BaseTask):
     location : SerializeAsEntityLink[Location]
         The location where the property task is performed.
     parent_id : str
-        The ID of the parent inventory item.
+        The ID of the parent project.
     blocks : list[Block]
         A list of blocks associated with the property task.
     id : str, optional


### PR DESCRIPTION
## What

General and property task creates with `parent_id` set to a project ID now automatically include the `Project` entity link in the POST body when callers omit `project`, so tasks are linked to the project on create.

## Why

Staging verification showed that without `Project` in the request body, General and Property tasks could be created with only a query `parentId` but were not associated with the project. Batch tasks already worked without this (the API backfills `Project` from the query param).

## How

Mirror `parent_id` into `Project.id` only when:
- `Project` is not already in the serialized payload (preserves property tasks that use `parent_id=inventory_id` with an explicit `project`), and
- `parent_id` starts with `PRO` (project ID, not inventory).

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_tasks.py -v`
- [x] Live staging repro (one-off): batch/general/property create scenarios with and without Project mirroring

## SDK Changes

Task creates with `parent_id` set to a project ID no longer require callers to also set `project` for General and Property tasks to be linked to that project.