### PR TITLE
fix(sheets): omit referenceId so new formula columns aren't dropped

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -1255,22 +1255,15 @@ class Sheet(BaseSessionResource):  # noqa:F811
             The names of the formulation columns to add, used as column headers.
         starting_position : dict, optional
             Where to insert the new columns, as a dict with ``reference_id`` (a
-            column ID) and ``position`` (``"leftOf"`` or ``"rightOf"``). Defaults
-            to just right of the leftmost pinned column.
+            column ID) and ``position`` (``"leftOf"`` or ``"rightOf"``). When
+            omitted, the platform chooses the default placement.
 
         Returns
         -------
         list[Column]
             The created formulation columns, in the order requested.
         """
-        if starting_position is None:
-            starting_position = {
-                "reference_id": self.leftmost_pinned_column,
-                "position": "rightOf",
-            }
-        sheet_id = self.id
-
-        endpoint = f"/api/v3/worksheet/sheet/{sheet_id}/columns"
+        endpoint = f"/api/v3/worksheet/sheet/{self.id}/columns"
 
         # In case a user supplied a single formulation name instead of a list
         formulation_names = (
@@ -1278,18 +1271,15 @@ class Sheet(BaseSessionResource):  # noqa:F811
         )
 
         payload = []
-        for formulation_name in (
-            formulation_names
-        ):  # IS there a limit to the number I can add at once? Need to check this.
-            # define payload for this item
-            payload.append(
-                {
-                    "type": "INV",
-                    "name": formulation_name,
-                    "referenceId": starting_position["reference_id"],  # initially defined column
-                    "position": starting_position["position"],
-                }
-            )
+        for formulation_name in formulation_names:
+            entry = {"type": "INV", "name": formulation_name}
+            # When no position is given, omit referenceId/position so the platform
+            # applies its default placement. Sending a null (or stale) referenceId
+            # leaves the new column out of the sheet sequence, hiding it on refresh.
+            if starting_position is not None:
+                entry["referenceId"] = starting_position["reference_id"]
+                entry["position"] = starting_position["position"]
+            payload.append(entry)
         response = self.session.post(endpoint, json=payload)
 
         self.grid = None

--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -816,7 +816,11 @@ class Sheet(BaseSessionResource):  # noqa:F811
     def leftmost_pinned_column(self):
         """The leftmost pinned column in the sheet"""
         if self._leftmost_pinned_column is None:
-            self._leftmost_pinned_column = self.app_design._leftmost_pinned_column
+            # Loading the product design grid populates its _leftmost_pinned_column
+            # as a side effect. Pinned columns are sheet-wide, so the product design
+            # (where formulation columns live) is the natural source.
+            _ = self.product_design.grid
+            self._leftmost_pinned_column = self.product_design._leftmost_pinned_column
 
         return self._leftmost_pinned_column
 
@@ -1260,9 +1264,6 @@ class Sheet(BaseSessionResource):  # noqa:F811
             The created formulation columns, in the order requested.
         """
         if starting_position is None:
-            # Ensure pinned-column state is resolved before computing the reference position.
-            if self.app_design is not None:
-                _ = self.app_design.grid
             starting_position = {
                 "reference_id": self.leftmost_pinned_column,
                 "position": "rightOf",


### PR DESCRIPTION
## Summary
- **Fix hidden/missing formula columns.** `add_formulation_columns` no longer computes and sends a `referenceId` when no `starting_position` is provided; it now omits `referenceId`/`position` so the platform applies its default placement. Previously a null or stale `referenceId` left the new column out of the sheet sequence, which hid it on the next refresh (root cause confirmed with the backend team).
- A caller-supplied `starting_position` is still honored as-is.
- **Refactor:** `Sheet.leftmost_pinned_column` now sources pinned state from the product design instead of the app design (pinned columns are sheet-wide, so the value is identical). This removes a redundant apps-grid request; the property is now only used by `_add_column`'s fallback.
- Verified against integration tests: `test_add_formulation`, `test_add_formulation_clear_updates_existing`, `test_add_formulation_no_clear_adds_new_column`, `test_crud_empty_column`, `test_property_reads` (all pass).