### PR TITLE
fix(property-data): handle empty response on get_properties_on_inventory

### DIFF
--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -76,6 +76,8 @@ class PropertyDataCollection(BaseCollection):
         params = {"entity": "inventory", "id": [inventory_id]}
         response = self.session.get(url=self.base_path, params=params)
         response_json = response.json()
+        if not response_json:
+            return InventoryPropertyData(inventoryId=inventory_id)
         return InventoryPropertyData(**response_json[0])
 
     @validate_call


### PR DESCRIPTION
## Summary
- `get_properties_on_inventory` indexed `response_json[0]` unconditionally, but the API returns `[]` (not an object) when the inventory item has no property data yet, causing an `IndexError`.
- Now returns an empty `InventoryPropertyData` in that case instead of crashing.

Fixes #611