### PR TITLE
fix(ci): route manifest-file per target branch in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,22 +31,21 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             ${{ github.event.repository.name }}
-      - name: Set config file
+      - name: Set config and manifest files
         id: config
         env:
           TARGET_BRANCH: ${{ inputs.target_branch || github.ref_name }}
         run: |
           if [ "$TARGET_BRANCH" = "next" ]; then
-            echo "file=release-please-config-next.json" >> "$GITHUB_OUTPUT"
-            echo "versioning_strategy=prerelease" >> "$GITHUB_OUTPUT"
+            echo "config_file=release-please-config-next.json" >> "$GITHUB_OUTPUT"
+            echo "manifest_file=.release-please-manifest-next.json" >> "$GITHUB_OUTPUT"
           else
-            echo "file=release-please-config.json" >> "$GITHUB_OUTPUT"
-            echo "versioning_strategy=default" >> "$GITHUB_OUTPUT"
+            echo "config_file=release-please-config.json" >> "$GITHUB_OUTPUT"
+            echo "manifest_file=.release-please-manifest.json" >> "$GITHUB_OUTPUT"
           fi
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
-          release-type: python
           target-branch: ${{ inputs.target_branch || github.ref_name }}
-          config-file: ${{ steps.config.outputs.file }}
-          versioning-strategy: ${{ steps.config.outputs.versioning_strategy }}
+          config-file: ${{ steps.config.outputs.config_file }}
+          manifest-file: ${{ steps.config.outputs.manifest_file }}


### PR DESCRIPTION
## Summary
- main's release-please workflow always used the default `.release-please-manifest.json`, ignoring `target_branch` — next's workflow correctly switches manifest-file per target.
- Aligns main's workflow with next's, so a workflow_dispatch with `target_branch=next` from main's ref uses `.release-please-manifest-next.json` instead of silently applying prerelease config against the wrong manifest.

## Test plan
- [ ] Confirm normal push-to-main release-please run still works (config-file/manifest-file resolve to `release-please-config.json` / `.release-please-manifest.json`)
- [ ] Confirm workflow_dispatch with target_branch=next resolves to `release-please-config-next.json` / `.release-please-manifest-next.json`