### PR TITLE
chore(hooks): add ruff format-on-edit and env/version guard hooks

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,27 @@
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '[.tool_input.file_path, (.tool_input.new_string // .tool_input.content // \"\")] | @tsv' | { IFS=$'\\t' read -r f body; case \"$f\" in *.env|*.env.*) echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Editing .env files is blocked (secrets).\"}}'; exit 0;; esac; case \"$f\" in */__init__.py|__init__.py|*/pyproject.toml|pyproject.toml) if printf '%s' \"$body\" | grep -Eq '(__version__|^version)[[:space:]]*='; then echo '{\"hookSpecificOutput\":{\"hookEventName\":\"PreToolUse\",\"permissionDecision\":\"deny\",\"permissionDecisionReason\":\"Version is owned by release-please; do not bump manually.\"}}'; fi;; esac; }"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path // .tool_response.filePath' | { read -r f; case \"$f\" in *.py) uv run ruff format \"$f\" && uv run ruff check --fix \"$f\";; esac; } 2>/dev/null || true",
+            "statusMessage": "ruff format + fix"
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -91,4 +91,5 @@ site/
 .vscode/launch.json
 
 # Claude Code
-.claude/
+.claude/*
+!.claude/settings.json


### PR DESCRIPTION
## Summary
- Add committed `.claude/settings.json` with two Claude Code hooks so anyone contributing via Claude Code inherits the same guardrails.
- **PostToolUse**: auto-runs `uv run ruff format` + `ruff check --fix` on every edited `.py`, enforcing the "after every code edit" rule in AGENTS.md.
- **PreToolUse**: blocks edits to `.env*` files (secrets) and manual version bumps in `__init__.py`/`pyproject.toml` (owned by release-please) before they're written.
- `.gitignore` now un-ignores `.claude/settings.json` while keeping `settings.local.json` and `worktrees/` ignored.