### PR TITLE
feat(notebooks): add append_blocks to safely add blocks

### DIFF
--- a/src/albert/collections/notebooks.py
+++ b/src/albert/collections/notebooks.py
@@ -210,6 +210,38 @@ class NotebookCollection(BaseCollection):
         return self.get_by_id(id=notebook.id)
 
     @validate_call
+    def append_blocks(self, *, id: NotebookId, blocks: list[NotebookBlock]) -> Notebook:
+        """Append blocks to the end of a Notebook, preserving existing blocks.
+
+        Parameters
+        ----------
+        id : str
+            The ID of the Notebook to append to.
+        blocks : list[NotebookBlock]
+            The blocks to append to the end of the Notebook.
+
+        Returns
+        -------
+        Notebook
+            The updated Notebook.
+
+        Examples
+        --------
+        !!! example "Append a paragraph block"
+            ```python
+            from albert.resources.notebooks import ParagraphBlock, ParagraphContent
+
+            notebook = client.notebooks.append_blocks(
+                id="NTB123",
+                blocks=[ParagraphBlock(content=ParagraphContent(text="Hello"))],
+            )
+            ```
+        """
+        notebook = self.get_by_id(id=id)
+        notebook.blocks.extend(blocks)
+        return self.update_block_content(notebook=notebook)
+
+    @validate_call
     def get_block_by_id(self, *, notebook_id: NotebookId, block_id: str) -> NotebookBlock:
         """Retrieve a Notebook Block by its ID.
 

--- a/src/albert/collections/notebooks.py
+++ b/src/albert/collections/notebooks.py
@@ -33,7 +33,39 @@ class _KetcherUpdateAction(BaseAlbertModel):
 
 
 class NotebookCollection(BaseCollection):
-    """NotebookCollection is a collection class for managing Notebook entities in the Albert platform."""
+    """NotebookCollection manages Notebook entities in the Albert platform.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The Albert session instance.
+
+    Attributes
+    ----------
+    base_path : str
+        The base URL for notebook API requests.
+
+    Methods
+    -------
+    get_by_id(id) -> Notebook
+        Retrieves a notebook by its ID.
+    list_by_parent_id(parent_id) -> list[Notebook]
+        Lists notebooks for a given parent (task or project).
+    create(notebook) -> Notebook
+        Creates or returns a notebook.
+    delete(id) -> None
+        Deletes a notebook by its ID.
+    update(notebook) -> Notebook
+        Updates a notebook's name.
+    update_block_content(notebook) -> Notebook
+        Updates the block content of a notebook.
+    append_blocks(id, blocks) -> Notebook
+        Appends blocks to a notebook, preserving existing blocks.
+    get_block_by_id(notebook_id, block_id) -> NotebookBlock
+        Retrieves a notebook block by its ID.
+    copy(notebook_copy_info, type) -> Notebook
+        Copies a notebook into a specified parent.
+    """
 
     _api_version = "v3"
     _updatable_attributes = {"name"}

--- a/tests/collections/test_notebooks.py
+++ b/tests/collections/test_notebooks.py
@@ -63,6 +63,18 @@ def test_update_block_content_with_reorder(client: Albert, seeded_notebook: Note
         assert updated.content == existing.content
 
 
+def test_append_blocks(client: Albert, seeded_notebook: Notebook):
+    """Test appending blocks preserves existing blocks."""
+    existing_ids = [b.id for b in seeded_notebook.blocks]
+    new_block = ParagraphBlock(content=ParagraphContent(text="Appended block."))
+
+    updated_notebook = client.notebooks.append_blocks(id=seeded_notebook.id, blocks=[new_block])
+
+    updated_ids = [b.id for b in updated_notebook.blocks]
+    assert updated_ids[: len(existing_ids)] == existing_ids
+    assert updated_notebook.blocks[-1].content.text == "Appended block."
+
+
 def test_update_block_content_with_empty_text(client: Albert, seeded_notebook: Notebook):
     # Ensure we can enter blocks with None Fields
     header_block = HeaderBlock(content=HeaderContent(level=1, text=None))


### PR DESCRIPTION
## Summary
- Adds `NotebookCollection.append_blocks(*, id, blocks)` to append blocks to a notebook without wiping existing content.
- Reads the notebook first, so existing blocks (including Ketcher `fileKey`/`s3Key`) are preserved rather than deleted by the content-diff PUT.
- Closes GAP 4 from the SDK gap audit (no `append_block`; manual read-modify-write silently dropped prior content).
- Adds `test_append_blocks` integration test; full notebooks suite passes against prod.