### PR TITLE
fix: add attachments field to ChatMessage

### DIFF
--- a/src/albert/resources/chats.py
+++ b/src/albert/resources/chats.py
@@ -83,6 +83,33 @@ class ChatSession(BaseResource):
     last_message_at: str | None = Field(default=None, alias="lastMessageAt")
 
 
+class ChatMessageAttachment(BaseAlbertModel):
+    """A compact reference to a file attached to a chat message.
+
+    Records which files arrived with a message so the transcript can render them.
+    Carries display metadata only, never file content or signed URLs.
+
+    Attributes
+    ----------
+    file_id : str
+        The attachment (ATT) ID of the file.
+    title : str
+        The file's display name.
+    kind : str
+        The file kind (e.g. ``pdf``, ``image``, ``workbook``, ``csv``).
+    size_bytes : int | None
+        The file size in bytes.
+    parts_summary : str | None
+        A human-readable description of the file's structure (e.g. ``"34 pages"``).
+    """
+
+    file_id: str = Field(alias="fileId")
+    title: str
+    kind: str
+    size_bytes: int | None = Field(default=None, alias="sizeBytes")
+    parts_summary: str | None = Field(default=None, alias="partsSummary")
+
+
 class ChatMessage(BaseResource):
     """
     A single message component within a chat session.
@@ -120,6 +147,8 @@ class ChatMessage(BaseResource):
         Whether to show the feedback UI for this message.
     page_context : PageContext | None
         Embed page the user was viewing when they sent the message.
+    attachments : list[ChatMessageAttachment] | None
+        Files the user attached to this message, for display in the transcript.
     """
 
     id: str | None = Field(default=None)
@@ -138,6 +167,7 @@ class ChatMessage(BaseResource):
     display_feedback_component: bool | None = Field(default=None, alias="displayFeedbackComponent")
     value: list[dict] | None = Field(default=None)
     page_context: PageContext | None = Field(default=None, alias="pageContext")
+    attachments: list[ChatMessageAttachment] | None = Field(default=None)
 
 
 class ChatFolder(BaseResource):


### PR DESCRIPTION
## What
`ChatMessage` now round-trips a message's file attachments instead of
silently dropping them.

## Why
api-chat now returns an `attachments` array on chat messages (files a user
attached to that message), the same way it already returns `pageContext`.
Without this field the SDK strips the array on read, so any consumer
(including api-ai-ask's history proxy) never sees which files arrived with
a message.

## How
- Adds `ChatMessageAttachment` (`file_id`, `title`, `kind`, `size_bytes`,
  `parts_summary`), a compact display-only reference — never file content
  or signed URLs.
- Adds `ChatMessage.attachments: list[ChatMessageAttachment] | None`,
  wired the same way as the existing `page_context` field (camelCase wire
  aliases, `populate_by_name` so snake_case construction round-trips).
- Filed as `fix`, not `feat`, per this repo's convention: the field already
  exists in the API response, the SDK was just incomplete.

## Testing
`uv run ruff format --check .` and `uv run ruff check .` pass. `uv run
pytest tests/ -k chat` passes (2 passed, 15 skipped — skipped tests need
live `ALBERT_CLIENT_ID_SDK`/`ALBERT_CLIENT_SECRET_SDK`/`ALBERT_BASE_URL`
credentials per this repo's integration-only test convention). No new unit
tests added, matching the repo's policy of integration-only tests.