### PR TITLE
fix(inventory): dedup when company is an entity link

### DIFF
--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -137,18 +137,27 @@ class InventoryCollection(BaseCollection):
         InventoryItem or None
             The matching inventory item, or None if no match is found.
         """
-        inv_company = (
-            inventory_item.company.name
-            if isinstance(inventory_item.company, Company)
-            else inventory_item.company
-        )
+        company = inventory_item.company
+        company_id = company.id if company is not None else None
+        company_name = company.name if company is not None else None
 
         hits = self.get_all(
-            text=inventory_item.name, company=[inventory_item.company], max_items=100
+            text=inventory_item.name,
+            company=[company] if isinstance(company, Company) else None,
+            max_items=100,
         )
 
         for inv in hits:
-            if inv and inv.name == inventory_item.name and inv.company.name == inv_company:
+            if inv.name != inventory_item.name:
+                continue
+            inv_company = inv.company
+            # Prefer matching on company id; fall back to name when the id is
+            # unavailable (e.g. an unsaved Company passed without an id).
+            if company_id is not None:
+                matched = inv_company is not None and inv_company.id == company_id
+            else:
+                matched = (inv_company.name if inv_company else None) == company_name
+            if matched:
                 return inv
         return None
 

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -173,6 +173,20 @@ def test_blocks_dupes(caplog, client: Albert, seeded_inventory: list[InventoryIt
     )
 
 
+def test_blocks_dupes_with_entity_link_company(
+    client: Albert, seeded_inventory: list[InventoryItem]
+):
+    """Test duplicate detection when the company is provided as an entity link."""
+    original = seeded_inventory[0]
+    ii_copy = original.model_copy(
+        update={"id": None, "company": original.company.to_entity_link()}
+    )
+    returned_ii = client.inventory.create(inventory_item=ii_copy)
+
+    assert returned_ii.id == original.id
+    assert returned_ii.name == original.name
+
+
 def test_add_property_to_inv_spec(
     seed_prefix: str,
     client: Albert,


### PR DESCRIPTION
## Summary
- `InventoryCollection.get_match_or_none` passed an `EntityLink` company directly to `get_all(company=[...])`, which is typed `list[Company]` and rejects it — duplicate detection failed whenever the company was an entity link 
- Now matches on company **id** (falling back to **name** when the id is unavailable, e.g. an unsaved `Company`) and only forwards a `Company` to the server-side filter.
- Adds `test_blocks_dupes_with_entity_link_company`; both dedup tests pass against prod.