### PR TITLE
fix(property-data): type PropertyDataResult.trial as Any

### DIFF
--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -398,7 +398,7 @@ class PropertyDataResult(BaseAlbertModel):
     # This is not the actual PTD id it is the DAC this result is capturing
     data_column_id: DataColumnId = Field(..., alias="id")
     value: str | None = None
-    trial: str | None = None
+    trial: Any = None
     value_string: str | None = Field(None, alias="valueString")
 
 


### PR DESCRIPTION
## Summary
- Backend PR 284 removed `trial` from the PTD result schema and it can now come back as any datatype, so the required `trial: str` field raised `ValidationError` on search responses.
- Retype `PropertyDataResult.trial` as `Any` (default `None`): accepts strings, numbers, or any type without failing, and avoids the type-specific whack-a-mole seen with `value` (#564).