### PR TITLE
feat(btdataset): add targets to BTDatasetReferences

### DIFF
--- a/src/albert/resources/btdataset.py
+++ b/src/albert/resources/btdataset.py
@@ -26,6 +26,7 @@ class BTDatasetReferences(BaseAlbertModel):
     project_ids: list[str]
     data_column_ids: list[str] | None = Field(default=None)
     targets: list[BTDatasetTargetReference] | None = Field(default=None)
+    target_ids: list[str] | None = Field(default=None)
     sheet_ids: list[str] | None = Field(default=None)
     filter: dict[str, Any] | None = Field(default=None)
 

--- a/src/albert/resources/btdataset.py
+++ b/src/albert/resources/btdataset.py
@@ -7,25 +7,9 @@ from albert.core.shared.identifiers import BTDatasetId, ProjectId
 from albert.core.shared.models.base import BaseResource, EntityLink
 
 
-class BTDatasetTargetReference(BaseAlbertModel):
-    """A target output referenced by a Breakthrough dataset.
-
-    Attributes
-    ----------
-    data_column_id : str
-        The composite data template + data column identifier of the target output.
-    unit_id : str | None
-        The unit selected for the target output, if any.
-    """
-
-    data_column_id: str
-    unit_id: str | None = Field(default=None)
-
-
 class BTDatasetReferences(BaseAlbertModel):
     project_ids: list[str]
     data_column_ids: list[str] | None = Field(default=None)
-    targets: list[BTDatasetTargetReference] | None = Field(default=None)
     target_ids: list[str] | None = Field(default=None)
     sheet_ids: list[str] | None = Field(default=None)
     filter: dict[str, Any] | None = Field(default=None)

--- a/src/albert/resources/btdataset.py
+++ b/src/albert/resources/btdataset.py
@@ -7,9 +7,25 @@ from albert.core.shared.identifiers import BTDatasetId, ProjectId
 from albert.core.shared.models.base import BaseResource, EntityLink
 
 
+class BTDatasetTargetReference(BaseAlbertModel):
+    """A target output referenced by a Breakthrough dataset.
+
+    Attributes
+    ----------
+    data_column_id : str
+        The composite data template + data column identifier of the target output.
+    unit_id : str | None
+        The unit selected for the target output, if any.
+    """
+
+    data_column_id: str
+    unit_id: str | None = Field(default=None)
+
+
 class BTDatasetReferences(BaseAlbertModel):
     project_ids: list[str]
-    data_column_ids: list[str]
+    data_column_ids: list[str] | None = Field(default=None)
+    targets: list[BTDatasetTargetReference] | None = Field(default=None)
     sheet_ids: list[str] | None = Field(default=None)
     filter: dict[str, Any] | None = Field(default=None)
 


### PR DESCRIPTION
References are the persisted rebuild-query for a Breakthrough dataset. The dataset scope now selects targets as (data_column_id, unit_id) pairs, so references gain an optional targets list mirroring that shape; data_column_ids becomes optional for backward compatibility with existing records.