### PR TITLE
chore(release): match manifest component to plain tag scheme

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,8 @@
     ".": {
       "package-name": "albert",
       "version-file": "src/albert/__init__.py",
-      "include-v-in-tag": true
+      "include-v-in-tag": true,
+      "component": ""
     }
   }
 }


### PR DESCRIPTION
## Summary
- `release-please-config.json`'s package `.` sets `package-name: albert`, which implicitly names the manifest component `albert`.
- Every real tag in this repo is component-less (`v1.32.1`, never `albert-v1.32.1`).
- This mismatch was harmless until #594 pushed main's release-please run into full manifest-mode component search (explicit `manifest-file` input, config-file as sole source of `release-type`/`versioning-strategy`). That run rejected every historical tag as an unrecognized component and fell back to diffing the entire repo history, producing PR #596.
- Adding `"component": ""` overrides the implicit component to match the actual tag scheme, restores normal small-diff release PRs, and keeps `package-name` (changelog naming) as-is.

## Test plan
- [ ] Merge, close stale PR #596, delete branch `release-please--branches--main--components--albert`, re-trigger release-please on `main`, confirm the new PR only contains the real unreleased commit(s).