### PR TITLE
fix(tasks): use FINAL workflow id when updating block workflow

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -176,7 +176,8 @@ class TaskCollection(BaseCollection):
                 if w.name == "No Parameter Group" and len(b.workflow) > 1:
                     # hardcoded default workflow
                     continue
-                existing_workflow_id = w.id
+                if w.category != "INITIAL":
+                    existing_workflow_id = w.id
         if existing_workflow_id == workflow_id:
             logger.info(f"Block {block_id} already has workflow {workflow_id}")
             return None

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -169,6 +169,8 @@ class TaskCollection(BaseCollection):
         if not isinstance(task, PropertyTask | BatchTask):
             logger.error(f"Task {task_id} is not a PropertyTask or BatchTask")
             raise TypeError(f"Task {task_id} is not a PropertyTask or BatchTask")
+        existing_workflow_id: str | None = None
+        initial_workflow_id: str | None = None
         for b in task.blocks:
             if b.id != block_id:
                 continue
@@ -176,8 +178,17 @@ class TaskCollection(BaseCollection):
                 if w.name == "No Parameter Group" and len(b.workflow) > 1:
                     # hardcoded default workflow
                     continue
-                if w.category != "INITIAL":
+                if w.category == "INITIAL":
+                    if initial_workflow_id is None:
+                        initial_workflow_id = w.id
+                else:
                     existing_workflow_id = w.id
+            if existing_workflow_id is None:
+                existing_workflow_id = initial_workflow_id
+            break
+        if existing_workflow_id is None:
+            logger.error(f"No workflow found for block {block_id} on task {task_id}")
+            raise ValueError(f"No workflow found for block {block_id} on task {task_id}")
         if existing_workflow_id == workflow_id:
             logger.info(f"Block {block_id} already has workflow {workflow_id}")
             return None

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -8,7 +8,15 @@ from albert.resources.tasks import (
     TaskCategory,
     TaskSearchItem,
 )
+from albert.resources.workflows import Workflow
 from tests.utils.test_patches import change_metadata, make_metadata_update_assertions
+
+
+def _final_workflow_id(block) -> str:
+    for workflow in block.workflow:
+        if workflow.category != "INITIAL":
+            return workflow.id
+    return block.workflow[0].id
 
 
 def test_task_search_with_pagination(client: Albert, seeded_tasks):
@@ -128,21 +136,26 @@ def test_add_block(client: Albert, seeded_tasks, seeded_workflows, seeded_data_t
 
 
 def test_update_block_workflow(
-    client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
+    client: Albert,
+    seeded_tasks,
+    seeded_workflows: list[Workflow],
 ):
-    task = [x for x in seeded_tasks if isinstance(x, PropertyTask)][0]
+    task: PropertyTask = [x for x in seeded_tasks if isinstance(x, PropertyTask)][0]
     # in case it mutated
     task = client.tasks.get_by_id(id=task.id)
     starting_blocks = len(task.blocks)
     block_id = task.blocks[0].id
-    new_workflow = [x for x in seeded_workflows if x.id != task.blocks[0].workflow][0]
+    current_final_workflow_id = _final_workflow_id(task.blocks[0])
+    new_workflow = next(
+        workflow for workflow in seeded_workflows if workflow.id != current_final_workflow_id
+    )
     client.tasks.update_block_workflow(
         task_id=task.id, block_id=block_id, workflow_id=new_workflow.id
     )
-    updated_task = client.tasks.get_by_id(id=task.id)
+    updated_task: PropertyTask = client.tasks.get_by_id(id=task.id)
     assert len(updated_task.blocks) == starting_blocks
-    updated_block = [x for x in updated_task.blocks if x.id == block_id][0]
-    assert new_workflow.id in [x.id for x in updated_block.workflow]
+    updated_block = next(block for block in updated_task.blocks if block.id == block_id)
+    assert new_workflow.id == _final_workflow_id(updated_block)
 
 
 def test_add_block_to_batch_task(
@@ -169,15 +182,17 @@ def test_update_block_workflow_on_batch_task(
     task = client.tasks.get_by_id(id=task.id)
     starting_blocks = len(task.blocks)
     block_id = task.blocks[0].id
-    current_workflow_id = task.blocks[0].workflow[0].id
-    new_workflow = next(x for x in seeded_workflows if x.id != current_workflow_id)
+    current_final_workflow_id = _final_workflow_id(task.blocks[0])
+    new_workflow = next(
+        workflow for workflow in seeded_workflows if workflow.id != current_final_workflow_id
+    )
     client.tasks.update_block_workflow(
         task_id=task.id, block_id=block_id, workflow_id=new_workflow.id
     )
     updated_task = client.tasks.get_by_id(id=task.id)
     assert len(updated_task.blocks) == starting_blocks
-    updated_block = next(x for x in updated_task.blocks if x.id == block_id)
-    assert new_workflow.id in [x.id for x in updated_block.workflow]
+    updated_block = next(block for block in updated_task.blocks if block.id == block_id)
+    assert new_workflow.id == _final_workflow_id(updated_block)
 
 
 def test_remove_block_from_batch_task(client: Albert, seeded_tasks, seeded_workflows):


### PR DESCRIPTION
## Summary

- Fixes `update_block_workflow()` to resolve the block's current workflow from the **FINAL** entry (skipping `INITIAL`) when building the patch `oldValue`.
- Tightens `test_update_block_workflow` and `test_update_block_workflow_on_batch_task` to assert the FINAL workflow id is updated, not just that the new id appears somewhere in the block's workflow list.

## Bug verification (live API spec + dev)

Verified against the tasks OpenAPI spec (`/api/v3/tasks/jsonspecs/`) and live dev data:

- `TaskBlock.Workflow[].category` is an enum of `INITIAL` | `FINAL` — the FINAL entry is the current workflow to patch.
- Live property-task search returns blocks where INITIAL and FINAL differ (e.g. FINAL `WFL36063`, INITIAL `WFL30235`).
- The previous SDK logic could pick the INITIAL id as `oldValue`, causing patch failures or leaving FINAL unchanged.

## Test plan

- [x] `uv run pytest tests/collections/test_tasks.py::test_update_block_workflow -v`
- [x] `uv run pytest tests/collections/test_tasks.py::test_update_block_workflow_on_batch_task -v`


Made with [Cursor](https://cursor.com)