### PR TITLE
fix(cas): skip PATCH when no updatable fields changed

### DIFF
--- a/src/albert/collections/cas.py
+++ b/src/albert/collections/cas.py
@@ -319,6 +319,8 @@ class CasCollection(BaseCollection):
 
         # Generate the PATCH payload
         patch_payload = self._generate_patch_payload(existing=existing_cas, updated=updated_object)
+        if not patch_payload.data:
+            return existing_cas
         url = f"{self.base_path}/{updated_object.id}"
         self.session.patch(url, json=patch_payload.model_dump(mode="json", by_alias=True))
 


### PR DESCRIPTION
## Summary
- `CasCollection.update()` was sending `{"data": []}` to the API when the passed object had no changes relative to server state, causing a 400 error.
- Fix: early-return the existing object when `patch_payload.data` is empty, same pattern already used in `TaskCollection`.