### PR TITLE
fix(ci): trigger claude review workflows only on PR state changes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -3,7 +3,7 @@ name: Claude Code Review
 on:
   workflow_dispatch:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
 
 jobs:
   claude-review:

--- a/.github/workflows/claude-security-review.yml
+++ b/.github/workflows/claude-security-review.yml
@@ -2,7 +2,7 @@ name: Claude Security Review
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, reopened, ready_for_review]
   workflow_dispatch:
 
 concurrency:
@@ -36,7 +36,6 @@ jobs:
           claude-api-key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude-model: claude-opus-4-8
           claudecode-timeout: 10
-          run-every-commit: true
 
       - name: Classify security findings by severity
         id: classify


### PR DESCRIPTION
## Summary
- Drop `synchronize` from `claude-code-review.yml` and `claude-security-review.yml` trigger types — workflows now run only on `opened`, `reopened`, `ready_for_review`, not every push to an open PR.
- Drop `run-every-commit: true` from the security-review action config since it's moot without the `synchronize` trigger.

## Test plan
- [ ] Push a commit to an open PR, confirm neither workflow re-triggers.
- [ ] Reopen/mark-ready a PR, confirm both workflows trigger.