### PR TITLE
fix(property-data): make PTD search result trial optional

### DIFF
--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -398,7 +398,7 @@ class PropertyDataResult(BaseAlbertModel):
     # This is not the actual PTD id it is the DAC this result is capturing
     data_column_id: DataColumnId = Field(..., alias="id")
     value: str | None = None
-    trial: str
+    trial: str | None = None
     value_string: str | None = Field(None, alias="valueString")
 
 


### PR DESCRIPTION
## Summary
- Backend removed `trial` from the property data search result schema ([api-propertydata#284](https://github.com/MoleculeEngineering/api-propertydata/pull/284)).
- `PropertyDataResult.trial` was required, so search responses missing the field raised a `ValidationError`. Made it optional (`str | None = None`).