### PR TITLE
fix(parameter-groups): add missing timestamp DataType enum value

### DIFF
--- a/src/albert/resources/parameter_groups.py
+++ b/src/albert/resources/parameter_groups.py
@@ -32,6 +32,7 @@ class DataType(str, Enum):
     ENUM = "enum"
     IMAGE = "image"
     CURVE = "curve"
+    TIMESTAMP = "timestamp"
 
 
 class Operator(str, Enum):


### PR DESCRIPTION
## What

Adds `TIMESTAMP = "timestamp"` to the `DataType` enum in `albert-python`, enabling the SDK to correctly deserialize data templates and parameter groups that use the `timestamp` datatype.

## Why

The Albert API returns `"timestamp"` as a valid `datatype` value for parameters and data columns, but the SDK's `DataType` enum did not include it. Any attempt to deserialize a data template or parameter group containing a `timestamp`-typed parameter would raise a validation error. This unblocks Zeus from deserializing timeseries-type parameters (ML-1444).

## How

- Single enum member added to `DataType` in `src/albert/resources/parameter_groups.py` — no other changes needed, as `DataType` is used purely for deserialization and the `timestamp` type has no special serialization or patch behavior distinct from other scalar types.

## Testing

Covered by existing integration tests. Manually verify by fetching a data template that contains a `timestamp` parameter and confirming it deserializes without a Pydantic validation error.