### PR TITLE
chore(ci): revert manifest-file routing in release-please workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -31,21 +31,22 @@ jobs:
           owner: ${{ github.repository_owner }}
           repositories: |
             ${{ github.event.repository.name }}
-      - name: Set config and manifest files
+      - name: Set config file
         id: config
         env:
           TARGET_BRANCH: ${{ inputs.target_branch || github.ref_name }}
         run: |
           if [ "$TARGET_BRANCH" = "next" ]; then
-            echo "config_file=release-please-config-next.json" >> "$GITHUB_OUTPUT"
-            echo "manifest_file=.release-please-manifest-next.json" >> "$GITHUB_OUTPUT"
+            echo "file=release-please-config-next.json" >> "$GITHUB_OUTPUT"
+            echo "versioning_strategy=prerelease" >> "$GITHUB_OUTPUT"
           else
-            echo "config_file=release-please-config.json" >> "$GITHUB_OUTPUT"
-            echo "manifest_file=.release-please-manifest.json" >> "$GITHUB_OUTPUT"
+            echo "file=release-please-config.json" >> "$GITHUB_OUTPUT"
+            echo "versioning_strategy=default" >> "$GITHUB_OUTPUT"
           fi
       - uses: googleapis/release-please-action@v4
         with:
           token: ${{ steps.app-token.outputs.token }}
+          release-type: python
           target-branch: ${{ inputs.target_branch || github.ref_name }}
-          config-file: ${{ steps.config.outputs.config_file }}
-          manifest-file: ${{ steps.config.outputs.manifest_file }}
+          config-file: ${{ steps.config.outputs.file }}
+          versioning-strategy: ${{ steps.config.outputs.versioning_strategy }}


### PR DESCRIPTION
## Summary
- Reverts #594.
- Explicitly passing `manifest-file` (and dropping the `release-type`/`versioning-strategy` action inputs) pushed main's release-please run into full manifest-mode component search. That mode doesn't recognize this repo's component-less tags and produces a full-history diff instead of a normal small release PR (see #596, #603 — both had to be closed).
- Reverting restores main's release-please run to its previously-working behavior. Next's manifest-routing fix will need a different approach that doesn't regress main.

## Test plan
- [ ] Merge, close stale PR #603, delete branch `release-please--branches--main--components--albert`, re-trigger release-please on `main`, confirm the new PR only contains real unreleased commits.