### PR TITLE
feat: add label template and PDF generator collections

### DIFF
--- a/docs/collections/label_templates.md
+++ b/docs/collections/label_templates.md
@@ -1,0 +1,1 @@
+::: albert.collections.label_templates.LabelTemplateCollection

--- a/docs/collections/pdf_generator.md
+++ b/docs/collections/pdf_generator.md
@@ -1,0 +1,1 @@
+::: albert.collections.pdf_generator.PDFGeneratorCollection

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -1,0 +1,222 @@
+# Label Templates
+
+Label templates drive the printable outputs in Albert, such as inventory lot barcode labels, batch task labels, and formula reports. A label template is a Mustache HTML file stored for your tenant, plus a template record that names it, types it, and holds its page options.
+
+This page covers the end-to-end SDK workflow and, most importantly, the rules for authoring the template HTML file itself.
+
+## End-to-end workflow
+
+!!! example "Create a template and print a Lot label"
+    ```python
+    from pathlib import Path
+
+    from albert import Albert
+    from albert.resources.label_templates import LabelTemplate, LabelTemplateType
+
+    client = Albert.from_client_credentials()
+
+    # 1) Create the template, uploading its HTML file
+    template = LabelTemplate(
+        name="3x1 Inventory Label",
+        type=LabelTemplateType.INVENTORY,
+        template_file="3x1-inventory-label.html",
+        metadata={
+            "width": "3in",
+            "height": "1in",
+            "margin": {"top": "0mm", "bottom": "0mm", "left": "0mm", "right": "0mm"},
+        },
+    )
+    created = client.label_templates.create(
+        label_template=template,
+        template_html=Path("3x1-inventory-label.html").read_text(),
+    )
+
+    # 2) Generate a label PDF for a Lot
+    url = client.label_templates.generate_label_pdf(
+        inventory_lot_number_id="LOTB1234",
+        template_id=created.id,
+    )
+    # url is a short-lived link to the rendered PDF
+    ```
+
+To inspect what data a template will receive (or to render manually), use `get_print_payload`:
+
+!!! example "Inspect the render payload"
+    ```python
+    payload = client.label_templates.get_print_payload(
+        inventory_lot_number_id="LOTB1234",
+        template_id=created.id,
+    )
+    payload.template.body  # URL of the stored Mustache HTML file
+    payload.data["labels"]  # one entry per printed entity
+    ```
+
+## Anatomy of a template file
+
+A template file is a complete HTML document. It is rendered with [Mustache](https://mustache.github.io/mustache.5.html) and printed to PDF by headless Chrome. The general shape is:
+
+```html
+<html>
+<head>
+  <meta charset="UTF-8">
+  <!-- DO NOT MODIFY the below commented line, API (template/print) is consuming it -->
+  <!--metadata:{
+    "width": "3in",
+    "height": "1in",
+    "margin": {"top": "0mm", "bottom": "0mm", "left": "0mm", "right": "0mm"},
+    "renderBackgroundImage": true
+  }-->
+  <style>
+    /* Inline CSS. Fixed sizing is typical: 1in = 96px. */
+    body { width: 100%; overflow: hidden; }
+  </style>
+</head>
+<body>
+  {{#labels}}
+  <!-- One block per printed entity -->
+  <div class="label-container">
+    ...
+  </div>
+  {{/labels}}
+</body>
+</html>
+```
+
+Key rules:
+
+- **Wrap the body in `{{#labels}} ... {{/labels}}`.** The render data is `{"labels": [...]}` with one entry per printed entity, and each entry's fields live under `info`.
+- **The `<!--metadata:{...}-->` comment must contain valid JSON.** It is parsed out of the file and merged over the template record's `metadata`; the merged object supplies the PDF page options (`width`, `height`, `margin`, and so on).
+- **The page renders in headless Chrome and waits for network idle**, so externally hosted fonts, stylesheets, and images load before printing. Inline `<script>` tags also run before printing, so DOM post-processing is supported.
+- **Size the page explicitly.** Set `width`/`height` in the metadata (or template record `metadata`) and size your containers to match, with `overflow: hidden` to prevent spill. When printing multiple entities in one PDF, use `page-break-before: always` / `page-break-after: always` on the per-label container.
+
+## The metadata block
+
+Recognized keys observed across production templates:
+
+| Key | Purpose |
+| --- | --- |
+| `width`, `height` | Page size (e.g. `"3in"`, `"1in"`). |
+| `margin` | Object with `top`/`bottom`/`left`/`right`. |
+| `renderBackgroundImage` | Print CSS backgrounds when `true`. |
+| `hasBlackPictos` | Use the black (no-line) pictogram set. |
+| `useGhsOfficialPictos` | Use official GHS pictogram images. |
+| `numberOfPictos` | Cap how many hazard pictograms are passed to the template. |
+| `header`, `footer` | File names of separate header/footer HTML files. |
+| `templateId` | Informational name for the file. |
+
+The same keys can also be set on the template record's `metadata` when creating via the SDK; the file block wins where both define a key.
+
+## Data available to inventory labels
+
+Each entry in `{{#labels}}` exposes these fields under `info` for `type=inventory`:
+
+| Field | Contents |
+| --- | --- |
+| `{{info.albertId}}` | The parent Inventory ID. |
+| `{{info.inventoryName}}` | Inventory item name. |
+| `{{info.alias}}` | Inventory alias. |
+| `{{{info.lotNumber}}}` | **Barcode image URL** for the lot. Use inside `<img src="...">`. |
+| `{{{info.lotNumberQrCode}}}` | **QR code image** as a `data:` URI. Use inside `<img src="...">`. |
+| `{{info.vendorLotNumber}}` | Manufacturer lot number. |
+| `{{info.Supplier}}` / `{{info.manufacturer}}` | Supplier/manufacturer company name. |
+| `{{info.owner}}` | Lot owner name. |
+| `{{info.lotCreationDate}}` | Lot creation date. |
+| `{{info.expirationDate}}` | Lot expiration date. |
+| `{{info.locationAddress}}` | Location address. |
+| `{{info.sublocation}}` | Location and storage location names combined. |
+| `{{info.inventoryCategory}}` | Parent category (e.g. RawMaterials). |
+| `{{info.logo}}` | Tenant logo image URL. |
+| `{{#info.Symbols}}` | Loop of hazard pictogram image URLs. |
+| `{{info.AdditionalInfo.InventoryInfo...}}` | The full Inventory object, including `Metadata.<customField>`. |
+| `{{info.AdditionalInfo.LotInfo...}}` | The full Lot object (e.g. `StorageLocation.name`, `manufacturerLotNumber`). |
+| `{{info.AdditionalInfo.RegulatoryInfo...}}` | Regulatory data for the item. |
+
+Other template types receive different fields (for example, batch and property task labels expose `info.taskId`, `info.taskName`, and loop pictograms via `{{#info.pictograms}}`). Use `get_print_payload` with the matching `type` to see exactly what a template will receive.
+
+## Mustache patterns that matter
+
+**Use triple braces for image sources.** Barcode URLs and QR `data:` URIs contain characters that double braces would HTML-escape into broken links:
+
+```html
+<img src="{{{info.lotNumber}}}" width="100" height="40">
+<img src="{{{info.lotNumberQrCode}}}" width="90" height="90">
+```
+
+**Loop arrays with sections.** Inside a loop, `{{.}}` is the current item:
+
+```html
+{{#info.Symbols}}
+  <img src="{{.}}" width="15" height="15">
+{{/info.Symbols}}
+```
+
+**Use inverted sections for fallbacks.** For example, show the storage location, falling back to the location:
+
+```html
+{{#info.AdditionalInfo.LotInfo.StorageLocation.name}}
+  {{info.AdditionalInfo.LotInfo.StorageLocation.name}}
+{{/info.AdditionalInfo.LotInfo.StorageLocation.name}}
+{{^info.AdditionalInfo.LotInfo.StorageLocation.name}}
+  {{info.AdditionalInfo.LotInfo.Location.name}}
+{{/info.AdditionalInfo.LotInfo.StorageLocation.name}}
+```
+
+**Reach custom fields through `AdditionalInfo`.** Tenant custom fields on the Inventory are available at `{{info.AdditionalInfo.InventoryInfo.Metadata.<fieldName>}}`.
+
+**Manual fields.** Placeholders of the form `{{manualFields.<Name>}}` are detected in the file and surfaced so the user is prompted for values before printing. They are returned in `LabelPrintPayload.manual_fields`.
+
+## Complete example: 3x1in inventory lot label
+
+A functional starting point (plain black-and-white, barcode plus QR plus pictograms):
+
+```html
+<html>
+<head>
+  <meta charset="UTF-8">
+  <!-- DO NOT MODIFY the below commented line, API (template/print) is consuming it -->
+  <!--metadata:{
+    "width": "3in",
+    "height": "1in",
+    "margin": {"top": "0mm", "bottom": "0mm", "left": "0mm", "right": "0mm"},
+    "renderBackgroundImage": true
+  }-->
+  <style>
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    body { font-family: Arial, sans-serif; overflow: hidden; }
+    .label-container {
+      display: grid;
+      grid-template-columns: 180px 108px;
+      width: 288px;   /* 3in */
+      height: 96px;   /* 1in */
+      overflow: hidden;
+      padding: 4px;
+      page-break-after: always;
+    }
+    .name { font-size: 10px; font-weight: 700; }
+    .field { font-size: 8px; }
+    .field b { font-weight: 700; }
+    .pictos img { width: 14px; height: 14px; }
+  </style>
+</head>
+<body>
+{{#labels}}
+  <div class="label-container">
+    <div>
+      <div class="name">{{info.inventoryName}}</div>
+      <div class="field"><b>ID:</b> {{info.albertId}}</div>
+      <div class="field"><b>Mfr Lot #:</b> {{info.vendorLotNumber}}</div>
+      <div class="field"><b>Location:</b> {{info.sublocation}}</div>
+      <div class="field"><b>Exp:</b> {{info.expirationDate}}</div>
+      <div class="pictos">
+        {{#info.Symbols}}<img src="{{.}}">{{/info.Symbols}}
+      </div>
+    </div>
+    <div>
+      <img src="{{{info.lotNumber}}}" width="100" height="40">
+      <img src="{{{info.lotNumberQrCode}}}" width="45" height="45">
+    </div>
+  </div>
+{{/labels}}
+</body>
+</html>
+```

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -129,9 +129,13 @@ Header and footer templates repeat on every page and support special classes tha
 
 Available classes: `pageNumber`, `totalPages`, `date`, `title`. Set `hideHeaderFromFirstPage: true` in the options to keep the first page clean while headers appear on subsequent pages. Size the header/footer with inline styles and leave room for them via the page `margin`.
 
-## Data available to inventory labels
+## Data available to each template type
 
-Each entry in `{{#labels}}` exposes these fields under `info` for `type=inventory`:
+Each entry in `{{#labels}}` exposes its fields under `info` (except `propertytaskreport`, noted below). All types also receive `{{info.currentUser.name}}` and `{{info.currentUser.email}}` (the printing user). Whatever the tables below say, `get_print_payload(type=...)` is always the ground truth for what a given template receives.
+
+### `inventory` (Lot barcode labels)
+
+Print with `inventory_lot_number_id` (one or more Lot IDs).
 
 | Field | Contents |
 | --- | --- |
@@ -148,13 +152,101 @@ Each entry in `{{#labels}}` exposes these fields under `info` for `type=inventor
 | `{{info.locationAddress}}` | Location address. |
 | `{{info.sublocation}}` | Location and storage location names combined. |
 | `{{info.inventoryCategory}}` | Parent category (e.g. RawMaterials). |
+| `{{info.rsnNumber}}`, `{{info.idh}}` | Values from inventory metadata where present. |
 | `{{info.logo}}` | Tenant logo image URL. |
 | `{{#info.Symbols}}` | Loop of hazard pictogram image URLs. |
 | `{{info.AdditionalInfo.InventoryInfo...}}` | The full Inventory object, including `Metadata.<customField>`. |
 | `{{info.AdditionalInfo.LotInfo...}}` | The full Lot object (e.g. `StorageLocation.name`, `manufacturerLotNumber`). |
-| `{{info.AdditionalInfo.RegulatoryInfo...}}` | Regulatory data for the item. |
+| `{{info.AdditionalInfo.RegulatoryInfo...}}` | Regulatory data for the item (hazard statements, precautionary phrases). |
 
-Other template types receive different fields (for example, batch and property task labels expose `info.taskId`, `info.taskName`, and loop pictograms via `{{#info.pictograms}}`). Use `get_print_payload` with the matching `type` to see exactly what a template will receive.
+### `batch` (Product/Formula lot labels)
+
+Print with `albert_id` (the formula Inventory ID) and `task_id` (the batch task). One entry total.
+
+| Field | Contents |
+| --- | --- |
+| `{{info.albertId}}` / `{{info.formulaID}}` | Formula Inventory ID (prefix stripped). |
+| `{{info.formulaName}}` | Formula name. |
+| `{{info.lotId}}` | Batch lot display ID (e.g. `B123-4`). |
+| `{{info.lotNumber}}` | Batch lot number prefix as **text** (no barcode image for this type). |
+| `{{info.taskID}}`, `{{info.taskName}}` | Batch task ID and name. |
+| `{{info.batchWeight}}` | Batch size. |
+| `{{info.batchStartDate}}` | Task start date. |
+| `{{info.batchLocation.name}}` | Task location. |
+| `{{info.taskOwner}}` | Assigned user name. |
+| `{{info.taskTags}}` | Task tags. |
+| `{{info.Project.id}}`, `{{info.Project.name}}`, `{{info.Project.Technology}}` | Parent project details. |
+| `{{#info.hasQcTasks}}` / `{{#info.QCResultsTable}}` | QC task rows, each with `info.taskId`, `info.barcodeId`, `info.property`, `info.target`, `info.qcResult`, `info.qcResultStatus`, `info.ParameterGroups`. |
+| `{{info.Created...}}`, `{{info.Updated...}}` | Template audit info. |
+| `{{info.logo}}`, `{{info.backgroundImageUrl}}` | Tenant logo and background image URLs. |
+
+### `property` (Property task interval labels)
+
+Print with `task_id` and `albert_id`; optionally `lot_id` and `block_id`. One entry per inventory x block x interval, so these templates are usually printed as one small label per page.
+
+| Field | Contents |
+| --- | --- |
+| `{{{info.lotNumber}}}` | **Barcode image URL** encoding task-inventory-block-interval. |
+| `{{{info.lotNumberQrCode}}}` | **QR code image** of the same code, as a `data:` URI. |
+| `{{info.intervalId}}` | Human-readable interval name. |
+| `{{info.blockId}}`, `{{info.intervalRow}}` | Block and interval row IDs. |
+| `{{info.taskID}}`, `{{info.taskName}}` | Property task ID and name. |
+| `{{info.albertId}}`, `{{info.inventoryName}}`, `{{info.alias}}`, `{{info.lotId}}` | The inventory/lot the label is for. |
+| `{{info.propertyName}}` / `{{info.Datatemplate}}` | The data template (property) being measured. |
+| `{{info.startDate}}`, `{{info.dueDate}}`, `{{info.priority}}`, `{{info.state}}`, `{{info.status}}`, `{{info.result}}`, `{{info.target}}` | Task fields. |
+| `{{info.AssignedTo.name}}`, `{{info.Location...}}`, `{{info.Tags}}`, `{{info.Workflow...}}` | Task assignment details. |
+| `{{info.ParameterGroups...}}`, `{{info.Notes}}`, `{{info.Tasks}}`, `{{info.History}}` | Workflow parameter groups, task notes, related lot tasks, task history. |
+| `{{info.Created.date}}` | Task creation date (formatted). |
+| `{{#info.Symbols}}` | Loop of hazard pictogram image URLs. |
+| `{{info.formulaIngredient}}` | Unpacked formula ingredients, for formula inventories. |
+| `{{info.AdditionalInfo...}}` | `InventoryInfo`, `LotInfo`, `projectInfo`, and `TaskMetadata` objects. |
+| `{{info.logo}}` | Tenant logo image URL. |
+
+Data template names honor the `x-alb-language` request header for localization.
+
+### `propertytaskreport` (Property task reports)
+
+Print with `task_id` and `albert_id`. One entry, and uniquely its fields are **top-level** (no `info` wrapper): `{{task...}}` (the full task), `{{taskHistory}}`, `{{propertyDataResult}}` (processed property data by block/interval), `{{wflPGData}}` (workflow parameter groups), `{{projectDetails...}}`, and `{{taskNotes}}`.
+
+### `batchtemplate` (Batch task documents, e.g. CoA)
+
+Print with `task_id`. One entry.
+
+| Field | Contents |
+| --- | --- |
+| `{{info.overview.taskId}}`, `{{info.overview.taskName}}` | Batch task ID and name. |
+| `{{{info.overview.taskIdBarcode}}}` | **Barcode image** of the task ID, as a `data:` URI. |
+| `{{#info.overview.Product}}` | Loop of produced formulas: `id`, `name`, `lotNumber`, `barcodeId`. |
+| `{{info.overview.Created...}}`, `{{info.overview.AssignedTo...}}` | Task audit and assignee. |
+| `{{#info.tableJson}}` | Batch usage tables (raw materials and amounts), grouped per `numberOfProducts` from the metadata block. |
+| `{{info.workflows...}}` | The task's final workflow, including parameter groups. |
+| `{{info.projectDetails...}}` | Parent project, including `Metadata.<customField>`. |
+| `{{info.AdditionalInfo.TaskInfo...}}` | The full task object, including `Metadata.<customField>`. |
+| `{{info.AdditionalInfo.TaskNotes}}` | Task notes. |
+
+This type pairs naturally with `{{manualFields.X}}` placeholders and a metadata `schema` block for operator-entered values (see below).
+
+### `generaltasklabel` (General task labels)
+
+Print with `task_id`. One entry whose `info` is the **full task object**, enriched with:
+
+| Field | Contents |
+| --- | --- |
+| `{{info.displayId}}` | Task ID with the prefix stripped. |
+| `{{info.name}}`, `{{info.status}}`, and all other task fields | The task record itself. |
+| `{{info.ProjectInfo...}}` | The full parent project. |
+| `{{#info.Inventories}}` | Loop of task inventories, each with `displayId`, `inventoryInfo` (full inventory record, `Symbols` resolved to pictogram URLs) and `lotInfo` (full lot record, plus `RecentTransferDate`). |
+
+### `batchlabel` and `formulareport` (direct generation)
+
+These two types skip the print-payload step entirely; the platform assembles the data and renders the PDF in one call, returning a finished URL:
+
+```python
+url = client.label_templates.get_batch_label_url(task_id="TAS1234")
+url = client.label_templates.get_formula_report_url(formula_id="INVA1234-001", template_id="TMP123")
+```
+
+The GHS batch label (`batchlabel`) is rendered by the platform's document generator with computed hazard data (signal word, hazard and precautionary statements, pictograms); its template is not a tenant label template file. The formula report uses a `formulareport` tenant template with internally assembled composition and results data.
 
 ## Mustache patterns that matter
 

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -39,6 +39,15 @@ This page covers the end-to-end SDK workflow and, most importantly, the rules fo
     # url is a short-lived link to the rendered PDF
     ```
 
+### Where the HTML file lives
+
+You never upload to S3 yourself. `create(template_html=...)` sends the HTML through the template API, which stores it for your tenant under the `template_file` name; that name is the file's identity. There is no URL at create time: when a label is printed, the platform resolves the template record's `template_file` into the stored file's URL (returned as `payload.template.body`) and the renderer fetches it server-side.
+
+Two consequences of the name-is-identity model:
+
+- Uploading a file with the same `template_file` name replaces the stored file for the whole tenant, so pick distinct names unless replacement is what you want.
+- `update()` can repoint a template record to a different `template_file` name, but the only way to upload file content is `create()`. To revise a template's HTML, create a new template with the corrected file (or re-upload under the same file name and delete the extra record).
+
 To inspect what data a template will receive (or to render manually), use `get_print_payload`:
 
 !!! example "Inspect the render payload"

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -106,7 +106,7 @@ Key rules:
 
 The metadata block carries two kinds of keys: PDF page options consumed by the renderer, and label-assembly settings consumed while gathering the data. The same keys can also be set on the template record's `metadata` when creating via the SDK; the file block wins where both define a key.
 
-**Page options** (the renderer reads exactly these; anything else is ignored — see `PDFOptions`):
+**Page options** (the renderer reads exactly these and ignores anything else; see `PDFOptions`):
 
 | Key | Purpose |
 | --- | --- |

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -53,7 +53,11 @@ To inspect what data a template will receive (or to render manually), use `get_p
 
 ## Anatomy of a template file
 
-A template file is a complete HTML document. It is rendered with [Mustache](https://mustache.github.io/mustache.5.html) and printed to PDF by headless Chrome. The general shape is:
+A template file is a complete, ordinary HTML document with placeholders where the label's data goes. The placeholder syntax is [Mustache](https://mustache.github.io/mustache.5.html): `{{info.inventoryName}}` inserts a value, `{{#info.Symbols}}...{{/info.Symbols}}` repeats a block for each item in a list, and `{{{info.lotNumber}}}` (triple braces) inserts a value without HTML escaping. That is all the syntax there is; if you can write HTML and CSS, you can write a label template. At print time the placeholders are filled in and the page is printed to PDF by headless Chrome.
+
+The placeholder names are not arbitrary: they are the fields of the print payload assembled for your template's `type`. The full list per type is in [Data available to each template type](#data-available-to-each-template-type) below, and `get_print_payload(type=...)` returns the exact data (`payload.data["labels"]`) your template will be rendered with.
+
+The general shape is:
 
 ```html
 <html>

--- a/docs/examples/label_templates.md
+++ b/docs/examples/label_templates.md
@@ -91,20 +91,43 @@ Key rules:
 
 ## The metadata block
 
-Recognized keys observed across production templates:
+The metadata block carries two kinds of keys: PDF page options consumed by the renderer, and label-assembly settings consumed while gathering the data. The same keys can also be set on the template record's `metadata` when creating via the SDK; the file block wins where both define a key.
+
+**Page options** (the renderer reads exactly these; anything else is ignored — see `PDFOptions`):
 
 | Key | Purpose |
 | --- | --- |
-| `width`, `height` | Page size (e.g. `"3in"`, `"1in"`). |
+| `width`, `height` | Page size as CSS lengths (e.g. `"3in"`, `"1in"`). Both must be set to apply. |
+| `format` | Named paper size (e.g. `"A4"`, `"Letter"`) as an alternative to `width`/`height`. |
 | `margin` | Object with `top`/`bottom`/`left`/`right`. |
-| `renderBackgroundImage` | Print CSS backgrounds when `true`. |
+| `landscape` | Render in landscape orientation when `true`. |
+| `renderBackgroundImage` | Print CSS background colors and images when `true`. |
+| `hideHeaderFromFirstPage` | Skip the header on page 1 (title-page pattern) when `true`. |
+
+**Label-assembly settings**:
+
+| Key | Purpose |
+| --- | --- |
 | `hasBlackPictos` | Use the black (no-line) pictogram set. |
 | `useGhsOfficialPictos` | Use official GHS pictogram images. |
 | `numberOfPictos` | Cap how many hazard pictograms are passed to the template. |
 | `header`, `footer` | File names of separate header/footer HTML files. |
+| `languageCode` | Language for regulatory precautionary phrases (default `EN`). |
 | `templateId` | Informational name for the file. |
 
-The same keys can also be set on the template record's `metadata` when creating via the SDK; the file block wins where both define a key.
+## Headers, footers, and page numbers
+
+For multi-page outputs (reports, certificates), a template can have separate header and footer HTML files. Reference them in the metadata block (`"header"`, `"footer"`) or upload them via `create(header_html=..., footer_html=...)`, with their file names in the template record's `metadata`.
+
+Header and footer templates repeat on every page and support special classes that the renderer fills in:
+
+```html
+<div style="font-size: 8px; width: 100%; text-align: right; padding-right: 1cm;">
+  Page <span class="pageNumber"></span> of <span class="totalPages"></span>
+</div>
+```
+
+Available classes: `pageNumber`, `totalPages`, `date`, `title`. Set `hideHeaderFromFirstPage: true` in the options to keep the first page clean while headers appear on subsequent pages. Size the header/footer with inline styles and leave room for them via the page `margin`.
 
 ## Data available to inventory labels
 
@@ -141,6 +164,8 @@ Other template types receive different fields (for example, batch and property t
 <img src="{{{info.lotNumber}}}" width="100" height="40">
 <img src="{{{info.lotNumberQrCode}}}" width="90" height="90">
 ```
+
+The barcode image itself is a fixed-format Code 128 PNG with the human-readable text always included; style it by sizing, rotating, or cropping the `<img>` in CSS (only the text size is tunable server-side, via the `generate_barcode` endpoint's `text_size`).
 
 **Loop arrays with sections.** Inside a loop, `{{.}}` is the current item:
 

--- a/docs/resources/label_templates.md
+++ b/docs/resources/label_templates.md
@@ -1,0 +1,1 @@
+::: albert.resources.label_templates

--- a/docs/resources/pdf_generator.md
+++ b/docs/resources/pdf_generator.md
@@ -1,0 +1,1 @@
+::: albert.resources.pdf_generator

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
           - Files: collections/files.md
           - Hazards: collections/hazards.md
           - Inventory: collections/inventory.md
+          - Label Templates: collections/label_templates.md
           - Links: collections/links.md
           - Lists: collections/lists.md
           - Locations: collections/locations.md
@@ -167,6 +168,7 @@ nav:
           - Notes: collections/notes.md
           - Parameter Groups: collections/parameter_groups.md
           - Parameters: collections/parameters.md
+          - PDF Generator: collections/pdf_generator.md
           - Pricings: collections/pricings.md
           - Product Design: collections/product_design.md
           - Projects: collections/projects.md
@@ -210,6 +212,7 @@ nav:
           - Hazards: resources/hazards.md
           - Identifiers: resources/identifiers.md
           - Inventory: resources/inventory.md
+          - Label Templates: resources/label_templates.md
           - Links: resources/links.md
           - Lists: resources/lists.md
           - Locations: resources/locations.md
@@ -218,6 +221,7 @@ nav:
           - Notes: resources/notes.md
           - Parameter Groups: resources/parameter_groups.md
           - Parameters: resources/parameters.md
+          - PDF Generator: resources/pdf_generator.md
           - Pricings: resources/pricings.md
           - Product Design: resources/product_design.md
           - Projects: resources/projects.md
@@ -244,6 +248,7 @@ nav:
   - Examples:
       - Data Templates: examples/data_templates.md
       - Inventory: examples/inventory.md
+      - Label Templates: examples/label_templates.md
       - Notebooks: examples/notebook.md
       - Parameter Groups: examples/parameter_groups.md
       - Property Data: examples/property_data.md

--- a/src/albert/client.py
+++ b/src/albert/client.py
@@ -24,6 +24,7 @@ from albert.collections.entity_types import EntityTypeCollection
 from albert.collections.files import FileCollection
 from albert.collections.hazards import HazardsCollection
 from albert.collections.inventory import InventoryCollection
+from albert.collections.label_templates import LabelTemplateCollection
 from albert.collections.links import LinksCollection
 from albert.collections.lists import ListsCollection
 from albert.collections.locations import LocationCollection
@@ -32,6 +33,7 @@ from albert.collections.notebooks import NotebookCollection
 from albert.collections.notes import NotesCollection
 from albert.collections.parameter_groups import ParameterGroupCollection
 from albert.collections.parameters import ParameterCollection
+from albert.collections.pdf_generator import PDFGeneratorCollection
 from albert.collections.pricings import PricingCollection
 from albert.collections.product_design import ProductDesignCollection
 from albert.collections.projects import ProjectCollection
@@ -295,6 +297,14 @@ class Albert:
     @property
     def custom_templates(self) -> CustomTemplatesCollection:
         return CustomTemplatesCollection(session=self.session)
+
+    @property
+    def label_templates(self) -> LabelTemplateCollection:
+        return LabelTemplateCollection(session=self.session)
+
+    @property
+    def pdf_generator(self) -> PDFGeneratorCollection:
+        return PDFGeneratorCollection(session=self.session)
 
     @property
     def parameter_groups(self) -> ParameterGroupCollection:

--- a/src/albert/collections/label_templates.py
+++ b/src/albert/collections/label_templates.py
@@ -10,6 +10,7 @@ from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import PaginationMode
 from albert.core.shared.identifiers import (
+    BlockId,
     InventoryId,
     LabelTemplateId,
     LotId,
@@ -360,6 +361,7 @@ class LabelTemplateCollection(BaseCollection):
         albert_id: InventoryId | None = None,
         task_id: TaskId | None = None,
         lot_id: str | None = None,
+        block_id: BlockId | None = None,
         template_id: LabelTemplateId | None = None,
         jurisdiction: str | None = None,
     ) -> LabelPrintPayload:
@@ -405,6 +407,9 @@ class LabelTemplateCollection(BaseCollection):
             ``batchtemplate``, or ``generaltasklabel``.
         lot_id : str, optional
             Restrict property task labels to a specific lot.
+        block_id : BlockId, optional
+            Restrict property task labels to a specific block (format
+            ``BLK...``).
         template_id : LabelTemplateId, optional
             The Label Template ID to render with (format ``TMP...``). When not
             provided, the tenant default template for the type is used.
@@ -422,6 +427,7 @@ class LabelTemplateCollection(BaseCollection):
             "albertId": albert_id,
             "taskId": task_id,
             "lotId": lot_id,
+            "blockId": block_id,
             "templateId": template_id,
             "jurisdiction": jurisdiction,
         }

--- a/src/albert/collections/label_templates.py
+++ b/src/albert/collections/label_templates.py
@@ -76,6 +76,10 @@ class LabelTemplateCollection(BaseCollection):
         Assemble the render payload for printing a label.
     generate_label_pdf(...) -> str
         Generate a label PDF for a Lot and return its download URL.
+    get_batch_label_url(task_id, lot_id=None) -> str
+        Generate a hazard batch label PDF for a batch task.
+    get_formula_report_url(formula_id, template_id=None, lot_id=None) -> str
+        Generate a formula report PDF.
     """
 
     _api_version = "v3"
@@ -375,18 +379,23 @@ class LabelTemplateCollection(BaseCollection):
         ----------
         type : LabelTemplateType, optional
             The kind of label to assemble. Defaults to ``inventory`` (Lot
-            barcode labels).
+            barcode labels). Supported types are ``inventory``, ``batch``,
+            ``property``, ``propertytaskreport``, ``batchtemplate``, and
+            ``generaltasklabel``; the ``batchlabel`` and ``formulareport``
+            types render directly via [`get_batch_label_url`][albert.collections.label_templates.LabelTemplateCollection.get_batch_label_url]
+            and [`get_formula_report_url`][albert.collections.label_templates.LabelTemplateCollection.get_formula_report_url] instead.
         inventory_lot_number_id : LotId or list[LotId], optional
             The Lot ID(s) to print (format ``LOT...``). Required when ``type``
             is ``inventory``.
         albert_id : InventoryId, optional
             The Inventory ID (format ``INV...``). Required when ``type`` is
-            ``batch`` or ``property``.
+            ``batch``, ``property``, or ``propertytaskreport``.
         task_id : TaskId, optional
             The Task ID (format ``TAS...``). Required when ``type`` is
-            ``property``, ``batchlabel``, or ``batchtemplate``.
+            ``batch``, ``property``, ``propertytaskreport``,
+            ``batchtemplate``, or ``generaltasklabel``.
         lot_id : str, optional
-            The lot number. Required when ``type`` is ``batch``.
+            Restrict property task labels to a specific lot.
         template_id : LabelTemplateId, optional
             The Label Template ID to render with (format ``TMP...``). When not
             provided, the tenant default template for the type is used.
@@ -463,3 +472,87 @@ class LabelTemplateCollection(BaseCollection):
             options=payload.options,
             albert_id=template_id,
         )
+
+    @validate_call
+    def get_batch_label_url(
+        self,
+        *,
+        task_id: TaskId,
+        lot_id: str | None = None,
+    ) -> str:
+        """Generate a hazard batch label PDF for a batch task.
+
+        Renders the GHS-style batch label (hazard pictograms, signal word,
+        hazard and precautionary statements) for the formulas on a batch task
+        and returns a short-lived URL for the finished PDF. This label type is
+        rendered by the platform's document generator rather than from a
+        tenant label template file.
+
+        !!! example
+            ```python
+            url = client.label_templates.get_batch_label_url(task_id="TAS1234")
+            # 'https://s3.us-west-2.amazonaws.com/...'
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The batch Task ID (format ``TAS...``).
+        lot_id : str, optional
+            A specific lot number to print, when the task produced multiple
+            lots.
+
+        Returns
+        -------
+        str
+            A short-lived URL for downloading the generated batch label PDF.
+        """
+        params = {"taskId": task_id, "lotId": lot_id}
+        response = self.session.get(f"{self.base_path}/sds", params=params)
+        return response.json()["data"]
+
+    @validate_call
+    def get_formula_report_url(
+        self,
+        *,
+        formula_id: InventoryId,
+        template_id: LabelTemplateId | None = None,
+        lot_id: str | None = None,
+    ) -> str:
+        """Generate a formula report PDF.
+
+        Renders a full report for a formula (composition, property task
+        results, and related details) using a ``formulareport`` template and
+        returns a short-lived URL for the finished PDF.
+
+        !!! example
+            ```python
+            url = client.label_templates.get_formula_report_url(
+                formula_id="INVA1234-001",
+                template_id="TMP123",
+            )
+            # 'https://s3.us-west-2.amazonaws.com/...'
+            ```
+
+        Parameters
+        ----------
+        formula_id : InventoryId
+            The formula Inventory ID (format ``INV...``).
+        template_id : LabelTemplateId, optional
+            The ``formulareport`` template to render with (format ``TMP...``).
+            When not provided, the tenant default is used.
+        lot_id : str, optional
+            Restrict the report to a specific lot.
+
+        Returns
+        -------
+        str
+            A short-lived URL for downloading the generated report PDF.
+        """
+        params = {
+            "formulaId": formula_id,
+            "templateId": template_id,
+            "lotId": lot_id,
+        }
+        response = self.session.get(f"{self.base_path}/formulareport", params=params)
+        return response.json()["presignedURL"]

--- a/src/albert/collections/label_templates.py
+++ b/src/albert/collections/label_templates.py
@@ -311,7 +311,7 @@ class LabelTemplateCollection(BaseCollection):
         Returns
         -------
         LabelTemplate
-            The updated LabelTemplate, re-fetched from Albert.
+            The updated LabelTemplate.
 
         Notes
         -----

--- a/src/albert/collections/label_templates.py
+++ b/src/albert/collections/label_templates.py
@@ -114,10 +114,19 @@ class LabelTemplateCollection(BaseCollection):
         template's ``metadata``. Without HTML content, the template record is
         created pointing at an already-stored ``template_file``.
 
-        The HTML file is a complete Mustache HTML document whose body is
-        wrapped in a ``{{#labels}} ... {{/labels}}`` section. See the Label
-        Templates page in the docs Examples section for the authoring rules
-        and available fields.
+        The HTML file is a complete, ordinary HTML document whose body is
+        wrapped in a ``{{#labels}} ... {{/labels}}`` section, with Mustache
+        placeholders that are filled from the print payload for the
+        template's ``type``. Inventory label templates, for example, can use
+        ``{{info.inventoryName}}``, ``{{info.vendorLotNumber}}``,
+        ``{{info.expirationDate}}``, ``{{{info.lotNumber}}}`` (barcode
+        image), ``{{{info.lotNumberQrCode}}}`` (QR image),
+        ``{{#info.Symbols}}`` (hazard pictograms), and the full records under
+        ``{{info.AdditionalInfo...}}``, plus ``{{manualFields.<Name>}}`` for
+        user-entered values. The complete per-type field reference is on the
+        Label Templates page in the docs Examples section; to see exactly
+        what a template will receive, call [`get_print_payload`][albert.collections.label_templates.LabelTemplateCollection.get_print_payload]
+        and inspect ``payload.data["labels"]``.
 
         !!! example
             ```python

--- a/src/albert/collections/label_templates.py
+++ b/src/albert/collections/label_templates.py
@@ -1,0 +1,465 @@
+import json
+from collections.abc import Iterator
+from typing import Any
+
+from pydantic import validate_call
+
+from albert.collections.base import BaseCollection
+from albert.collections.pdf_generator import PDFGeneratorCollection
+from albert.core.pagination import AlbertPaginator
+from albert.core.session import AlbertSession
+from albert.core.shared.enums import PaginationMode
+from albert.core.shared.identifiers import (
+    InventoryId,
+    LabelTemplateId,
+    LotId,
+    TaskId,
+)
+from albert.core.utils import ensure_list
+from albert.resources.label_templates import (
+    LabelPrintPayload,
+    LabelTemplate,
+    LabelTemplateType,
+)
+
+
+class LabelTemplateCollection(BaseCollection):
+    """Manage Label Templates in the Albert platform.
+
+    A label template pairs a tenant-scoped Mustache HTML file with page
+    rendering options, and drives printable outputs such as inventory lot
+    barcode labels, batch task labels, and formula reports. Label Template
+    IDs use the ``TMP`` prefix.
+
+    Printing a label is a two-step flow: [`get_print_payload`][albert.collections.label_templates.LabelTemplateCollection.get_print_payload]
+    assembles the label data for an entity (for example a Lot), and
+    [`generate_pdf`][albert.collections.pdf_generator.PDFGeneratorCollection.generate_pdf]
+    renders it to a stored PDF. Use [`generate_label_pdf`][albert.collections.label_templates.LabelTemplateCollection.generate_label_pdf]
+    to run both steps in one call.
+
+    This collection is accessed as ``client.label_templates``.
+
+    !!! example
+        ```python
+        from albert import Albert
+
+        client = Albert()
+        url = client.label_templates.generate_label_pdf(
+            inventory_lot_number_id="LOTB1234",
+        )
+        # 'https://s3.us-west-2.amazonaws.com/...'
+        ```
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The authenticated Albert session used for API calls.
+
+    Attributes
+    ----------
+    base_path : str
+        The base API route for label template requests.
+
+    Methods
+    -------
+    create(label_template, template_html=None, header_html=None, footer_html=None) -> LabelTemplate
+        Create a new label template, optionally uploading its HTML files.
+    get_by_id(id) -> LabelTemplate
+        Get a single label template by its ID.
+    get_all(...) -> Iterator[LabelTemplate]
+        Get all label templates, with optional filters.
+    update(label_template) -> LabelTemplate
+        Update an existing label template.
+    delete(id) -> None
+        Delete a label template by its ID.
+    get_print_payload(...) -> LabelPrintPayload
+        Assemble the render payload for printing a label.
+    generate_label_pdf(...) -> str
+        Generate a label PDF for a Lot and return its download URL.
+    """
+
+    _api_version = "v3"
+    _updatable_attributes = {"name", "template_file", "default", "metadata"}
+
+    def __init__(self, *, session: AlbertSession):
+        """Initialize a LabelTemplateCollection.
+
+        Parameters
+        ----------
+        session : AlbertSession
+            The authenticated Albert session used for API calls.
+        """
+        super().__init__(session=session)
+        self.base_path = f"/api/{LabelTemplateCollection._api_version}/template"
+
+    @validate_call
+    def create(
+        self,
+        *,
+        label_template: LabelTemplate,
+        template_html: str | bytes | None = None,
+        header_html: str | bytes | None = None,
+        footer_html: str | bytes | None = None,
+    ) -> LabelTemplate:
+        """Create a new label template.
+
+        When HTML content is provided, it is uploaded and stored for the
+        tenant alongside the new template. ``template_html`` is stored under
+        the ``template_file`` name, and ``header_html`` / ``footer_html`` are
+        stored under the ``header`` / ``footer`` file names from the
+        template's ``metadata``. Without HTML content, the template record is
+        created pointing at an already-stored ``template_file``.
+
+        The HTML file is a complete Mustache HTML document whose body is
+        wrapped in a ``{{#labels}} ... {{/labels}}`` section. See the Label
+        Templates page in the docs Examples section for the authoring rules
+        and available fields.
+
+        !!! example
+            ```python
+            from pathlib import Path
+
+            from albert.resources.label_templates import LabelTemplate, LabelTemplateType
+
+            template = LabelTemplate(
+                name="3x1 Inventory Label",
+                type=LabelTemplateType.INVENTORY,
+                template_file="3x1-inventory-label.html",
+                metadata={"width": "3in", "height": "1in"},
+            )
+            created = client.label_templates.create(
+                label_template=template,
+                template_html=Path("3x1-inventory-label.html").read_text(),
+            )
+            created.id
+            # 'TMP123'
+            ```
+
+        Parameters
+        ----------
+        label_template : LabelTemplate
+            The label template to create. ``name`` is required; ``type`` and
+            ``template_file`` should be set for the template to be usable.
+        template_html : str or bytes, optional
+            The Mustache HTML content for the template body. Stored under the
+            ``template_file`` name.
+        header_html : str or bytes, optional
+            The Mustache HTML content for the page header. Stored under the
+            ``metadata["header"]`` file name.
+        footer_html : str or bytes, optional
+            The Mustache HTML content for the page footer. Stored under the
+            ``metadata["footer"]`` file name.
+
+        Returns
+        -------
+        LabelTemplate
+            The newly created label template, fully populated.
+
+        Raises
+        ------
+        ValueError
+            If HTML content is provided without a corresponding file name on
+            the template.
+        """
+        payload = label_template.model_dump(
+            by_alias=True, mode="json", exclude_none=True, exclude_unset=True
+        )
+
+        if template_html is None and header_html is None and footer_html is None:
+            response = self.session.post(self.base_path, json=payload)
+            return self.get_by_id(id=response.json()["albertId"])
+
+        metadata = label_template.metadata or {}
+        files = []
+        if template_html is not None:
+            if not label_template.template_file:
+                raise ValueError("`template_file` must be set to upload `template_html`.")
+            files.append(("file", (label_template.template_file, template_html, "text/html")))
+        if header_html is not None:
+            header_file = metadata.get("header")
+            if not header_file:
+                raise ValueError("`metadata['header']` must be set to upload `header_html`.")
+            files.append(("headerFile", (header_file, header_html, "text/html")))
+        if footer_html is not None:
+            footer_file = metadata.get("footer")
+            if not footer_file:
+                raise ValueError("`metadata['footer']` must be set to upload `footer_html`.")
+            files.append(("footerFile", (footer_file, footer_html, "text/html")))
+
+        response = self.session.post(
+            self.base_path,
+            files=files,
+            data={"templateInfo": json.dumps(payload)},
+            # Unset the session's JSON content type so the multipart boundary is used.
+            headers={"Content-Type": None},
+        )
+        return self.get_by_id(id=response.json()["albertId"])
+
+    @validate_call
+    def get_by_id(self, *, id: LabelTemplateId) -> LabelTemplate:
+        """Get a label template by its ID.
+
+        !!! example
+            ```python
+            template = client.label_templates.get_by_id(id="TMP123")
+            template.name
+            # 'Small Inventory Label'
+            ```
+
+        Parameters
+        ----------
+        id : LabelTemplateId
+            The Label Template ID (format ``TMP...``).
+
+        Returns
+        -------
+        LabelTemplate
+            The fully populated LabelTemplate.
+        """
+        response = self.session.get(f"{self.base_path}/{id}")
+        return LabelTemplate(**response.json())
+
+    @validate_call
+    def get_all(
+        self,
+        *,
+        name: str | None = None,
+        type: LabelTemplateType | list[LabelTemplateType] | None = None,
+        start_key: str | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[LabelTemplate]:
+        """Get all label templates, with optional filters.
+
+        Results are returned as a lazily paginated iterator.
+
+        !!! example
+            ```python
+            from albert.resources.label_templates import LabelTemplateType
+
+            for template in client.label_templates.get_all(
+                type=LabelTemplateType.INVENTORY,
+            ):
+                print(template.id, template.name, template.default)
+            ```
+
+        Parameters
+        ----------
+        name : str, optional
+            Filter templates by name.
+        type : LabelTemplateType or list[LabelTemplateType], optional
+            Filter templates by type (e.g. ``inventory`` for inventory lot
+            labels).
+        start_key : str, optional
+            Provide the ``lastKey`` from a previous request to resume
+            pagination.
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over
+            all matches.
+
+        Returns
+        -------
+        Iterator[LabelTemplate]
+            A lazily paginated iterator of matching label templates.
+        """
+        params = {
+            "name": name,
+            "type": ensure_list(type),
+            "startKey": start_key,
+        }
+        return AlbertPaginator(
+            mode=PaginationMode.KEY,
+            path=self.base_path,
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [LabelTemplate(**item) for item in items],
+        )
+
+    @validate_call
+    def update(self, *, label_template: LabelTemplate) -> LabelTemplate:
+        """Update an existing label template.
+
+        Fetch a template (e.g. via [`get_by_id`][albert.collections.label_templates.LabelTemplateCollection.get_by_id]), modify the updatable
+        fields on the returned object, then pass it here. The template is
+        matched by its ``id``.
+
+        !!! example
+            ```python
+            template = client.label_templates.get_by_id(id="TMP123")
+            template.name = "Small Inventory Label (2in)"
+            updated = client.label_templates.update(label_template=template)
+            ```
+
+        Parameters
+        ----------
+        label_template : LabelTemplate
+            The label template to update. Its ``id`` must be set.
+
+        Returns
+        -------
+        LabelTemplate
+            The updated LabelTemplate, re-fetched from Albert.
+
+        Notes
+        -----
+        The following fields can be updated: ``default``, ``metadata``,
+        ``name``, ``template_file``.
+        """
+        current = self.get_by_id(id=label_template.id)
+        patch_payload = self._generate_patch_payload(
+            existing=current,
+            updated=label_template,
+            generate_metadata_diff=False,
+        )
+        if patch_payload.data:
+            self.session.patch(
+                f"{self.base_path}/{label_template.id}",
+                json=patch_payload.model_dump(mode="json", by_alias=True),
+            )
+        return self.get_by_id(id=label_template.id)
+
+    @validate_call
+    def delete(self, *, id: LabelTemplateId) -> None:
+        """Delete a label template by its ID.
+
+        !!! example
+            ```python
+            client.label_templates.delete(id="TMP123")
+            ```
+
+        Parameters
+        ----------
+        id : LabelTemplateId
+            The Label Template ID to delete (format ``TMP...``).
+
+        Returns
+        -------
+        None
+        """
+        self.session.delete(f"{self.base_path}/{id}")
+
+    @validate_call
+    def get_print_payload(
+        self,
+        *,
+        type: LabelTemplateType = LabelTemplateType.INVENTORY,
+        inventory_lot_number_id: LotId | list[LotId] | None = None,
+        albert_id: InventoryId | None = None,
+        task_id: TaskId | None = None,
+        lot_id: str | None = None,
+        template_id: LabelTemplateId | None = None,
+        jurisdiction: str | None = None,
+    ) -> LabelPrintPayload:
+        """Assemble the render payload for printing a label.
+
+        Gathers everything needed to render the label for the given entity:
+        the resolved template file URLs (``payload.template.body`` is the URL
+        of the tenant's Mustache HTML file), the per-entity label data
+        (including barcode and QR code images), page options, and the storage
+        destination. Pass the payload fields to
+        [`generate_pdf`][albert.collections.pdf_generator.PDFGeneratorCollection.generate_pdf]
+        to render the PDF, or use [`generate_label_pdf`][albert.collections.label_templates.LabelTemplateCollection.generate_label_pdf]
+        to do both steps in one call.
+
+        !!! example
+            ```python
+            payload = client.label_templates.get_print_payload(
+                inventory_lot_number_id="LOTB1234",
+                template_id="TMP123",
+            )
+            payload.template.body
+            # 'https://s3.us-west-2.amazonaws.com/.../templates/TEN123/small-inventory-label.html'
+            ```
+
+        Parameters
+        ----------
+        type : LabelTemplateType, optional
+            The kind of label to assemble. Defaults to ``inventory`` (Lot
+            barcode labels).
+        inventory_lot_number_id : LotId or list[LotId], optional
+            The Lot ID(s) to print (format ``LOT...``). Required when ``type``
+            is ``inventory``.
+        albert_id : InventoryId, optional
+            The Inventory ID (format ``INV...``). Required when ``type`` is
+            ``batch`` or ``property``.
+        task_id : TaskId, optional
+            The Task ID (format ``TAS...``). Required when ``type`` is
+            ``property``, ``batchlabel``, or ``batchtemplate``.
+        lot_id : str, optional
+            The lot number. Required when ``type`` is ``batch``.
+        template_id : LabelTemplateId, optional
+            The Label Template ID to render with (format ``TMP...``). When not
+            provided, the tenant default template for the type is used.
+        jurisdiction : str, optional
+            The jurisdiction used to select hazard pictograms.
+
+        Returns
+        -------
+        LabelPrintPayload
+            The assembled label render payload.
+        """
+        params: dict[str, Any] = {
+            "type": type,
+            "inventoryLotNumberId": ensure_list(inventory_lot_number_id) or None,
+            "albertId": albert_id,
+            "taskId": task_id,
+            "lotId": lot_id,
+            "templateId": template_id,
+            "jurisdiction": jurisdiction,
+        }
+        response = self.session.get(f"{self.base_path}/print", params=params)
+        return LabelPrintPayload(**response.json())
+
+    @validate_call
+    def generate_label_pdf(
+        self,
+        *,
+        inventory_lot_number_id: LotId | list[LotId],
+        template_id: LabelTemplateId | None = None,
+        jurisdiction: str | None = None,
+    ) -> str:
+        """Generate a barcode label PDF for one or more Lots.
+
+        Assembles the label data for the given Lot(s) and renders it to a
+        stored PDF using the given template (or the tenant default). This is
+        the one-call equivalent of [`get_print_payload`][albert.collections.label_templates.LabelTemplateCollection.get_print_payload]
+        followed by [`generate_pdf`][albert.collections.pdf_generator.PDFGeneratorCollection.generate_pdf].
+
+        !!! example
+            ```python
+            url = client.label_templates.generate_label_pdf(
+                inventory_lot_number_id="LOTB1234",
+                template_id="TMP123",
+            )
+            # 'https://s3.us-west-2.amazonaws.com/...'
+            ```
+
+        Parameters
+        ----------
+        inventory_lot_number_id : LotId or list[LotId]
+            The Lot ID(s) to print (format ``LOT...``).
+        template_id : LabelTemplateId, optional
+            The Label Template ID to render with (format ``TMP...``). When not
+            provided, the tenant default inventory label template is used.
+        jurisdiction : str, optional
+            The jurisdiction used to select hazard pictograms.
+
+        Returns
+        -------
+        str
+            A short-lived URL for downloading the generated label PDF.
+        """
+        payload = self.get_print_payload(
+            type=LabelTemplateType.INVENTORY,
+            inventory_lot_number_id=inventory_lot_number_id,
+            template_id=template_id,
+            jurisdiction=jurisdiction,
+        )
+        pdf_generator = PDFGeneratorCollection(session=self.session)
+        return pdf_generator.generate_pdf(
+            template=payload.template,
+            data=payload.data,
+            s3_storage=payload.s3_storage,
+            options=payload.options,
+            albert_id=template_id,
+        )

--- a/src/albert/collections/pdf_generator.py
+++ b/src/albert/collections/pdf_generator.py
@@ -1,0 +1,191 @@
+from typing import Any
+
+from pydantic import validate_call
+
+from albert.collections.base import BaseCollection
+from albert.core.session import AlbertSession
+from albert.resources.pdf_generator import PDFS3Storage, PDFTemplate
+
+
+class PDFGeneratorCollection(BaseCollection):
+    """Manage PDF, barcode, and QR code generation in the Albert platform.
+
+    Renders Mustache HTML templates with data into stored PDFs, and generates
+    barcode and QR code images from text. This is the rendering engine behind
+    printable label templates; see
+    [`LabelTemplateCollection`][albert.collections.label_templates.LabelTemplateCollection]
+    for the higher-level label workflow.
+
+    This collection is accessed as ``client.pdf_generator``.
+
+    !!! example
+        ```python
+        from albert import Albert
+
+        client = Albert()
+        barcode = client.pdf_generator.generate_barcode(text="B1234-001")
+        barcode[:22]
+        # 'data:image/png;base64,'
+        ```
+
+    Parameters
+    ----------
+    session : AlbertSession
+        The authenticated Albert session used for API calls.
+
+    Attributes
+    ----------
+    base_path : str
+        The base API route for PDF generator requests.
+
+    Methods
+    -------
+    generate_pdf(template, data, s3_storage, options=None, albert_id=None) -> str
+        Render a PDF from an HTML template and data, returning a download URL.
+    generate_barcode(text, text_size=None, as_signed_url=False) -> str
+        Generate a barcode image from text.
+    generate_qr_code(text) -> str
+        Generate a QR code image from text.
+    """
+
+    _api_version = "v2"
+
+    def __init__(self, *, session: AlbertSession):
+        """Initialize a PDFGeneratorCollection.
+
+        Parameters
+        ----------
+        session : AlbertSession
+            The authenticated Albert session used for API calls.
+        """
+        super().__init__(session=session)
+        self.base_path = f"/api/{PDFGeneratorCollection._api_version}/pdfgenerator"
+
+    @validate_call
+    def generate_pdf(
+        self,
+        *,
+        template: PDFTemplate,
+        data: dict[str, Any],
+        s3_storage: PDFS3Storage,
+        options: dict[str, Any] | None = None,
+        albert_id: str | None = None,
+    ) -> str:
+        """Render a PDF from an HTML template and data.
+
+        The template HTML is rendered with ``data`` using Mustache
+        placeholders, printed to PDF, and stored at the ``s3_storage``
+        destination. A short-lived download URL for the PDF is returned.
+
+        The inputs typically come from a
+        [`LabelPrintPayload`][albert.resources.label_templates.LabelPrintPayload]
+        produced by
+        [`get_print_payload`][albert.collections.label_templates.LabelTemplateCollection.get_print_payload].
+
+        !!! example
+            ```python
+            payload = client.label_templates.get_print_payload(
+                inventory_lot_number_id="LOTB1234",
+            )
+            url = client.pdf_generator.generate_pdf(
+                template=payload.template,
+                data=payload.data,
+                s3_storage=payload.s3_storage,
+                options=payload.options,
+            )
+            ```
+
+        Parameters
+        ----------
+        template : PDFTemplate
+            The HTML template sources to render. ``template.body`` is required.
+        data : dict[str, Any]
+            The values substituted into the template's Mustache placeholders.
+        s3_storage : PDFS3Storage
+            Where the generated PDF is stored.
+        options : dict[str, Any], optional
+            Page rendering options such as ``width``, ``height``, ``format``,
+            ``margin``, and ``landscape``.
+        albert_id : str, optional
+            An identifier echoed back in the response.
+
+        Returns
+        -------
+        str
+            A short-lived URL for downloading the generated PDF.
+        """
+        payload: dict[str, Any] = {
+            "template": template.model_dump(by_alias=True, mode="json", exclude_none=True),
+            "data": data,
+            "s3Storage": s3_storage.model_dump(by_alias=True, mode="json", exclude_none=True),
+        }
+        if options is not None:
+            payload["options"] = options
+        if albert_id is not None:
+            payload["albertId"] = albert_id
+
+        response = self.session.post(f"{self.base_path}/generate", json=payload)
+        return response.json()["presignedURL"]
+
+    @validate_call
+    def generate_barcode(
+        self,
+        *,
+        text: str,
+        text_size: int | None = None,
+        as_signed_url: bool = False,
+    ) -> str:
+        """Generate a barcode image from text.
+
+        !!! example
+            ```python
+            barcode = client.pdf_generator.generate_barcode(text="B1234-001")
+            barcode[:22]
+            # 'data:image/png;base64,'
+            ```
+
+        Parameters
+        ----------
+        text : str
+            The text to encode in the barcode.
+        text_size : int, optional
+            The size of the human-readable text rendered below the barcode.
+        as_signed_url : bool, optional
+            When True, return a short-lived URL for the stored barcode image
+            instead of an inline ``data:`` URI. Defaults to False.
+
+        Returns
+        -------
+        str
+            The barcode image as a base64 ``data:`` URI, or a short-lived URL
+            when ``as_signed_url`` is True.
+        """
+        params: dict[str, Any] = {"text": text, "textsize": text_size}
+        if as_signed_url:
+            params["s3url"] = "true"
+        response = self.session.get(f"{self.base_path}/barcode", params=params)
+        return response.json()["barCode"]
+
+    @validate_call
+    def generate_qr_code(self, *, text: str) -> str:
+        """Generate a QR code image from text.
+
+        !!! example
+            ```python
+            qr = client.pdf_generator.generate_qr_code(text="LOTB1234")
+            qr[:22]
+            # 'data:image/png;base64,'
+            ```
+
+        Parameters
+        ----------
+        text : str
+            The text to encode in the QR code.
+
+        Returns
+        -------
+        str
+            The QR code image as a base64 ``data:`` URI.
+        """
+        response = self.session.get(f"{self.base_path}/qrcode", params={"text": text})
+        return response.json()["qrCode"]

--- a/src/albert/collections/pdf_generator.py
+++ b/src/albert/collections/pdf_generator.py
@@ -107,7 +107,7 @@ class PDFGeneratorCollection(BaseCollection):
             Page rendering options. See [`PDFOptions`][albert.resources.pdf_generator.PDFOptions]
             for the recognized settings; unrecognized keys are ignored.
         albert_id : str, optional
-            An identifier echoed back in the response.
+            An optional identifier to associate with the generated PDF.
 
         Returns
         -------

--- a/src/albert/collections/pdf_generator.py
+++ b/src/albert/collections/pdf_generator.py
@@ -4,7 +4,7 @@ from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
 from albert.core.session import AlbertSession
-from albert.resources.pdf_generator import PDFS3Storage, PDFTemplate
+from albert.resources.pdf_generator import PDFOptions, PDFS3Storage, PDFTemplate
 
 
 class PDFGeneratorCollection(BaseCollection):
@@ -68,7 +68,7 @@ class PDFGeneratorCollection(BaseCollection):
         template: PDFTemplate,
         data: dict[str, Any],
         s3_storage: PDFS3Storage,
-        options: dict[str, Any] | None = None,
+        options: PDFOptions | dict[str, Any] | None = None,
         albert_id: str | None = None,
     ) -> str:
         """Render a PDF from an HTML template and data.
@@ -103,9 +103,9 @@ class PDFGeneratorCollection(BaseCollection):
             The values substituted into the template's Mustache placeholders.
         s3_storage : PDFS3Storage
             Where the generated PDF is stored.
-        options : dict[str, Any], optional
-            Page rendering options such as ``width``, ``height``, ``format``,
-            ``margin``, and ``landscape``.
+        options : PDFOptions or dict[str, Any], optional
+            Page rendering options. See [`PDFOptions`][albert.resources.pdf_generator.PDFOptions]
+            for the recognized settings; unrecognized keys are ignored.
         albert_id : str, optional
             An identifier echoed back in the response.
 
@@ -119,6 +119,8 @@ class PDFGeneratorCollection(BaseCollection):
             "data": data,
             "s3Storage": s3_storage.model_dump(by_alias=True, mode="json", exclude_none=True),
         }
+        if isinstance(options, PDFOptions):
+            options = options.model_dump(by_alias=True, mode="json", exclude_none=True)
         if options is not None:
             payload["options"] = options
         if albert_id is not None:

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -18,6 +18,7 @@ _ALBERT_PREFIXES = {
     "DataTemplateId": "DAT",
     "EntityTypeId": "ETT",
     "InventoryId": "INV",
+    "LabelTemplateId": "TMP",
     "LinkId": "LNK",
     "LotId": "LOT",
     "NotebookId": "NTB",
@@ -269,6 +270,13 @@ def ensure_project_search_id(id: str) -> str:
 
 
 SearchProjectId = Annotated[str, AfterValidator(ensure_project_search_id)]
+
+
+def ensure_label_template_id(id: str) -> str:
+    return _ensure_albert_id(id, "LabelTemplateId")
+
+
+LabelTemplateId = Annotated[str, AfterValidator(ensure_label_template_id)]
 
 
 def ensure_link_id(id: str) -> str:

--- a/src/albert/resources/label_templates.py
+++ b/src/albert/resources/label_templates.py
@@ -43,10 +43,14 @@ class LabelTemplateType(str, Enum):
 class LabelTemplate(BaseResource):
     """A label template in the Albert platform.
 
-    A label template pairs a tenant-scoped Mustache HTML file with page
-    rendering options. Templates drive the printable outputs in Albert, such
-    as inventory lot barcode labels, batch task labels, and formula reports.
-    Label Template IDs use the ``TMP`` prefix.
+    A label template pairs a tenant-scoped HTML file with page rendering
+    options. The HTML file is an ordinary HTML document containing Mustache
+    placeholders (e.g. ``{{info.inventoryName}}``) that are filled at render
+    time from the print payload for the template's ``type``: the payload's
+    ``data["labels"]`` list holds one entry per printed entity, and each
+    entry's fields are read under ``info``. Templates drive the printable
+    outputs in Albert, such as inventory lot barcode labels, batch task
+    labels, and formula reports. Label Template IDs use the ``TMP`` prefix.
 
     See [`LabelTemplateCollection`][albert.collections.label_templates.LabelTemplateCollection]
     for creating, retrieving, and rendering label templates.

--- a/src/albert/resources/label_templates.py
+++ b/src/albert/resources/label_templates.py
@@ -1,0 +1,116 @@
+from enum import Enum
+from typing import Any
+
+from pydantic import Field
+
+from albert.core.shared.models.base import BaseAlbertModel, BaseResource
+from albert.resources.pdf_generator import PDFS3Storage, PDFTemplate
+
+
+class LabelTemplateType(str, Enum):
+    """The type of a label template, describing what it renders.
+
+    Attributes
+    ----------
+    BATCH : str
+        Product/Formula lot labels.
+    PROPERTY : str
+        Property task labels.
+    INVENTORY : str
+        Inventory lot labels.
+    BATCH_LABEL : str
+        Batch task labels.
+    FORMULA_REPORT : str
+        Product/Formula reports.
+    BATCH_TEMPLATE : str
+        Batch task templates.
+    PROPERTY_TASK_REPORT : str
+        Property task reports.
+    GENERAL_TASK_LABEL : str
+        General task labels.
+    """
+
+    BATCH = "batch"
+    PROPERTY = "property"
+    INVENTORY = "inventory"
+    BATCH_LABEL = "batchlabel"
+    FORMULA_REPORT = "formulareport"
+    BATCH_TEMPLATE = "batchtemplate"
+    PROPERTY_TASK_REPORT = "propertytaskreport"
+    GENERAL_TASK_LABEL = "generaltasklabel"
+
+
+class LabelTemplate(BaseResource):
+    """A label template in the Albert platform.
+
+    A label template pairs a tenant-scoped Mustache HTML file with page
+    rendering options. Templates drive the printable outputs in Albert, such
+    as inventory lot barcode labels, batch task labels, and formula reports.
+    Label Template IDs use the ``TMP`` prefix.
+
+    See [`LabelTemplateCollection`][albert.collections.label_templates.LabelTemplateCollection]
+    for creating, retrieving, and rendering label templates.
+    """
+
+    id: str | None = Field(default=None, alias="albertId")
+    """The Albert ID of the label template (format ``TMP...``)."""
+
+    name: str = Field(min_length=1, max_length=255)
+    """The display name of the template. Unique per tenant."""
+
+    description: str | None = Field(default=None)
+    """A human-readable description of the template, optional."""
+
+    type: LabelTemplateType | None = Field(default=None)
+    """The type of output the template renders (e.g. ``inventory`` for
+    inventory lot labels)."""
+
+    template_file: str | None = Field(default=None, alias="templateFile", max_length=500)
+    """The file name of the Mustache HTML template stored for the tenant
+    (e.g. ``"my-label.html"``)."""
+
+    default: bool | None = Field(default=None)
+    """When True, this template is the tenant default for its type."""
+
+    custom_ui_type: str | None = Field(default=None, alias="customUiType", frozen=True)
+    """The display name of the template type shown in the UI. Read-only."""
+
+    metadata: dict[str, Any] | None = Field(default=None)
+    """Page rendering options and template settings, such as ``width``,
+    ``height``, ``margin``, and header/footer file names, optional."""
+
+
+class LabelPrintPayload(BaseAlbertModel):
+    """The assembled render payload for printing a label.
+
+    Contains everything needed to generate the final PDF: the resolved
+    template file URLs, the label data for each entity, page options, and the
+    storage destination. Pass these fields to
+    [`generate_pdf`][albert.collections.pdf_generator.PDFGeneratorCollection.generate_pdf]
+    to render the PDF, or use
+    [`generate_label_pdf`][albert.collections.label_templates.LabelTemplateCollection.generate_label_pdf]
+    to do both steps in one call.
+    """
+
+    template: PDFTemplate
+    """The resolved template file URLs. ``template.body`` is the URL of the
+    tenant's Mustache HTML file."""
+
+    data: dict[str, Any] = Field(default_factory=dict)
+    """The label data rendered into the template. For labels this contains a
+    ``labels`` list with one entry per printed entity, whose fields the
+    template reads under ``info`` (e.g. ``{{info.inventoryName}}``)."""
+
+    s3_storage: PDFS3Storage = Field(alias="s3Storage")
+    """The storage destination for the generated PDF."""
+
+    options: dict[str, Any] | None = Field(default=None)
+    """Page rendering options such as ``width``, ``height``, and ``margin``,
+    optional."""
+
+    metadata: Any | None = Field(default=None)
+    """Template settings parsed from the template file's metadata block,
+    optional."""
+
+    manual_fields: Any | None = Field(default=None, alias="manualFields")
+    """Fields the template expects the user to fill in manually, optional."""

--- a/src/albert/resources/pdf_generator.py
+++ b/src/albert/resources/pdf_generator.py
@@ -8,6 +8,15 @@ from albert.core.base import BaseAlbertModel
 class PDFTemplate(BaseAlbertModel):
     """The HTML template sources used to render a PDF.
 
+    Each source is an HTML file with Mustache placeholders: ``{{field}}``
+    inserts a value, ``{{#list}}...{{/list}}`` repeats a block per item, and
+    ``{{{field}}}`` inserts without HTML escaping (needed for image URLs).
+    The valid placeholder names are exactly the keys of the ``data`` object
+    supplied at render time, using dotted paths for nested values. Label
+    payloads pass ``data={"labels": [...]}``, so those templates wrap their
+    body in ``{{#labels}}...{{/labels}}`` and read each entity's fields under
+    ``{{info.<field>}}``.
+
     When ``header`` or ``footer`` is set, the pages render with that header or
     footer template. Header and footer templates can show page numbers and
     document metadata via elements with the classes ``pageNumber``,

--- a/src/albert/resources/pdf_generator.py
+++ b/src/albert/resources/pdf_generator.py
@@ -6,7 +6,14 @@ from albert.core.base import BaseAlbertModel
 
 
 class PDFTemplate(BaseAlbertModel):
-    """The HTML template sources used to render a PDF."""
+    """The HTML template sources used to render a PDF.
+
+    When ``header`` or ``footer`` is set, the pages render with that header or
+    footer template. Header and footer templates can show page numbers and
+    document metadata via elements with the classes ``pageNumber``,
+    ``totalPages``, ``date``, and ``title`` (e.g.
+    ``<span class="pageNumber"></span>``).
+    """
 
     body: str
     """URL or S3 path of the Mustache HTML template for the document body."""
@@ -16,6 +23,54 @@ class PDFTemplate(BaseAlbertModel):
 
     footer: str | None = Field(default=None)
     """URL or S3 path of the Mustache HTML template for the page footer, optional."""
+
+
+class PDFMargin(BaseAlbertModel):
+    """Page margins for a rendered PDF, as CSS lengths (e.g. ``"0mm"``, ``"0.5in"``)."""
+
+    top: str | None = Field(default=None)
+    """Top margin."""
+
+    bottom: str | None = Field(default=None)
+    """Bottom margin."""
+
+    left: str | None = Field(default=None)
+    """Left margin."""
+
+    right: str | None = Field(default=None)
+    """Right margin."""
+
+
+class PDFOptions(BaseAlbertModel):
+    """Page rendering options for a generated PDF.
+
+    These are the only rendering settings the PDF generator reads; any other
+    keys are ignored. Set either ``format`` or an explicit ``width`` and
+    ``height`` pair (both must be set for the pair to apply).
+    """
+
+    width: str | None = Field(default=None)
+    """Page width as a CSS length (e.g. ``"3in"``). Applied together with ``height``."""
+
+    height: str | None = Field(default=None)
+    """Page height as a CSS length (e.g. ``"1in"``). Applied together with ``width``."""
+
+    format: str | None = Field(default=None)
+    """Named paper format (e.g. ``"A4"``, ``"Letter"``). Alternative to
+    ``width``/``height``."""
+
+    margin: PDFMargin | None = Field(default=None)
+    """Page margins, optional."""
+
+    landscape: bool | None = Field(default=None)
+    """When True, render in landscape orientation."""
+
+    render_background_image: bool | None = Field(default=None, alias="renderBackgroundImage")
+    """When True, print CSS background colors and images."""
+
+    hide_header_from_first_page: bool | None = Field(default=None, alias="hideHeaderFromFirstPage")
+    """When True and a header template is set, the first page renders without
+    the header."""
 
 
 class PDFS3Storage(BaseAlbertModel):
@@ -50,9 +105,9 @@ class PDFGenerationRequest(BaseAlbertModel):
     s3_storage: PDFS3Storage = Field(alias="s3Storage")
     """Where the generated PDF is stored."""
 
-    options: dict[str, Any] | None = Field(default=None)
-    """Page rendering options such as ``width``, ``height``, ``format``,
-    ``margin``, and ``landscape``, optional."""
+    options: PDFOptions | dict[str, Any] | None = Field(default=None)
+    """Page rendering options, optional. See [`PDFOptions`][albert.resources.pdf_generator.PDFOptions]
+    for the recognized settings."""
 
     albert_id: str | None = Field(default=None, alias="albertId")
     """An identifier echoed back in the response, optional."""

--- a/src/albert/resources/pdf_generator.py
+++ b/src/albert/resources/pdf_generator.py
@@ -119,4 +119,4 @@ class PDFGenerationRequest(BaseAlbertModel):
     for the recognized settings."""
 
     albert_id: str | None = Field(default=None, alias="albertId")
-    """An identifier echoed back in the response, optional."""
+    """An identifier to associate with the generated PDF, optional."""

--- a/src/albert/resources/pdf_generator.py
+++ b/src/albert/resources/pdf_generator.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from pydantic import Field
+
+from albert.core.base import BaseAlbertModel
+
+
+class PDFTemplate(BaseAlbertModel):
+    """The HTML template sources used to render a PDF."""
+
+    body: str
+    """URL or S3 path of the Mustache HTML template for the document body."""
+
+    header: str | None = Field(default=None)
+    """URL or S3 path of the Mustache HTML template for the page header, optional."""
+
+    footer: str | None = Field(default=None)
+    """URL or S3 path of the Mustache HTML template for the page footer, optional."""
+
+
+class PDFS3Storage(BaseAlbertModel):
+    """The storage destination for a generated PDF."""
+
+    bucket: str = Field(alias="Bucket")
+    """The S3 bucket the generated PDF is stored in."""
+
+    key: str = Field(alias="Key")
+    """The S3 object key the generated PDF is stored under."""
+
+    acl: str | None = Field(default=None, alias="ACL")
+    """The S3 ACL applied to the generated PDF, optional."""
+
+    force_overwrite: bool | None = Field(default=None, alias="forceOverwrite")
+    """When True, regenerate the PDF even if a cached copy already exists."""
+
+
+class PDFGenerationRequest(BaseAlbertModel):
+    """A request to render a PDF from HTML templates and data.
+
+    The ``template`` HTML is rendered with ``data`` using Mustache placeholders,
+    printed to PDF, and stored at the ``s3_storage`` destination.
+    """
+
+    template: PDFTemplate
+    """The HTML template sources to render."""
+
+    data: dict[str, Any] = Field(default_factory=dict)
+    """The values substituted into the template's Mustache placeholders."""
+
+    s3_storage: PDFS3Storage = Field(alias="s3Storage")
+    """Where the generated PDF is stored."""
+
+    options: dict[str, Any] | None = Field(default=None)
+    """Page rendering options such as ``width``, ``height``, ``format``,
+    ``margin``, and ``landscape``, optional."""
+
+    albert_id: str | None = Field(default=None, alias="albertId")
+    """An identifier echoed back in the response, optional."""

--- a/tests/collections/test_label_templates.py
+++ b/tests/collections/test_label_templates.py
@@ -1,0 +1,81 @@
+from albert.client import Albert
+from albert.resources.label_templates import (
+    LabelPrintPayload,
+    LabelTemplate,
+    LabelTemplateType,
+)
+from albert.resources.lots import Lot
+
+
+def test_label_template_get_by_id(client: Albert, seeded_label_templates: list[LabelTemplate]):
+    """Test get_by_id returns a fully populated LabelTemplate."""
+    seeded = seeded_label_templates[0]
+    fetched = client.label_templates.get_by_id(id=seeded.id)
+    assert isinstance(fetched, LabelTemplate)
+    assert fetched.id == seeded.id
+    assert fetched.name == seeded.name
+    assert fetched.type == LabelTemplateType.INVENTORY
+    assert fetched.template_file == seeded.template_file
+
+
+def test_label_template_get_all(client: Albert, seeded_label_templates: list[LabelTemplate]):
+    """Test get_all returns matching LabelTemplate items."""
+    seeded = seeded_label_templates[0]
+    results = list(client.label_templates.get_all(type=LabelTemplateType.INVENTORY, max_items=50))
+    assert results
+    for template in results:
+        assert isinstance(template, LabelTemplate)
+        assert template.type == LabelTemplateType.INVENTORY
+    assert any(template.id == seeded.id for template in results)
+
+
+def test_label_template_update(client: Albert, seeded_label_templates: list[LabelTemplate]):
+    """Test update changes the name of a label template."""
+    seeded = seeded_label_templates[0]
+    template = client.label_templates.get_by_id(id=seeded.id)
+    updated_name = f"{template.name}-updated"
+    template.name = updated_name
+    updated = client.label_templates.update(label_template=template)
+    assert updated.name == updated_name
+
+    # Restore the original name so other tests see consistent state
+    updated.name = seeded.name
+    restored = client.label_templates.update(label_template=updated)
+    assert restored.name == seeded.name
+
+
+def test_label_template_get_print_payload(
+    client: Albert,
+    seeded_label_templates: list[LabelTemplate],
+    seeded_lots: list[Lot],
+):
+    """Test get_print_payload assembles the label render payload for a Lot."""
+    seeded_template = seeded_label_templates[0]
+    seeded_lot = seeded_lots[0]
+
+    payload = client.label_templates.get_print_payload(
+        inventory_lot_number_id=seeded_lot.id,
+        template_id=seeded_template.id,
+    )
+    assert isinstance(payload, LabelPrintPayload)
+    assert payload.template.body.endswith(seeded_template.template_file)
+    assert payload.s3_storage.bucket
+    assert payload.s3_storage.key
+    assert payload.data.get("labels")
+
+
+def test_label_template_generate_label_pdf(
+    client: Albert,
+    seeded_label_templates: list[LabelTemplate],
+    seeded_lots: list[Lot],
+):
+    """Test generate_label_pdf returns a download URL for the rendered label."""
+    seeded_template = seeded_label_templates[0]
+    seeded_lot = seeded_lots[0]
+
+    url = client.label_templates.generate_label_pdf(
+        inventory_lot_number_id=seeded_lot.id,
+        template_id=seeded_template.id,
+    )
+    assert isinstance(url, str)
+    assert url.startswith("http")

--- a/tests/collections/test_pdf_generator.py
+++ b/tests/collections/test_pdf_generator.py
@@ -1,0 +1,19 @@
+from albert.client import Albert
+
+
+def test_generate_barcode(client: Albert):
+    """Test generate_barcode returns an inline barcode image."""
+    barcode = client.pdf_generator.generate_barcode(text="B1234-001")
+    assert barcode.startswith("data:image/png;base64,")
+
+
+def test_generate_barcode_as_signed_url(client: Albert):
+    """Test generate_barcode returns a URL when as_signed_url is True."""
+    barcode = client.pdf_generator.generate_barcode(text="B1234-001", as_signed_url=True)
+    assert barcode.startswith("http")
+
+
+def test_generate_qr_code(client: Albert):
+    """Test generate_qr_code returns an inline QR code image."""
+    qr_code = client.pdf_generator.generate_qr_code(text="LOTB1234")
+    assert qr_code.startswith("data:image/png;base64,")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,6 +32,7 @@ from albert.resources.data_templates import DataTemplate
 from albert.resources.entity_types import EntityType
 from albert.resources.files import FileCategory, FileInfo, FileNamespace
 from albert.resources.inventory import InventoryCategory, InventoryItem
+from albert.resources.label_templates import LabelTemplate, LabelTemplateType
 from albert.resources.lists import ListItem
 from albert.resources.locations import Location
 from albert.resources.lots import Lot
@@ -417,6 +418,47 @@ def seeded_custom_templates(
     for template in seeded:
         with suppress(NotFoundError):
             client.custom_templates.delete(id=template.id)
+
+
+@pytest.fixture(scope="session")
+def seeded_label_templates(
+    client: Albert,
+    seed_prefix: str,
+) -> Iterator[list[LabelTemplate]]:
+    template = LabelTemplate(
+        name=f"{seed_prefix}-inventory-label",
+        type=LabelTemplateType.INVENTORY,
+        template_file=f"{seed_prefix}-inventory-label.html",
+        description="SDK test inventory label template",
+        metadata={"width": "4in", "height": "2in"},
+    )
+    template_html = (
+        "<html><head>"
+        '<meta charset="UTF-8">'
+        '<!--metadata:{"width": "4in", "height": "2in",'
+        ' "margin": {"top": "0mm", "bottom": "0mm", "left": "0mm", "right": "0mm"}}-->'
+        "<style>body { font-family: Arial, sans-serif; overflow: hidden; }</style>"
+        "</head><body>"
+        "{{#labels}}"
+        "<div><h3>{{info.inventoryName}}</h3>"
+        "<p>{{info.albertId}} | {{info.expirationDate}}</p>"
+        '<img src="{{{info.lotNumber}}}" width="100" height="40" />'
+        '<img src="{{{info.lotNumberQrCode}}}" width="80" height="80" />'
+        "</div>"
+        "{{/labels}}"
+        "</body></html>"
+    )
+    created = client.label_templates.create(
+        label_template=template,
+        template_html=template_html,
+    )
+    seeded = [created]
+
+    yield seeded
+
+    for label_template in seeded:
+        with suppress(NotFoundError):
+            client.label_templates.delete(id=label_template.id)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
## Summary

Adds complete SDK coverage for the label template service (`/api/v3/template`) and the PDF generator service (`/api/v2/pdfgenerator`), enabling programmatic generation of inventory lot barcode labels and every other label template type.

### New collections

- **`client.label_templates`** (`LabelTemplateCollection`, IDs `TMP...`)
  - `create()` - creates a template record and optionally uploads its Mustache HTML file(s) (body/header/footer) in one multipart call
  - `get_by_id()`, `get_all()` (key pagination), `update()` (name, template_file, default, metadata), `delete()`
  - `get_print_payload()` - assembles the label render payload for the six print types (`inventory`, `batch`, `property`, `propertytaskreport`, `batchtemplate`, `generaltasklabel`); `payload.template.body` is the URL of the tenant's stored Mustache HTML
  - `generate_label_pdf()` - one-call flow: Lot ID (+ optional template ID) in, short-lived PDF URL out
  - `get_batch_label_url()` - the `batchlabel` type (GHS hazard batch labels via `/template/sds`), which renders directly and returns a finished PDF URL
  - `get_formula_report_url()` - the `formulareport` type (`/template/formulareport`), also direct-render
- **`client.pdf_generator`** (`PDFGeneratorCollection`)
  - `generate_pdf()` - render Mustache HTML + data to a stored PDF, returns presigned URL; accepts a typed `PDFOptions` model covering the renderer's exact option allowlist (`width`, `height`, `format`, `margin`, `landscape`, `renderBackgroundImage`, `hideHeaderFromFirstPage`)
  - `generate_barcode()` (data URI or signed URL), `generate_qr_code()`

### Resources

- `LabelTemplate`, `LabelTemplateType`, `LabelPrintPayload`
- `PDFTemplate`, `PDFOptions`, `PDFMargin`, `PDFS3Storage`, `PDFGenerationRequest`
- New `LabelTemplateId` (`TMP` prefix) identifier

### Docs

- Collection and resource pages added and linked in the mkdocs nav (alphabetical)
- New **Examples > Label Templates** authoring guide, verified against the api-template/api-pdfgenerator source and production templates: full-document structure, the `<!--metadata:{...}-->` options block, headers/footers with `pageNumber`/`totalPages` classes, the triple-brace rule for barcode/QR image URLs, `manualFields`, and a **per-type field reference for all six print types** plus the two direct-render types
- A complete generic 3x1in inventory label example (no customer content)

### Tests

- Integration tests for label template CRUD, print payload, and end-to-end label PDF generation (new `seeded_label_templates` fixture), plus barcode/QR generation. Relies on CI credentials.
- `get_batch_label_url` / `get_formula_report_url` are intentionally untested: they require a seeded batch task with real composition data for the hazard computation to succeed.

### Intentionally out of scope

- `/template/shoppinglist` (not a template type)
- The document generator service's internal batch-label template (separate service, not tenant-editable)

This PR contains AI-assisted code generated with Claude Code. The author has reviewed and takes full responsibility for all changes.