### PR TITLE
fix(units): match unit names case-insensitively in get_or_create

### DIFF
--- a/src/albert/collections/units.py
+++ b/src/albert/collections/units.py
@@ -67,12 +67,13 @@ class UnitCollection(BaseCollection):
         Unit
             The existing or newly created Unit object.
         """
-        match = self.get_by_name(name=unit.name, exact_match=True)
-        if match:
-            logging.warning(
-                f"Unit with the name {unit.name} already exists. Returning the existing unit."
-            )
-            return match
+        found = self.get_all(name=unit.name, max_items=50)
+        for existing in found:
+            if existing.name.lower() == unit.name.lower():
+                logging.warning(
+                    f"Unit with the name {unit.name} already exists. Returning the existing unit."
+                )
+                return existing
         return self.create(unit=unit)
 
     @validate_call


### PR DESCRIPTION
## Summary
- `get_or_create` used an exact, case-sensitive name lookup before creating a unit, but the backend enforces name+category uniqueness case-insensitively — so a unit like `Bar` wouldn't be found by a lookup for `bar`, and the subsequent create call would 400 with "Name and Category already exist".
- Replaced the lookup with a broader name search (`max_items=50`) and a case-insensitive comparison against results, so existing units are correctly returned instead of hitting the duplicate error.
- Verified live against sandbox: creating `SDKBar` then calling `get_or_create` with `sdkBar` now returns the existing unit instead of raising.