### PR TITLE
test(lists): stop test_update mutating shared static_lists fixture

### DIFF
--- a/tests/collections/test_lists.py
+++ b/tests/collections/test_lists.py
@@ -45,9 +45,19 @@ def test_get_matching_id(client: Albert, static_lists: list[ListItem]):
 
 
 def test_update(client: Albert, static_lists: list[ListItem], seed_prefix: str):
-    updated_li = static_lists[-1]
-    new_name = f"{seed_prefix} new name"
-    updated_li.name = new_name
-    updated_list_item = client.lists.update(list_item=updated_li)
-    assert updated_list_item.name == new_name
-    assert updated_list_item.id == static_lists[-1].id
+    """Test updating a list item's name."""
+    source = static_lists[-1]
+    created = client.lists.create(
+        list_item=ListItem(
+            name=f"{seed_prefix} update target",
+            category=source.category,
+            list_type=source.list_type,
+        )
+    )
+    try:
+        created.name = f"{seed_prefix} new name"
+        updated_list_item = client.lists.update(list_item=created)
+        assert updated_list_item.name == f"{seed_prefix} new name"
+        assert updated_list_item.id == created.id
+    finally:
+        client.lists.delete(id=created.id)


### PR DESCRIPTION
## Summary
- `test_update` renamed `static_lists[-1]` in place, permanently mutating a session-scoped fixture reused across runs and by other seeders.
- On reruns the fixture's name-based `get_matching_item` fallback (eventually-consistent search) returned the already-renamed record, so `update()` built a stale `oldValue` and the server rejected the PATCH with `400 "Old Name mismatch"` — the flake.
- Fix: create a dedicated, seed-prefixed list item, update that, and delete it in a `finally` block. No shared state touched, no orphaned records left behind.