### PR TITLE
perf(tests): parallelize integration test suite with pytest-xdist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            uv run pytest -n 4
+            uv run pytest -n 4 -v --tb=long -r fEsxX --showlocals --durations=15
 
   validate_version_bump:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            uv run pytest
+            uv run pytest -n 4 --dist loadgroup
 
   validate_version_bump:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            uv run pytest -n 4 --dist loadgroup
+            uv run pytest -n 4
 
   validate_version_bump:
     executor:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -82,16 +82,25 @@ Expose a `max_items` parameter on public list/search methods where appropriate t
 
 ## Testing
 
+- **Read `tests/TESTING.md` before writing or changing any test.** The suite runs in parallel
+  with pytest-xdist and that document is the authority on the required patterns.
+- The non-negotiables it covers:
+  - Every test file that consumes a session-scoped `seeded_*`/`static_*` fixture carries a
+    module-level `pytestmark = pytest.mark.xdist_group("...")`; pick the group that already
+    owns the fixtures (table in TESTING.md).
+  - Shared `seeded_*` fixtures are read-only; update/delete tests create private entities and
+    clean up in `try/finally`.
+  - Search assertions must be scoped to `seed_prefix`, filtered to the fixture's ids, and
+    wrapped in `poll_until` (`tests/utils/wait.py`); `text`/`name` params are fuzzy full-text
+    queries, and other workers delete their seeds mid-run.
+  - No exact-count asserts on unscoped queries.
 - Tests use pytest (see tests/).
-- Integration-style tests require environment variables:
-  - ALBERT_CLIENT_ID_SDK
-  - ALBERT_CLIENT_SECRET_SDK
-  - ALBERT_BASE_URL
 - Only add integration-style tests. Do not add unit tests that use `FakeAlbertSession`.
-- Seed helpers live in `tests/seeding.py` and are reused across fixtures.
+- Seed helpers live in `tests/seeding.py` and are reused across fixtures; new seed entities
+  are appended (tests index into seeded lists).
 - Test docstrings should be crisp, start with "Test ...", and avoid implementation details.
 - Required env vars: `ALBERT_CLIENT_ID_SDK`, `ALBERT_CLIENT_SECRET_SDK`, `ALBERT_BASE_URL`.
-- Verify changes work by running the related tests — don't assume.
+- Verify changes work by running the related tests with `-n 4` — don't assume.
 
 ## Documentation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,6 +80,8 @@ select = [
 known-first-party = ["albert", "tests"]
 
 [tool.pytest.ini_options]
+# Inert without -n; guarantees xdist_group semantics for any parallel invocation
+addopts = "--dist loadgroup"
 env_files = [".env"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ dev = [
     "pre-commit>=4.2.0",
     "rich>=14.3.2",
     "pytest-asyncio>=1.3.0",
+    "pytest-xdist>=3.8.0",
 ]
 
 [project.urls]

--- a/src/albert/core/auth/_manager.py
+++ b/src/albert/core/auth/_manager.py
@@ -1,3 +1,4 @@
+import threading
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 
@@ -23,6 +24,8 @@ class AuthManager(ABC):
 
     _token_info: OAuthTokenInfo | None = None
     _refresh_time: datetime | None = None
+    # Class-level lock: serializes token refresh across threads sharing a manager
+    _refresh_lock: threading.Lock = threading.Lock()
 
     def _requires_refresh(self) -> bool:
         return (

--- a/src/albert/core/auth/credentials.py
+++ b/src/albert/core/auth/credentials.py
@@ -118,7 +118,10 @@ class AlbertClientCredentials(BaseAlbertModel, AuthManager):
     def get_access_token(self) -> str:
         """Return a valid access token, refreshing it if needed."""
         if self._requires_refresh():
-            self._request_access_token()
+            with self._refresh_lock:
+                # Double-checked: another thread may have refreshed while we waited
+                if self._requires_refresh():
+                    self._request_access_token()
         return self._token_info.access_token
 
 

--- a/src/albert/core/session.py
+++ b/src/albert/core/session.py
@@ -83,7 +83,11 @@ class AlbertSession(requests.Session):
         return self._provided_token
 
     def request(self, method: str, path: str, *args, **kwargs) -> requests.Response:
-        self.headers["Authorization"] = f"Bearer {self._access_token}"
+        # Send auth via per-request headers: mutating self.headers is not safe when
+        # the session is shared across threads.
+        headers = {"Authorization": f"Bearer {self._access_token}"}
+        headers.update(kwargs.pop("headers", None) or {})
+        kwargs["headers"] = headers
         kwargs.setdefault("timeout", self._timeout)
         full_url = urljoin(self.base_url, path) if not path.startswith("http") else path
         params = self._encode_query_params(kwargs.pop("params", None) or {})

--- a/tests/TESTING.md
+++ b/tests/TESTING.md
@@ -1,0 +1,154 @@
+# Writing Integration Tests
+
+The integration suite runs **in parallel** with pytest-xdist (`-n 4` in CI, `--dist loadgroup`
+via `addopts` in `pyproject.toml`). Every rule in this document exists to keep tests correct
+and flake-free under that model. New tests must follow these patterns; a test that passes
+sequentially but races other workers will fail intermittently in CI and is considered broken.
+
+## How the parallel model works
+
+- Each xdist worker is a separate process with its **own copy of every session-scoped fixture**.
+- `seed_prefix` is a per-worker `SDK-Test-<uuid>` string. All seeded entity names include it,
+  so workers never collide on names.
+- `--dist loadgroup` assigns tests to workers by their `xdist_group` mark. All tests in one
+  group run on one worker, so they share one set of session fixtures.
+- Tests **without** a group mark are scheduled one by one onto any free worker. Two tests from
+  the same unmarked file can land on different workers, and each worker will build its own copy
+  of every session fixture those tests request.
+- Workers finish at different times. When a worker finishes, its session fixture teardowns
+  **delete its seeded entities while other workers are still running tests**.
+
+That last point drives most of the rules below.
+
+## Rule 1: assign the right xdist group
+
+Any test file that uses a session-scoped `seeded_*` or expensive `static_*` fixture must carry
+a module-level mark:
+
+```python
+pytestmark = pytest.mark.xdist_group("datatemplates")
+```
+
+Pick the group whose worker already builds the fixtures you need:
+
+| Group | Owns fixture chain | Files (non-exhaustive) |
+|---|---|---|
+| `tasks` | `seeded_tasks` and everything under it (`seeded_workflows`, `seeded_notes`, `seeded_links`, `seeded_reports`) | test_tasks, test_batch_data, test_property_data, test_notes, test_links, test_reports, test_workflows |
+| `sheets` | `seeded_worksheet`, `seeded_sheet`, `seeded_products` | test_worksheet, test_product_design, resources/test_sheets |
+| `inventory` | `seeded_inventory`, `seeded_lots`, `seeded_pricings`, `seeded_label_templates` | test_inventory, test_attachments, test_lots, test_pricings, test_label_templates |
+| `datatemplates` | `seeded_data_templates`, `seeded_data_columns`, `seeded_units`, `seeded_parameters`, `seeded_parameter_groups`, `seeded_targets`, `seeded_smart_dataset` | test_data_templates, test_data_columns, test_units, test_parameters, test_parameter_groups, test_targets, test_smart_datasets, test_design_runs |
+| `projects` | `seeded_projects`, `seeded_locations`, `seeded_storage_locations`, `seeded_cas`, `seeded_companies`, `seeded_notebooks` | test_projects, test_notebooks, test_locations, test_storage_locations, test_cas, test_company |
+| `bt` | `seeded_btdataset`, `seeded_btmodelsession`, `seeded_btmodel`, `seeded_btinsight` | test_btdataset, test_btmodel, test_btinsight |
+| `entitytypes`, `teams`, `tags`, `customtemplates`, `lists`, `customfields` | one small fixture family each | the matching single file |
+
+Guidelines:
+
+- **New test file for an existing collection**: use the group that already owns its fixtures.
+- **New fixture family with no dependency on existing chains**: create a new group named after
+  the module (like `teams` or `bt`). One group per independent family.
+- **File uses only `client` / `fake_client` / function-scoped fixtures**: leave it unmarked so
+  the scheduler can balance it freely. The moment it grows a `seeded_*` dependency, add a mark.
+- Never split one file across groups; `pytestmark` applies to the whole module. If two tests in
+  one file genuinely need different heavy chains, that is a sign they belong in different files.
+- Group assignment affects wall time: the `tasks` worker is the critical path. Do not add
+  slow tests to `tasks` if another group's fixtures suffice.
+
+## Rule 2: treat shared seeded fixtures as read-only
+
+Session fixtures (`seeded_tags`, `seeded_locations`, ...) are shared by every test on the
+worker, and their list order matters (seeding helpers index into them).
+
+- Never delete, rename, or update an entity owned by a `seeded_*` fixture.
+- A test that exercises update/delete creates its **own private entity** and cleans it up in
+  `try/finally`, suppressing `NotFoundError`:
+
+```python
+def test_tag_update(client: Albert):
+    test_tag = client.tags.create(tag=Tag(tag=f"TEST - rename me {uuid.uuid4()}"))
+    try:
+        ...asserts...
+    finally:
+        with suppress(NotFoundError):
+            client.tags.delete(id=test_tag.id)
+```
+
+- Name private entities with `seed_prefix` or `TEST - <uuid>` so leaked entities are
+  identifiable and never collide across workers.
+
+## Rule 3: never assert on unscoped search results
+
+`text=` and `name=` search parameters are **tokenized full-text queries**, not prefix or
+substring filters. `text=seed_prefix` still matches unrelated old records (tokens like "SDK"
+and "Test"), including entities the client cannot read (ACL 403) or that another worker just
+deleted. The search index also lags writes by seconds.
+
+For any search-based assertion:
+
+1. Scope the query with `text=`/`name=` set to `seed_prefix` (reduces noise).
+2. **Filter results to the ids owned by the fixture** (correctness).
+3. Wrap the fetch in `poll_until` from `tests/utils/wait.py` (index lag).
+
+```python
+from tests.utils.wait import poll_until
+
+def test_hydrate_project(client: Albert, seed_prefix: str, seeded_projects: list[Project]):
+    seeded_ids = {p.id for p in seeded_projects}
+    projects = poll_until(
+        lambda: [
+            p
+            for p in client.projects.search(text=seed_prefix, max_items=100)
+            if p.id in seeded_ids
+        ]
+    )
+    assert projects, "Expected at least one project in search results"
+```
+
+Also:
+
+- Never assert **exact counts** of unscoped `search()`/`get_all()` results; other workers
+  create and delete entities concurrently. Count only your own fixture's ids, or better, skip
+  the search round-trip and use the fixture directly (see `test_get_by_ids`).
+- Hydrating or `get_by_id`-ing an entity you did not seed can 403/404 at any moment.
+- Watch id formats: inventory search items drop the `INV` prefix, so compare with
+  `f"INV{item.id}"`.
+
+## Rule 4: seeding conventions (conftest.py / seeding.py)
+
+- Seed data generators live in `tests/seeding.py`; every generated name embeds `seed_prefix`.
+- Fixtures create entities concurrently through `_pmap` (order-preserving, retries once on
+  5xx because urllib3 does not retry POSTs) and tear down through `_delete_all`.
+- **Append** new seed entities at the end of a generator's list. Tests and other seeders index
+  into these lists (`seeded_locations[2]`), so reordering or removing entries breaks them.
+- Shared, non-prefixed static entities (`static_custom_fields`, `static_lists`) must be
+  registered **sequentially** through `_get_or_register`: concurrent same-name creates from
+  multiple workers 504 the backend. The `entitytypes` endpoint 500s under concurrent creates,
+  so `seeded_entity_types` also stays sequential.
+- The fixed `time.sleep(1.5)` / `time.sleep(3)` calls after seeding are deliberate
+  search-index buffers. Do not remove them; in tests, prefer `poll_until` over new sleeps.
+
+## Rule 5: general hygiene
+
+- Integration tests only; no unit tests with `FakeAlbertSession`.
+- Docstrings crisp, start with "Test ...".
+- The shared `client` is session-scoped and used from multiple threads during seeding; do not
+  add fixture code that mutates client/session state.
+- Env vars required: `ALBERT_CLIENT_ID_SDK`, `ALBERT_CLIENT_SECRET_SDK`, `ALBERT_BASE_URL`.
+
+## Running
+
+```bash
+uv run pytest tests -n 4          # parallel, same as CI (loadgroup comes from addopts)
+uv run pytest tests/collections/test_tags.py -v   # single file, sequential
+```
+
+Before opening a PR that touches fixtures or adds tests to a group, run at least the affected
+group's files with `-n 4` to catch cross-worker races.
+
+## Checklist for a new test file
+
+- [ ] `pytestmark = pytest.mark.xdist_group("...")` chosen per Rule 1 (or deliberately unmarked because only `client` is used)
+- [ ] No mutation of `seeded_*` entities; private entities cleaned up in `try/finally`
+- [ ] Search assertions scoped, id-filtered, and wrapped in `poll_until`
+- [ ] No exact-count asserts on global queries
+- [ ] Names of created entities include `seed_prefix` or `TEST - <uuid>`
+- [ ] Ran the file plus its group with `-n 4` locally

--- a/tests/collections/test_attachments.py
+++ b/tests/collections/test_attachments.py
@@ -2,6 +2,8 @@ from contextlib import suppress
 from datetime import date
 from pathlib import Path
 
+import pytest
+
 from albert import Albert
 from albert.resources.attachments import Attachment, AttachmentCategory, AttachmentMetadata
 from albert.resources.files import FileInfo
@@ -9,6 +11,8 @@ from albert.resources.hazards import HazardStatement, HazardSymbol
 from albert.resources.inventory import InventoryItem
 from albert.resources.notes import Note
 from albert.resources.projects import Project
+
+pytestmark = pytest.mark.xdist_group("inventory")
 
 
 def test_attach_file_to_note(

--- a/tests/collections/test_batch_data.py
+++ b/tests/collections/test_batch_data.py
@@ -10,6 +10,8 @@ from albert.resources.batch_data import (
 )
 from albert.resources.tasks import BaseTask, BatchTask
 
+pytestmark = pytest.mark.xdist_group("tasks")
+
 
 def test_get_by_id(client: Albert, seeded_tasks: list[BaseTask]):
     batch_task = [t for t in seeded_tasks if isinstance(t, BatchTask)][0]

--- a/tests/collections/test_btdataset.py
+++ b/tests/collections/test_btdataset.py
@@ -1,6 +1,10 @@
+import pytest
+
 from albert import Albert
 from albert.resources.btdataset import BTDataset, BTDatasetReferences
 from albert.resources.users import User
+
+pytestmark = pytest.mark.xdist_group("bt")
 
 
 def test_get_by_id(client: Albert, seeded_btdataset: BTDataset):

--- a/tests/collections/test_btinsight.py
+++ b/tests/collections/test_btinsight.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.btinsight import BTInsight, BTInsightCategory, BTInsightRegistry
+
+pytestmark = pytest.mark.xdist_group("bt")
 
 
 def test_get_by_id(client: Albert, seeded_btinsight: BTInsight):

--- a/tests/collections/test_btmodel.py
+++ b/tests/collections/test_btmodel.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.btmodel import BTModel, BTModelRegistry, BTModelSession
+
+pytestmark = pytest.mark.xdist_group("bt")
 
 
 def test_get_model_session_by_id(client: Albert, seeded_btmodelsession: BTModelSession):

--- a/tests/collections/test_cas.py
+++ b/tests/collections/test_cas.py
@@ -10,6 +10,8 @@ from albert.resources.cas import Cas
 from albert.resources.custom_fields import CustomField, FieldType, ServiceType
 from albert.resources.lists import ListItem
 
+pytestmark = pytest.mark.xdist_group("projects")
+
 
 def _cas_list_metadata_items(
     static_custom_fields: list[CustomField],

--- a/tests/collections/test_company.py
+++ b/tests/collections/test_company.py
@@ -4,6 +4,8 @@ from albert.client import Albert
 from albert.exceptions import AlbertException
 from albert.resources.companies import Company
 
+pytestmark = pytest.mark.xdist_group("projects")
+
 
 def assert_valid_company_items(items: list[Company]):
     """Assert basic structure and types of Company items."""

--- a/tests/collections/test_custom_fields.py
+++ b/tests/collections/test_custom_fields.py
@@ -15,6 +15,8 @@ from albert.resources.custom_fields import (
 )
 from albert.resources.lists import ListItem
 
+pytestmark = pytest.mark.xdist_group("customfields")
+
 
 def get_or_create_custom_field(
     client: Albert, name: str, field_type: FieldType, service: ServiceType, **kwargs

--- a/tests/collections/test_custom_templates.py
+++ b/tests/collections/test_custom_templates.py
@@ -1,3 +1,5 @@
+import pytest
+
 from albert.client import Albert
 from albert.resources.acls import ACL, AccessControlLevel
 from albert.resources.custom_templates import (
@@ -7,6 +9,8 @@ from albert.resources.custom_templates import (
     _CustomTemplateDataUnion,
 )
 from albert.resources.users import User
+
+pytestmark = pytest.mark.xdist_group("customtemplates")
 
 
 def assert_template_items(

--- a/tests/collections/test_data_columns.py
+++ b/tests/collections/test_data_columns.py
@@ -1,3 +1,5 @@
+import time
+
 import pytest
 
 from albert import Albert
@@ -29,7 +31,13 @@ def test_data_column_get_all_with_filters(client: Albert, seeded_data_columns: l
     """Test get_all filters by name with and without exact match."""
     name = seeded_data_columns[0].name
 
-    results = list(client.data_columns.get_all(name=name, exact_match=False, max_items=10))
+    # Poll briefly: the search index can lag behind seeding under parallel load
+    deadline = time.monotonic() + 15
+    while True:
+        results = list(client.data_columns.get_all(name=name, exact_match=False, max_items=10))
+        if any(name.lower() in dc.name.lower() for dc in results) or time.monotonic() > deadline:
+            break
+        time.sleep(1)
     assert any(name.lower() in dc.name.lower() for dc in results)
     assert_valid_data_column_items(results)
 

--- a/tests/collections/test_data_columns.py
+++ b/tests/collections/test_data_columns.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.data_columns import DataColumn
+
+pytestmark = pytest.mark.xdist_group("datatemplates")
 
 
 def assert_valid_data_column_items(returned_list: list[DataColumn], limit=100):

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -23,6 +23,8 @@ from albert.resources.tags import Tag
 from albert.resources.units import Unit
 from albert.resources.users import User
 
+pytestmark = pytest.mark.xdist_group("datatemplates")
+
 
 def assert_valid_data_template_items(
     items: list[DataTemplate | DataTemplateSearchItem], expected_type: type

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -518,9 +518,10 @@ def test_update_enum_validations_on_data_column_and_parameter(
     assert updated_param.value == "ParamOption3"
 
 
-def test_hydrate_data_template(client: Albert):
+def test_hydrate_data_template(client: Albert, seed_prefix: str, seeded_data_templates):
     """Test that data templates can be hydrated correctly."""
-    data_templates = client.data_templates.search(max_items=3)
+    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
+    data_templates = client.data_templates.search(name=seed_prefix, max_items=3)
     assert data_templates, "Expected at least one data_template in search results"
 
     for data_template in data_templates:

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -22,6 +22,7 @@ from albert.resources.parameters import Parameter
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
 from albert.resources.users import User
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("datatemplates")
 
@@ -520,8 +521,16 @@ def test_update_enum_validations_on_data_column_and_parameter(
 
 def test_hydrate_data_template(client: Albert, seed_prefix: str, seeded_data_templates):
     """Test that data templates can be hydrated correctly."""
-    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
-    data_templates = client.data_templates.search(name=seed_prefix, max_items=3)
+    # Filter to this worker's seeds: name search is fuzzy (tokenized) and can rank
+    # unrelated or deleted templates
+    seeded_ids = {dt.id for dt in seeded_data_templates}
+    data_templates = poll_until(
+        lambda: [
+            dt
+            for dt in client.data_templates.search(name=seed_prefix, max_items=100)
+            if dt.id in seeded_ids
+        ]
+    )
     assert data_templates, "Expected at least one data_template in search results"
 
     for data_template in data_templates:

--- a/tests/collections/test_design_runs.py
+++ b/tests/collections/test_design_runs.py
@@ -10,6 +10,8 @@ from albert.resources.targets import (
     NumericRange,
 )
 
+pytestmark = pytest.mark.xdist_group("datatemplates")
+
 ignore_in_ten0 = pytest.mark.xfail(
     reason="No DWH available in TEN0 test environment.",
     strict=False,

--- a/tests/collections/test_entity_types.py
+++ b/tests/collections/test_entity_types.py
@@ -1,7 +1,11 @@
 from uuid import uuid4
 
+import pytest
+
 from albert import Albert
 from albert.resources.entity_types import EntityType, EntityTypeSearchQueryStrings
+
+pytestmark = pytest.mark.xdist_group("entitytypes")
 
 
 def test_entity_type_get_by_id(client: Albert, seeded_entity_types: list[EntityType]):

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -19,6 +19,8 @@ from albert.resources.tags import Tag
 from albert.resources.units import Unit
 from albert.resources.workflows import Workflow
 
+pytestmark = pytest.mark.xdist_group("inventory")
+
 
 def assert_valid_inventory_items(returned_list: list[InventoryItem]):
     """Assert basic InventoryItem structure and types."""

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -60,9 +60,10 @@ def test_inventory_get_all_with_filters(
         assert test_item.name.lower() in item.name.lower()
 
 
-def test_inventory_hydration_from_search(client: Albert):
+def test_inventory_hydration_from_search(client: Albert, seed_prefix: str, seeded_inventory):
     """Test that inventory search results can be hydrated to full InventoryItem."""
-    search_results = client.inventory.search(max_items=5)
+    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
+    search_results = client.inventory.search(text=seed_prefix, max_items=5)
     assert search_results, "Expected at least one inventory item in search results"
 
     for partial in search_results:
@@ -115,13 +116,11 @@ def test_get_by_id(client: Albert, seeded_inventory):
     assert seeded_inventory[0].id == get_by_id.id
 
 
-def test_get_by_ids(client: Albert):
-    # Gather 51 unique inventory IDs
-    inventory_ids = []
-    for x in client.inventory.search():
-        inventory_ids.append(x.id)
-        if len(inventory_ids) == 51:
-            break
+def test_get_by_ids(client: Albert, seed_prefix: str, seeded_inventory):
+    # Gather this worker's seeded inventory IDs; unscoped search would race other
+    # workers' teardown deletes and break the exact-count assertion
+    inventory_ids = [x.id for x in client.inventory.search(text=seed_prefix)]
+    assert inventory_ids, "Expected seeded inventory in search results"
 
     # Assert same length obtained
     items = client.inventory.get_by_ids(ids=inventory_ids)

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -18,6 +18,7 @@ from albert.resources.inventory import (
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
 from albert.resources.workflows import Workflow
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("inventory")
 
@@ -45,13 +46,15 @@ def test_inventory_get_all_with_filters(
     test_item = seeded_inventory[1]
     matching_cas = next(x for x in seeded_cas if x.id in test_item.cas[0].id)
 
-    results = list(
-        client.inventory.get_all(
-            text=test_item.name,
-            category=InventoryCategory.CONSUMABLES,
-            cas=matching_cas,
-            company=test_item.company,
-            max_items=10,
+    results = poll_until(
+        lambda: list(
+            client.inventory.get_all(
+                text=test_item.name,
+                category=InventoryCategory.CONSUMABLES,
+                cas=matching_cas,
+                company=test_item.company,
+                max_items=10,
+            )
         )
     )
 
@@ -62,8 +65,16 @@ def test_inventory_get_all_with_filters(
 
 def test_inventory_hydration_from_search(client: Albert, seed_prefix: str, seeded_inventory):
     """Test that inventory search results can be hydrated to full InventoryItem."""
-    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
-    search_results = client.inventory.search(text=seed_prefix, max_items=5)
+    # Filter to this worker's seeds: text search is fuzzy (tokenized) and can rank
+    # unrelated or deleted items (search item ids lack the INV prefix)
+    seeded_ids = {i.id for i in seeded_inventory}
+    search_results = poll_until(
+        lambda: [
+            p
+            for p in client.inventory.search(text=seed_prefix, max_items=100)
+            if f"INV{p.id}" in seeded_ids
+        ]
+    )
     assert search_results, "Expected at least one inventory item in search results"
 
     for partial in search_results:
@@ -116,11 +127,10 @@ def test_get_by_id(client: Albert, seeded_inventory):
     assert seeded_inventory[0].id == get_by_id.id
 
 
-def test_get_by_ids(client: Albert, seed_prefix: str, seeded_inventory):
-    # Gather this worker's seeded inventory IDs; unscoped search would race other
-    # workers' teardown deletes and break the exact-count assertion
-    inventory_ids = [x.id for x in client.inventory.search(text=seed_prefix)]
-    assert inventory_ids, "Expected seeded inventory in search results"
+def test_get_by_ids(client: Albert, seeded_inventory):
+    # Use this worker's seeded IDs directly; a search round-trip would race other
+    # workers' teardown deletes and fuzzy text matching
+    inventory_ids = [x.id for x in seeded_inventory]
 
     # Assert same length obtained
     items = client.inventory.get_by_ids(ids=inventory_ids)

--- a/tests/collections/test_label_templates.py
+++ b/tests/collections/test_label_templates.py
@@ -1,3 +1,5 @@
+import pytest
+
 from albert.client import Albert
 from albert.resources.label_templates import (
     LabelPrintPayload,
@@ -5,6 +7,8 @@ from albert.resources.label_templates import (
     LabelTemplateType,
 )
 from albert.resources.lots import Lot
+
+pytestmark = pytest.mark.xdist_group("inventory")
 
 
 def test_label_template_get_by_id(client: Albert, seeded_label_templates: list[LabelTemplate]):

--- a/tests/collections/test_links.py
+++ b/tests/collections/test_links.py
@@ -1,6 +1,10 @@
+import pytest
+
 from albert import Albert
 from albert.resources.links import Link
 from albert.resources.tasks import BaseTask
+
+pytestmark = pytest.mark.xdist_group("tasks")
 
 
 def test_link_get_all_basic(

--- a/tests/collections/test_lists.py
+++ b/tests/collections/test_lists.py
@@ -1,6 +1,10 @@
+import pytest
+
 from albert import Albert
 from albert.resources.custom_fields import CustomField, FieldType
 from albert.resources.lists import ListItem
+
+pytestmark = pytest.mark.xdist_group("lists")
 
 
 def assert_valid_list_items(list_items: list[ListItem]):

--- a/tests/collections/test_locations.py
+++ b/tests/collections/test_locations.py
@@ -1,7 +1,11 @@
 import uuid
 
+import pytest
+
 from albert.client import Albert
 from albert.resources.locations import Location
+
+pytestmark = pytest.mark.xdist_group("projects")
 
 
 def assert_valid_location_items(returned_list: list[Location]):
@@ -103,11 +107,20 @@ def test_location_exists(client: Albert, seeded_locations):
     assert exists.name == seeded_location.name
 
 
-def test_delete_location(client: Albert, seeded_locations: list[Location]):
-    # Create a new location to delete
+def test_delete_location(client: Albert):
+    # Create a new location to delete so shared seeded locations stay intact
+    location = client.locations.create(
+        location=Location(
+            name=f"TEST - delete me {uuid.uuid4()}",
+            latitude=40.7,
+            longitude=-74.0,
+            address="123 Test St",
+            country="US",
+        )
+    )
 
-    client.locations.delete(id=seeded_locations[2].id)
+    client.locations.delete(id=location.id)
 
     # Ensure it no longer exists
-    does_exist = client.locations.exists(location=seeded_locations[2])
+    does_exist = client.locations.exists(location=location)
     assert does_exist is None

--- a/tests/collections/test_locations.py
+++ b/tests/collections/test_locations.py
@@ -1,8 +1,10 @@
 import uuid
+from contextlib import suppress
 
 import pytest
 
 from albert.client import Albert
+from albert.exceptions import NotFoundError
 from albert.resources.locations import Location
 
 pytestmark = pytest.mark.xdist_group("projects")
@@ -119,8 +121,12 @@ def test_delete_location(client: Albert):
         )
     )
 
-    client.locations.delete(id=location.id)
+    try:
+        client.locations.delete(id=location.id)
 
-    # Ensure it no longer exists
-    does_exist = client.locations.exists(location=location)
-    assert does_exist is None
+        # Ensure it no longer exists
+        does_exist = client.locations.exists(location=location)
+        assert does_exist is None
+    finally:
+        with suppress(NotFoundError):
+            client.locations.delete(id=location.id)

--- a/tests/collections/test_lots.py
+++ b/tests/collections/test_lots.py
@@ -9,6 +9,8 @@ from albert.resources.lots import Lot, LotAdjustmentAction
 from albert.resources.storage_locations import StorageLocation
 from tests.seeding import generate_lot_seeds
 
+pytestmark = pytest.mark.xdist_group("inventory")
+
 
 @pytest.fixture(scope="function")
 def seeded_lot(

--- a/tests/collections/test_notebooks.py
+++ b/tests/collections/test_notebooks.py
@@ -16,6 +16,8 @@ from albert.resources.notebooks import (
 from albert.resources.projects import Project
 from tests.seeding import generate_notebook_block_seeds, generate_notebook_seeds
 
+pytestmark = pytest.mark.xdist_group("projects")
+
 
 @pytest.fixture(scope="function")
 def seeded_notebook(

--- a/tests/collections/test_notes.py
+++ b/tests/collections/test_notes.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.notes import Note
+
+pytestmark = pytest.mark.xdist_group("tasks")
 
 
 def test_get_by_id(client: Albert, seeded_notes: list[Note]):

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -14,6 +14,8 @@ from albert.resources.parameter_groups import (
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
 
+pytestmark = pytest.mark.xdist_group("datatemplates")
+
 
 def assert_valid_parameter_groups(
     items: list[ParameterGroupSearchItem | ParameterGroup],

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -107,8 +107,9 @@ def test_parameter_group_search(client: Albert):
     assert_valid_parameter_groups(results, ParameterGroupSearchItem)
 
 
-def test_hydrate_pg(client: Albert):
-    pgs = list(client.parameter_groups.search(max_items=5))
+def test_hydrate_pg(client: Albert, seed_prefix: str, seeded_parameter_groups):
+    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
+    pgs = list(client.parameter_groups.search(text=seed_prefix, max_items=5))
     assert pgs, "Expected at least one pg in search results"
 
     for pg in pgs:

--- a/tests/collections/test_parameter_groups.py
+++ b/tests/collections/test_parameter_groups.py
@@ -13,6 +13,7 @@ from albert.resources.parameter_groups import (
 )
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("datatemplates")
 
@@ -108,8 +109,16 @@ def test_parameter_group_search(client: Albert):
 
 
 def test_hydrate_pg(client: Albert, seed_prefix: str, seeded_parameter_groups):
-    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
-    pgs = list(client.parameter_groups.search(text=seed_prefix, max_items=5))
+    # Filter to this worker's seeds: text search is fuzzy (tokenized) and can rank
+    # unrelated or deleted parameter groups
+    seeded_ids = {pg.id for pg in seeded_parameter_groups}
+    pgs = poll_until(
+        lambda: [
+            pg
+            for pg in client.parameter_groups.search(text=seed_prefix, max_items=100)
+            if pg.id in seeded_ids
+        ]
+    )
     assert pgs, "Expected at least one pg in search results"
 
     for pg in pgs:

--- a/tests/collections/test_parameters.py
+++ b/tests/collections/test_parameters.py
@@ -1,7 +1,11 @@
 import uuid
 
+import pytest
+
 from albert.client import Albert
 from albert.resources.parameters import Parameter
+
+pytestmark = pytest.mark.xdist_group("datatemplates")
 
 
 def assert_valid_parameter_items(returned_list: list[Parameter]):

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -1,9 +1,13 @@
 import uuid
 
+import pytest
+
 from albert import Albert
 from albert.resources.inventory import InventoryItem
 from albert.resources.locations import Location
 from albert.resources.pricings import Pricing
+
+pytestmark = pytest.mark.xdist_group("inventory")
 
 
 def test_get_by_inventory_id(

--- a/tests/collections/test_product_design.py
+++ b/tests/collections/test_product_design.py
@@ -1,6 +1,10 @@
+import pytest
+
 from albert import Albert
 from albert.resources.inventory import InventoryItem
 from albert.resources.product_design import UnpackedProductDesign
+
+pytestmark = pytest.mark.xdist_group("sheets")
 
 
 def test_get_unpacked(client: Albert, seeded_products: list[InventoryItem]):

--- a/tests/collections/test_projects.py
+++ b/tests/collections/test_projects.py
@@ -1,3 +1,5 @@
+from contextlib import suppress
+
 import pytest
 
 from albert.client import Albert
@@ -42,8 +44,9 @@ def test_project_search_filtered(client: Albert):
     assert_valid_project_items(advanced_list, ProjectSearchItem)
 
 
-def test_hydrate_project(client: Albert):
-    projects = list(client.projects.search(created_by=["Sdk"], max_items=5))
+def test_hydrate_project(client: Albert, seed_prefix: str, seeded_projects: list[Project]):
+    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
+    projects = list(client.projects.search(text=seed_prefix, max_items=5))
     assert projects, "Expected at least one project in search results"
 
     for project in projects:
@@ -99,18 +102,21 @@ def test_create_project(client: Albert, seeded_locations):
     client.projects.delete(id=created_project.id)
 
 
-def test_update_project(seeded_locations, client: Albert):
+def test_update_project(seeded_locations, client: Albert, seed_prefix: str):
     # Update a private project so shared seeded projects stay intact
     project = client.projects.create(
         project=Project(
-            description="Project to Update",
+            description=f"{seed_prefix} - Project to Update",
             locations=[EntityLink(id=seeded_locations[1].id)],
         )
     )
-    project.grid = "PD"
-    updated = client.projects.update(project=project)
-    assert updated.id == project.id
-    client.projects.delete(id=project.id)
+    try:
+        project.grid = "PD"
+        updated = client.projects.update(project=project)
+        assert updated.id == project.id
+    finally:
+        with suppress(NotFoundError):
+            client.projects.delete(id=project.id)
 
 
 def test_delete_project(client: Albert, seeded_locations):

--- a/tests/collections/test_projects.py
+++ b/tests/collections/test_projects.py
@@ -7,6 +7,7 @@ from albert.core.shared.models.base import EntityLink
 from albert.exceptions import NotFoundError
 from albert.resources.attachments import Attachment
 from albert.resources.projects import DocumentSearchItem, Project, ProjectSearchItem
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("projects")
 
@@ -45,8 +46,16 @@ def test_project_search_filtered(client: Albert):
 
 
 def test_hydrate_project(client: Albert, seed_prefix: str, seeded_projects: list[Project]):
-    # Scope the search to this worker's seeds: other xdist workers may delete theirs mid-run
-    projects = list(client.projects.search(text=seed_prefix, max_items=5))
+    # Filter to this worker's seeds: text search is fuzzy (tokenized) and can rank
+    # unrelated projects the client has no ACL access to hydrate
+    seeded_ids = {p.id for p in seeded_projects}
+    projects = poll_until(
+        lambda: [
+            p
+            for p in client.projects.search(text=seed_prefix, max_items=100)
+            if p.id in seeded_ids
+        ]
+    )
     assert projects, "Expected at least one project in search results"
 
     for project in projects:

--- a/tests/collections/test_projects.py
+++ b/tests/collections/test_projects.py
@@ -6,6 +6,8 @@ from albert.exceptions import NotFoundError
 from albert.resources.attachments import Attachment
 from albert.resources.projects import DocumentSearchItem, Project, ProjectSearchItem
 
+pytestmark = pytest.mark.xdist_group("projects")
+
 
 def assert_valid_project_items(returned_list: list, entity_type: type = Project):
     """Assert that project items are valid and correctly typed."""
@@ -97,10 +99,18 @@ def test_create_project(client: Albert, seeded_locations):
     client.projects.delete(id=created_project.id)
 
 
-def test_update_project(seeded_projects, client: Albert):
-    seeded_projects[1].grid = "PD"
-    updated = client.projects.update(project=seeded_projects[1])
-    assert updated.id == seeded_projects[1].id
+def test_update_project(seeded_locations, client: Albert):
+    # Update a private project so shared seeded projects stay intact
+    project = client.projects.create(
+        project=Project(
+            description="Project to Update",
+            locations=[EntityLink(id=seeded_locations[1].id)],
+        )
+    )
+    project.grid = "PD"
+    updated = client.projects.update(project=project)
+    assert updated.id == project.id
+    client.projects.delete(id=project.id)
 
 
 def test_delete_project(client: Albert, seeded_locations):

--- a/tests/collections/test_property_data.py
+++ b/tests/collections/test_property_data.py
@@ -25,6 +25,8 @@ from albert.resources.tasks import (
     TaskInventoryInformation,
 )
 
+pytestmark = pytest.mark.xdist_group("tasks")
+
 
 def _get_latest_row(task_properties: TaskPropertyData) -> int:
     first_blk_interval = task_properties.data[0]

--- a/tests/collections/test_reports.py
+++ b/tests/collections/test_reports.py
@@ -13,6 +13,8 @@ from albert.resources.reports import (
 )
 from albert.resources.tasks import BaseTask
 
+pytestmark = pytest.mark.xdist_group("tasks")
+
 
 @pytest.mark.skip(reason="Report Queries not loaded into testing environment yet")
 def test_get_raw_dataframe(

--- a/tests/collections/test_smart_datasets.py
+++ b/tests/collections/test_smart_datasets.py
@@ -14,6 +14,8 @@ from albert.resources.smart_datasets import (
 from albert.resources.targets import Target
 from tests.seeding import generate_smart_dataset_seed
 
+pytestmark = pytest.mark.xdist_group("datatemplates")
+
 ignore_in_ten0 = pytest.mark.xfail(
     reason="No DWH available in TEN0 test environment.",
     strict=False,

--- a/tests/collections/test_storage_locations.py
+++ b/tests/collections/test_storage_locations.py
@@ -1,8 +1,12 @@
 import uuid
 
+import pytest
+
 from albert import Albert
 from albert.resources.locations import Location
 from albert.resources.storage_locations import StorageLocation
+
+pytestmark = pytest.mark.xdist_group("projects")
 
 
 def assert_valid_storage_location_items(returned_list: list[StorageLocation]):

--- a/tests/collections/test_tags.py
+++ b/tests/collections/test_tags.py
@@ -67,8 +67,9 @@ def test_tag_exists(client: Albert, seeded_tags: list[Tag]):
     )
 
 
-def test_tag_update(client: Albert, seeded_tags: list[Tag]):
-    test_tag = seeded_tags[3]
+def test_tag_update(client: Albert):
+    # Rename a private tag so shared seeded tags stay intact
+    test_tag = client.tags.create(tag=Tag(tag=f"TEST - rename me {uuid.uuid4()}"))
     new_name = f"TEST - {uuid.uuid4()}"
 
     assert test_tag.id is not None
@@ -82,6 +83,8 @@ def test_tag_update(client: Albert, seeded_tags: list[Tag]):
         client.tags.rename(
             old_name="y74r79ub4v9f874ebf982bTEST NONESENSEg89befbnr", new_name="Foo Bar!"
         )
+
+    client.tags.delete(id=test_tag.id)
 
 
 def test_get_or_create_tags(caplog, client: Albert, seeded_tags: list[Tag]):

--- a/tests/collections/test_tags.py
+++ b/tests/collections/test_tags.py
@@ -1,11 +1,14 @@
 import uuid
+from contextlib import suppress
 
 import pytest
 
 from albert.client import Albert
 from albert.core.shared.enums import OrderBy
-from albert.exceptions import AlbertException
+from albert.exceptions import AlbertException, NotFoundError
 from albert.resources.tags import Tag
+
+pytestmark = pytest.mark.xdist_group("tags")
 
 
 def assert_valid_tag_items(returned_list: list[Tag], limit=100):
@@ -70,21 +73,23 @@ def test_tag_exists(client: Albert, seeded_tags: list[Tag]):
 def test_tag_update(client: Albert):
     # Rename a private tag so shared seeded tags stay intact
     test_tag = client.tags.create(tag=Tag(tag=f"TEST - rename me {uuid.uuid4()}"))
-    new_name = f"TEST - {uuid.uuid4()}"
+    try:
+        new_name = f"TEST - {uuid.uuid4()}"
 
-    assert test_tag.id is not None
+        assert test_tag.id is not None
 
-    updated_tag = client.tags.rename(old_name=test_tag.tag, new_name=new_name)
-    assert isinstance(updated_tag, Tag)
-    assert test_tag.id == updated_tag.id
-    assert updated_tag.tag == new_name
+        updated_tag = client.tags.rename(old_name=test_tag.tag, new_name=new_name)
+        assert isinstance(updated_tag, Tag)
+        assert test_tag.id == updated_tag.id
+        assert updated_tag.tag == new_name
 
-    with pytest.raises(AlbertException):
-        client.tags.rename(
-            old_name="y74r79ub4v9f874ebf982bTEST NONESENSEg89befbnr", new_name="Foo Bar!"
-        )
-
-    client.tags.delete(id=test_tag.id)
+        with pytest.raises(AlbertException):
+            client.tags.rename(
+                old_name="y74r79ub4v9f874ebf982bTEST NONESENSEg89befbnr", new_name="Foo Bar!"
+            )
+    finally:
+        with suppress(NotFoundError):
+            client.tags.delete(id=test_tag.id)
 
 
 def test_get_or_create_tags(caplog, client: Albert, seeded_tags: list[Tag]):

--- a/tests/collections/test_targets.py
+++ b/tests/collections/test_targets.py
@@ -14,6 +14,8 @@ from albert.resources.targets import (
     TargetType,
 )
 
+pytestmark = pytest.mark.xdist_group("datatemplates")
+
 
 def test_target_create(
     client: Albert, seed_prefix: str, seeded_data_templates: list[DataTemplate]

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -12,6 +12,7 @@ from albert.resources.tasks import (
 )
 from albert.resources.workflows import Workflow
 from tests.utils.test_patches import change_metadata, make_metadata_update_assertions
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("tasks")
 
@@ -51,11 +52,13 @@ def test_hydrated_task(client: Albert, seed_prefix: str, seeded_tasks):
     # Scope the search to this worker's live seeds: unscoped results race other
     # workers' teardown, and the search index can still hold already-deleted tasks
     seeded_ids = {t.id for t in seeded_tasks}
-    tasks = [
-        t
-        for t in client.tasks.search(text=seed_prefix, category=TaskCategory.GENERAL)
-        if t.id in seeded_ids
-    ]
+    tasks = poll_until(
+        lambda: [
+            t
+            for t in client.tasks.search(text=seed_prefix, category=TaskCategory.GENERAL)
+            if t.id in seeded_ids
+        ]
+    )
     assert tasks, "Expected at least one task in search results"
 
     for t in tasks:

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -1,3 +1,5 @@
+import pytest
+
 from albert import Albert
 from albert.resources.lists import ListItem
 from albert.resources.tags import Tag
@@ -10,6 +12,8 @@ from albert.resources.tasks import (
 )
 from albert.resources.workflows import Workflow
 from tests.utils.test_patches import change_metadata, make_metadata_update_assertions
+
+pytestmark = pytest.mark.xdist_group("tasks")
 
 
 def _final_workflow_id(block) -> str:

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -47,8 +47,15 @@ def test_task_get_all_with_pagination(client: Albert, seeded_tasks):
         assert isinstance(task.category, str) and task.category
 
 
-def test_hydrated_task(client: Albert):
-    tasks = list(client.tasks.search(category=TaskCategory.GENERAL, max_items=5))
+def test_hydrated_task(client: Albert, seed_prefix: str, seeded_tasks):
+    # Scope the search to this worker's live seeds: unscoped results race other
+    # workers' teardown, and the search index can still hold already-deleted tasks
+    seeded_ids = {t.id for t in seeded_tasks}
+    tasks = [
+        t
+        for t in client.tasks.search(text=seed_prefix, category=TaskCategory.GENERAL)
+        if t.id in seeded_ids
+    ]
     assert tasks, "Expected at least one task in search results"
 
     for t in tasks:

--- a/tests/collections/test_teams.py
+++ b/tests/collections/test_teams.py
@@ -8,6 +8,8 @@ from albert.exceptions import AlbertException, NotFoundError
 from albert.resources.teams import Team, TeamMember
 from albert.resources.users import User
 
+pytestmark = pytest.mark.xdist_group("teams")
+
 
 def _assert_member_absent(client: Albert, team_id: str, user_id: str) -> Team:
     """Fetch team and assert user is not a member. Retries for eventual consistency."""

--- a/tests/collections/test_units.py
+++ b/tests/collections/test_units.py
@@ -1,6 +1,10 @@
+import pytest
+
 from albert.client import Albert
 from albert.core.shared.enums import OrderBy
 from albert.resources.units import Unit, UnitCategory
+
+pytestmark = pytest.mark.xdist_group("datatemplates")
 
 
 def assert_unit_items(returned_list: list[Unit]):

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.workflows import Workflow
+
+pytestmark = pytest.mark.xdist_group("tasks")
 
 
 def test_workflow_get_all_with_pagination(client: Albert, seeded_workflows: list[Workflow]):

--- a/tests/collections/test_worksheet.py
+++ b/tests/collections/test_worksheet.py
@@ -1,5 +1,9 @@
+import pytest
+
 from albert import Albert
 from albert.resources.worksheets import Worksheet
+
+pytestmark = pytest.mark.xdist_group("sheets")
 
 
 def test_get_worksheet(seeded_worksheet: Worksheet):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -105,43 +105,39 @@ def _pmap(fn: Callable, items) -> list:
     def _one(item):
         try:
             return fn(item)
-        except AlbertServerError:
+        except AlbertServerError as err:
             time.sleep(2.0)
-            return fn(item)
+            try:
+                return fn(item)
+            except BadRequestError as retry_err:
+                # The first attempt likely committed despite the 5xx; surface the
+                # real cause instead of a misleading "already exists"
+                raise err from retry_err
 
     items = list(items)
     with ThreadPoolExecutor(max_workers=min(8, max(1, len(items)))) as ex:
         return list(ex.map(_one, items))
 
 
-@pytest.hookimpl(hookwrapper=True)
-def pytest_fixture_setup(fixturedef, request):
-    """Report slow fixture setups so seeding regressions stay visible."""
-    start = time.monotonic()
-    yield
-    elapsed = time.monotonic() - start
-    if elapsed > 5:
-        print(f"[slow fixture] {fixturedef.argname}: {elapsed:.1f}s", flush=True)
-
-
-def _get_or_register(create_fn: Callable, get_fn: Callable, *, timeout: float = 10.0):
+def _get_or_register(create_fn: Callable, get_fn: Callable, *, timeout: float = 5.0):
     """Create a shared (non-prefixed) entity, falling back to fetching it.
 
     Concurrent xdist workers register the same static entities; the backend may answer
     the loser with a 400 (already exists) or buckle with a 5xx. Either way the entity
-    usually exists, so poll the getter before giving up.
+    usually exists, so try the getter (briefly polling) before giving up.
     """
     try:
         return create_fn()
     except (BadRequestError, AlbertServerError) as e:
         deadline = time.monotonic() + timeout
-        while time.monotonic() < deadline:
+        while True:
             with suppress(Exception):
                 found = get_fn()
                 if found is not None:
                     return found
+            if time.monotonic() >= deadline:
+                raise e
             time.sleep(0.5)
-        raise e
 
 
 def _delete_all(delete_fn: Callable, items, *suppressed: type[Exception]) -> None:
@@ -851,9 +847,11 @@ def seeded_entity_types(
         )
     ]
     yield seeded
-    _delete_all(
-        lambda entity_type: client.entity_types.delete(id=entity_type.id), seeded, NotFoundError
-    )
+    # Sequential teardown for the same reason; tolerate 5xx so cleanup errors
+    # don't fail the session
+    for entity_type in seeded:
+        with suppress(NotFoundError, AlbertServerError):
+            client.entity_types.delete(id=entity_type.id)
 
 
 @pytest.fixture(scope="session")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import time
 import uuid
-from collections.abc import AsyncGenerator, Iterator
+from collections.abc import AsyncGenerator, Callable, Iterator
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from pathlib import Path
 
@@ -10,7 +11,12 @@ import pytest_asyncio
 from albert import Albert, AlbertClientCredentials, AsyncAlbert
 from albert.collections.worksheets import WorksheetCollection
 from albert.core.shared.enums import Status
-from albert.exceptions import BadRequestError, ForbiddenError, NotFoundError
+from albert.exceptions import (
+    AlbertServerError,
+    BadRequestError,
+    ForbiddenError,
+    NotFoundError,
+)
 from albert.resources.attachments import Attachment
 from albert.resources.btdataset import BTDataset
 from albert.resources.btinsight import BTInsight
@@ -87,6 +93,65 @@ from tests.seeding import (
     generate_workflow_seeds,
 )
 from tests.utils.fake_session import FakeAlbertSession
+
+
+def _pmap(fn: Callable, items) -> list:
+    """Run independent seeding API calls concurrently, preserving input order.
+
+    Retries once on 5xx: the session's urllib3 retry only covers idempotent methods,
+    so seeding POSTs otherwise fail on a single transient gateway error.
+    """
+
+    def _one(item):
+        try:
+            return fn(item)
+        except AlbertServerError:
+            time.sleep(2.0)
+            return fn(item)
+
+    items = list(items)
+    with ThreadPoolExecutor(max_workers=min(8, max(1, len(items)))) as ex:
+        return list(ex.map(_one, items))
+
+
+@pytest.hookimpl(hookwrapper=True)
+def pytest_fixture_setup(fixturedef, request):
+    """Report slow fixture setups so seeding regressions stay visible."""
+    start = time.monotonic()
+    yield
+    elapsed = time.monotonic() - start
+    if elapsed > 5:
+        print(f"[slow fixture] {fixturedef.argname}: {elapsed:.1f}s", flush=True)
+
+
+def _get_or_register(create_fn: Callable, get_fn: Callable, *, timeout: float = 10.0):
+    """Create a shared (non-prefixed) entity, falling back to fetching it.
+
+    Concurrent xdist workers register the same static entities; the backend may answer
+    the loser with a 400 (already exists) or buckle with a 5xx. Either way the entity
+    usually exists, so poll the getter before giving up.
+    """
+    try:
+        return create_fn()
+    except (BadRequestError, AlbertServerError) as e:
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with suppress(Exception):
+                found = get_fn()
+                if found is not None:
+                    return found
+            time.sleep(0.5)
+        raise e
+
+
+def _delete_all(delete_fn: Callable, items, *suppressed: type[Exception]) -> None:
+    """Delete seeded entities concurrently, suppressing the given exceptions."""
+
+    def _one(item):
+        with suppress(*suppressed):
+            delete_fn(item)
+
+    _pmap(_one, items)
 
 
 @pytest.fixture(scope="session")
@@ -187,35 +252,23 @@ def static_consumeable_parameter(client: Albert) -> Parameter:
             return c
 
 
+def _register_custom_field(client: Albert, cf: CustomField) -> CustomField:
+    return _get_or_register(
+        lambda: client.custom_fields.create(custom_field=cf),
+        lambda: client.custom_fields.get_by_name(name=cf.name, service=cf.service),
+    )
+
+
 @pytest.fixture(scope="session")
 def static_custom_fields(client: Albert) -> list[CustomField]:
-    seeded = []
-    for cf in generate_custom_fields():
-        try:
-            registered_cf = client.custom_fields.create(custom_field=cf)
-        except BadRequestError as e:
-            # If it's already registered, this will raise a BadRequestError
-            registered_cf = client.custom_fields.get_by_name(name=cf.name, service=cf.service)
-            if registered_cf is None:  # If it was something else, raise the error
-                raise e
-        seeded.append(registered_cf)
-    return seeded
+    # Sequential on purpose: shared names race across xdist workers
+    return [_register_custom_field(client, cf) for cf in generate_custom_fields()]
 
 
 @pytest.fixture(scope="session")
 def static_entity_custom_fields(client: Albert) -> list[CustomField]:
     """Custom fields associated with an entity type."""
-    seeded = []
-    for cf in generate_entity_custom_fields():
-        try:
-            registered_cf = client.custom_fields.create(custom_field=cf)
-        except BadRequestError as e:
-            # If it's already registered, this will raise a BadRequestError
-            registered_cf = client.custom_fields.get_by_name(name=cf.name, service=cf.service)
-            if registered_cf is None:  # If it was something else, raise the error
-                raise e
-        seeded.append(registered_cf)
-    return seeded
+    return [_register_custom_field(client, cf) for cf in generate_entity_custom_fields()]
 
 
 @pytest.fixture(scope="session")
@@ -223,19 +276,16 @@ def static_lists(
     client: Albert,
     static_custom_fields: list[CustomField],
 ) -> list[ListItem]:
-    seeded = []
-    for list_item in generate_list_item_seeds(seeded_custom_fields=static_custom_fields):
-        try:
-            created_list = client.lists.create(list_item=list_item)
-        except BadRequestError as e:
-            # If it's already registered, this will raise a BadRequestError
-            created_list = client.lists.get_matching_item(
-                name=list_item.name, list_type=list_item.list_type
-            )
-            if created_list is None:
-                raise e
-        seeded.append(created_list)
-    return seeded
+    # Sequential on purpose: shared names race across xdist workers
+    return [
+        _get_or_register(
+            lambda li=list_item: client.lists.create(list_item=li),
+            lambda li=list_item: client.lists.get_matching_item(
+                name=li.name, list_type=li.list_type
+            ),
+        )
+        for list_item in generate_list_item_seeds(seeded_custom_fields=static_custom_fields)
+    ]
 
 
 ### TEAM FIXTURES
@@ -273,34 +323,33 @@ def seeded_cas(
     static_custom_fields: list[CustomField],
     static_lists: list[ListItem],
 ) -> Iterator[list[Cas]]:
-    seeded = []
-    for cas in generate_cas_seeds(seed_prefix, static_custom_fields, static_lists):
+    def _seed(cas: Cas) -> Cas | None:
         with suppress(BadRequestError):
-            created_cas = client.cas_numbers.get_or_create(cas=cas)
-            seeded.append(created_cas)
+            return client.cas_numbers.get_or_create(cas=cas)
+
+    results = _pmap(_seed, generate_cas_seeds(seed_prefix, static_custom_fields, static_lists))
+    seeded = [cas for cas in results if cas is not None]
 
     # Avoid race condition while it populated through DBs
     time.sleep(3)
 
     yield seeded
 
-    for cas in seeded:
-        with suppress(BadRequestError | NotFoundError):
-            client.cas_numbers.delete(id=cas.id)
+    _delete_all(
+        lambda cas: client.cas_numbers.delete(id=cas.id), seeded, BadRequestError, NotFoundError
+    )
 
 
 @pytest.fixture(scope="session")
 def seeded_locations(client: Albert, seed_prefix: str) -> Iterator[list[Location]]:
-    seeded = []
-    for location in generate_location_seeds(seed_prefix):
-        created_location = client.locations.get_or_create(location=location)
-        seeded.append(created_location)
+    seeded = _pmap(
+        lambda location: client.locations.get_or_create(location=location),
+        generate_location_seeds(seed_prefix),
+    )
 
     yield seeded
 
-    for location in seeded:
-        with suppress(NotFoundError):
-            client.locations.delete(id=location.id)
+    _delete_all(lambda location: client.locations.delete(id=location.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -311,21 +360,19 @@ def seeded_projects(
     static_custom_fields: list[CustomField],
     static_lists: list[ListItem],
 ) -> Iterator[list[Project]]:
-    seeded = []
-    for project in generate_project_seeds(
-        seed_prefix=seed_prefix,
-        seeded_locations=seeded_locations,
-        static_custom_fields=static_custom_fields,
-        static_lists=static_lists,
-    ):
-        created_project = client.projects.create(project=project)
-        seeded.append(created_project)
+    seeded = _pmap(
+        lambda project: client.projects.create(project=project),
+        generate_project_seeds(
+            seed_prefix=seed_prefix,
+            seeded_locations=seeded_locations,
+            static_custom_fields=static_custom_fields,
+            static_lists=static_lists,
+        ),
+    )
 
     yield seeded
 
-    for project in seeded:
-        with suppress(NotFoundError):
-            client.projects.delete(id=project.id)
+    _delete_all(lambda project: client.projects.delete(id=project.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -348,17 +395,21 @@ def seeded_project_document(
 
 @pytest.fixture(scope="session")
 def seeded_companies(client: Albert, seed_prefix: str) -> Iterator[list[Company]]:
-    seeded = []
-    for company in generate_company_seeds(seed_prefix):
-        created_company = client.companies.get_or_create(company=company)
-        seeded.append(created_company)
+    seeded = _pmap(
+        lambda company: client.companies.get_or_create(company=company),
+        generate_company_seeds(seed_prefix),
+    )
 
     yield seeded
 
     # ForbiddenError is raised when trying to delete a company that has InventoryItems associated with it (may be a bug. Teams discussion ongoing)
-    for company in seeded:
-        with suppress(NotFoundError, ForbiddenError, BadRequestError):
-            client.companies.delete(id=company.id)
+    _delete_all(
+        lambda company: client.companies.delete(id=company.id),
+        seeded,
+        NotFoundError,
+        ForbiddenError,
+        BadRequestError,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -366,32 +417,32 @@ def seeded_storage_locations(
     client: Albert,
     seeded_locations: list[Location],
 ) -> Iterator[list[StorageLocation]]:
-    seeded: list[StorageLocation] = []
-    for storage_location in generate_storage_location_seeds(seeded_locations=seeded_locations):
-        created_location = client.storage_locations.get_or_create(
+    seeded = _pmap(
+        lambda storage_location: client.storage_locations.get_or_create(
             storage_location=storage_location
-        )
-        seeded.append(created_location)
+        ),
+        generate_storage_location_seeds(seeded_locations=seeded_locations),
+    )
 
     yield seeded
 
-    for storage_location in seeded:
-        with suppress(NotFoundError):
-            client.storage_locations.delete(id=storage_location.id)
+    _delete_all(
+        lambda storage_location: client.storage_locations.delete(id=storage_location.id),
+        seeded,
+        NotFoundError,
+    )
 
 
 @pytest.fixture(scope="session")
 def seeded_tags(client: Albert, seed_prefix: str) -> Iterator[list[Tag]]:
-    seeded = []
-    for tag in generate_tag_seeds(seed_prefix):
-        created_tag = client.tags.get_or_create(tag=tag)
-        seeded.append(created_tag)
+    seeded = _pmap(
+        lambda tag: client.tags.get_or_create(tag=tag),
+        generate_tag_seeds(seed_prefix),
+    )
 
     yield seeded
 
-    for tag in seeded:
-        with suppress(NotFoundError, BadRequestError):
-            client.tags.delete(id=tag.id)
+    _delete_all(lambda tag: client.tags.delete(id=tag.id), seeded, NotFoundError, BadRequestError)
 
 
 @pytest.fixture(scope="session")
@@ -463,19 +514,19 @@ def seeded_label_templates(
 
 @pytest.fixture(scope="session")
 def seeded_units(client: Albert, seed_prefix: str) -> Iterator[list[Unit]]:
-    seeded = []
-    for unit in generate_unit_seeds(seed_prefix):
-        created_unit = client.units.get_or_create(unit=unit)
-        seeded.append(created_unit)
+    seeded = _pmap(
+        lambda unit: client.units.get_or_create(unit=unit),
+        generate_unit_seeds(seed_prefix),
+    )
 
     # Avoid race condition while it populated through search DBs
     time.sleep(1.5)
 
     yield seeded
 
-    for unit in seeded:
-        with suppress(NotFoundError, BadRequestError):
-            client.units.delete(id=unit.id)
+    _delete_all(
+        lambda unit: client.units.delete(id=unit.id), seeded, NotFoundError, BadRequestError
+    )
 
 
 @pytest.fixture(scope="session")
@@ -484,24 +535,23 @@ def seeded_data_columns(
     seed_prefix: str,
     seeded_units: list[Unit],
 ) -> Iterator[list[DataColumn]]:
-    seeded = []
-    for data_column in generate_data_column_seeds(
-        seed_prefix=seed_prefix,
-        seeded_units=seeded_units,
-    ):
-        created_data_column = client.data_columns.create(data_column=data_column)
-        seeded.append(created_data_column)
+    seeded = _pmap(
+        lambda data_column: client.data_columns.create(data_column=data_column),
+        generate_data_column_seeds(seed_prefix=seed_prefix, seeded_units=seeded_units),
+    )
 
     # Avoid race condition while it populated through search DBs
     time.sleep(1.5)
 
     yield seeded
 
-    for data_column in seeded:
-        with suppress(
-            NotFoundError, BadRequestError
-        ):  # used on deleted InventoryItem properties are blocking. Instead of making static to accomidate the unexpected behavior, doing this instead
-            client.data_columns.delete(id=data_column.id)
+    # used on deleted InventoryItem properties are blocking. Instead of making static to accomidate the unexpected behavior, doing this instead
+    _delete_all(
+        lambda data_column: client.data_columns.delete(id=data_column.id),
+        seeded,
+        NotFoundError,
+        BadRequestError,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -516,28 +566,30 @@ def seeded_data_templates(
     static_custom_fields: list[CustomField],
     static_lists: list[ListItem],
 ) -> Iterator[list[DataTemplate]]:
-    seeded = []
-    for data_template in generate_data_template_seeds(
-        user=static_user,
-        seed_prefix=seed_prefix,
-        seeded_data_columns=seeded_data_columns,
-        seeded_units=seeded_units,
-        seeded_tags=seeded_tags,
-        seeded_parameters=seeded_parameters,
-        static_custom_fields=static_custom_fields,
-        static_lists=static_lists,
-    ):
-        dt = client.data_templates.create(data_template=data_template)
-        seeded.append(dt)
+    seeded = _pmap(
+        lambda data_template: client.data_templates.create(data_template=data_template),
+        generate_data_template_seeds(
+            user=static_user,
+            seed_prefix=seed_prefix,
+            seeded_data_columns=seeded_data_columns,
+            seeded_units=seeded_units,
+            seeded_tags=seeded_tags,
+            seeded_parameters=seeded_parameters,
+            static_custom_fields=static_custom_fields,
+            static_lists=static_lists,
+        ),
+    )
 
     # Avoid race condition while it populated through search DBs
     time.sleep(1.5)
 
     yield seeded
 
-    for data_template in seeded:
-        with suppress(NotFoundError):
-            client.data_templates.delete(id=data_template.id)
+    _delete_all(
+        lambda data_template: client.data_templates.delete(id=data_template.id),
+        seeded,
+        NotFoundError,
+    )
 
 
 @pytest.fixture(scope="session")
@@ -573,36 +625,46 @@ def seeded_inventory(
     seeded_companies,
     seeded_locations,
 ) -> Iterator[list[InventoryItem]]:
-    seeded = []
-    for inventory in generate_inventory_seeds(
-        seed_prefix=seed_prefix,
-        seeded_cas=seeded_cas,
-        seeded_tags=seeded_tags,
-        seeded_companies=seeded_companies,
-        seeded_locations=seeded_locations,
-    ):
-        created_inventory = client.inventory.create(inventory_item=inventory)
-        seeded.append(created_inventory)
+    seeded = _pmap(
+        lambda inventory: client.inventory.create(inventory_item=inventory),
+        generate_inventory_seeds(
+            seed_prefix=seed_prefix,
+            seeded_cas=seeded_cas,
+            seeded_tags=seeded_tags,
+            seeded_companies=seeded_companies,
+            seeded_locations=seeded_locations,
+        ),
+    )
+
+    # Avoid race condition while it populated through search DBs
     time.sleep(1.5)
+
     yield seeded
-    for inventory in seeded:
-        # If the inv has been used in a formulation, it cannot be deleted and will give a BadRequestError
-        with suppress(NotFoundError, BadRequestError):
-            client.inventory.delete(id=inventory.id)
+
+    # If the inv has been used in a formulation, it cannot be deleted and will give a BadRequestError
+    _delete_all(
+        lambda inventory: client.inventory.delete(id=inventory.id),
+        seeded,
+        NotFoundError,
+        BadRequestError,
+    )
 
 
 @pytest.fixture(scope="session")
 def seeded_parameters(client: Albert, seed_prefix: str) -> Iterator[list[Parameter]]:
-    seeded = []
-    for parameter in generate_parameter_seeds(seed_prefix):
+    def _seed(parameter: Parameter) -> Parameter:
         created_parameter = client.parameters.get_or_create(parameter=parameter)
         # Extra get_by_id is required to populate the category field on parameter
-        seeded.append(client.parameters.get_by_id(id=created_parameter.id))
+        return client.parameters.get_by_id(id=created_parameter.id)
+
+    seeded = _pmap(_seed, generate_parameter_seeds(seed_prefix))
+
+    # Avoid race condition while it populated through search DBs
     time.sleep(1.5)
+
     yield seeded
-    for parameter in seeded:
-        with suppress(NotFoundError):
-            client.parameters.delete(id=parameter.id)
+
+    _delete_all(lambda parameter: client.parameters.delete(id=parameter.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -616,27 +678,29 @@ def seeded_parameter_groups(
     static_custom_fields: list[CustomField],
     static_lists: list[ListItem],
 ) -> Iterator[list[ParameterGroup]]:
-    seeded = []
-    for parameter_group in generate_parameter_group_seeds(
-        seed_prefix=seed_prefix,
-        seeded_parameters=seeded_parameters,
-        seeded_tags=seeded_tags,
-        seeded_units=seeded_units,
-        static_consumeable_parameter=static_consumeable_parameter,
-        static_custom_fields=static_custom_fields,
-        static_lists=static_lists,
-    ):
-        created_parameter_group = client.parameter_groups.create(parameter_group=parameter_group)
-        seeded.append(created_parameter_group)
+    seeded = _pmap(
+        lambda parameter_group: client.parameter_groups.create(parameter_group=parameter_group),
+        generate_parameter_group_seeds(
+            seed_prefix=seed_prefix,
+            seeded_parameters=seeded_parameters,
+            seeded_tags=seeded_tags,
+            seeded_units=seeded_units,
+            static_consumeable_parameter=static_consumeable_parameter,
+            static_custom_fields=static_custom_fields,
+            static_lists=static_lists,
+        ),
+    )
 
     # Avoid race condition while it populates through DBs
     time.sleep(1.5)
 
     yield seeded
 
-    for parameter_group in seeded:
-        with suppress(NotFoundError):
-            client.parameter_groups.delete(id=parameter_group.id)
+    _delete_all(
+        lambda parameter_group: client.parameter_groups.delete(id=parameter_group.id),
+        seeded,
+        NotFoundError,
+    )
 
 
 # PUT on lots is currently bugged. Teams discussion ongoing
@@ -666,29 +730,26 @@ def seeded_notebooks(
     seed_prefix: str,
     seeded_projects,
 ):
-    seeded = []
-    all_notebooks = generate_notebook_seeds(
-        seed_prefix=seed_prefix, seeded_projects=seeded_projects
-    )
-    for nb in all_notebooks:
+    def _seed(nb):
         seed = client.notebooks.create(notebook=nb)
         seed.blocks = generate_notebook_block_seeds()  # generate each iteration for new block ids
-        seeded.append(client.notebooks.update_block_content(notebook=seed))
+        return client.notebooks.update_block_content(notebook=seed)
+
+    seeded = _pmap(
+        _seed, generate_notebook_seeds(seed_prefix=seed_prefix, seeded_projects=seeded_projects)
+    )
     yield seeded
-    for notebook in seeded:
-        with suppress(NotFoundError):
-            client.notebooks.delete(id=notebook.id)
+    _delete_all(lambda notebook: client.notebooks.delete(id=notebook.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
 def seeded_pricings(client: Albert, seed_prefix: str, seeded_inventory, seeded_locations):
-    seeded = []
-    for p in generate_pricing_seeds(seed_prefix, seeded_inventory, seeded_locations):
-        seeded.append(client.pricings.create(pricing=p))
+    seeded = _pmap(
+        lambda p: client.pricings.create(pricing=p),
+        generate_pricing_seeds(seed_prefix, seeded_inventory, seeded_locations),
+    )
     yield seeded
-    for p in seeded:
-        with suppress(NotFoundError):
-            client.pricings.delete(id=p.id)
+    _delete_all(lambda p: client.pricings.delete(id=p.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -757,7 +818,6 @@ def seeded_tasks(
     static_lists: list[ListItem],
     static_custom_fields: list[CustomField],
 ):
-    seeded = []
     all_tasks = generate_task_seeds(
         seed_prefix=seed_prefix,
         user=static_user,
@@ -771,12 +831,9 @@ def seeded_tasks(
         static_lists=static_lists,
         static_custom_fields=static_custom_fields,
     )
-    for t in all_tasks:
-        seeded.append(client.tasks.create(task=t))
+    seeded = _pmap(lambda t: client.tasks.create(task=t), all_tasks)
     yield seeded
-    for t in seeded:
-        with suppress(NotFoundError, BadRequestError):
-            client.tasks.delete(id=t.id)
+    _delete_all(lambda t: client.tasks.delete(id=t.id), seeded, NotFoundError, BadRequestError)
 
 
 @pytest.fixture(scope="session")
@@ -785,17 +842,18 @@ def seeded_entity_types(
     seed_prefix: str,
     static_entity_custom_fields: list[CustomField],
 ) -> Iterator[list[EntityType]]:
-    seeded: list[EntityType] = []
-    entity_type_seeds = generate_entity_type_seeds(
-        seed_prefix=seed_prefix,
-        static_entity_custom_fields=static_entity_custom_fields,
-    )
-    for entity_type in entity_type_seeds:
-        seeded.append(client.entity_types.create(entity_type=entity_type))
+    # Sequential on purpose: the entitytypes endpoint 500s under concurrent creates
+    seeded = [
+        client.entity_types.create(entity_type=entity_type)
+        for entity_type in generate_entity_type_seeds(
+            seed_prefix=seed_prefix,
+            static_entity_custom_fields=static_entity_custom_fields,
+        )
+    ]
     yield seeded
-    for entity_type in seeded:
-        with suppress(NotFoundError):
-            client.entity_types.delete(id=entity_type.id)
+    _delete_all(
+        lambda entity_type: client.entity_types.delete(id=entity_type.id), seeded, NotFoundError
+    )
 
 
 @pytest.fixture(scope="session")
@@ -805,15 +863,14 @@ def seeded_notes(
     seeded_inventory: list[InventoryItem],
     seed_prefix: str,
 ):
-    seeded = []
-    for note in generate_note_seeds(
-        seeded_tasks=seeded_tasks, seeded_inventory=seeded_inventory, seed_prefix=seed_prefix
-    ):
-        seeded.append(client.notes.create(note=note))
+    seeded = _pmap(
+        lambda note: client.notes.create(note=note),
+        generate_note_seeds(
+            seeded_tasks=seeded_tasks, seeded_inventory=seeded_inventory, seed_prefix=seed_prefix
+        ),
+    )
     yield seeded
-    for note in seeded:
-        with suppress(NotFoundError):
-            client.notes.delete(id=note.id)
+    _delete_all(lambda note: client.notes.delete(id=note.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -895,16 +952,14 @@ def seeded_reports(
     seeded_projects: list[Project],
 ) -> Iterator[list[FullAnalyticalReport]]:
     """Create seeded reports for testing."""
-    seeded = []
-    for report in generate_report_seeds(seed_prefix=seed_prefix, seeded_projects=seeded_projects):
-        created_report = client.reports.create_report(report=report)
-        seeded.append(created_report)
+    seeded = _pmap(
+        lambda report: client.reports.create_report(report=report),
+        generate_report_seeds(seed_prefix=seed_prefix, seeded_projects=seeded_projects),
+    )
 
     yield seeded
 
-    for report in seeded:
-        with suppress(NotFoundError):
-            client.reports.delete(id=report.id)
+    _delete_all(lambda report: client.reports.delete(id=report.id), seeded, NotFoundError)
 
 
 @pytest.fixture(scope="session")
@@ -913,17 +968,17 @@ def seeded_targets(
     seed_prefix: str,
     seeded_data_templates: list[DataTemplate],
 ) -> Iterator[list[Target]]:
-    seeded = []
-    for target in generate_target_seeds(
-        seed_prefix=seed_prefix,
-        seeded_data_templates=seeded_data_templates,
-    ):
-        created_target = client.targets.create(target=target)
-        seeded.append(created_target)
+    seeded = _pmap(
+        lambda target: client.targets.create(target=target),
+        generate_target_seeds(
+            seed_prefix=seed_prefix,
+            seeded_data_templates=seeded_data_templates,
+        ),
+    )
     yield seeded
-    for target in seeded:
-        with suppress(NotFoundError, BadRequestError):
-            client.targets.delete(id=target.id)
+    _delete_all(
+        lambda target: client.targets.delete(id=target.id), seeded, NotFoundError, BadRequestError
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/resources/test_inventory.py
+++ b/tests/resources/test_inventory.py
@@ -9,6 +9,8 @@ from albert.resources.inventory import (
     InventoryMinimum,
 )
 
+pytestmark = pytest.mark.xdist_group("inventory")
+
 
 def test_cas_amount_attributes():
     cas = Cas(number="test", smiles="CCC", id="dogs")

--- a/tests/resources/test_lots.py
+++ b/tests/resources/test_lots.py
@@ -1,4 +1,8 @@
+import pytest
+
 from albert.resources.lots import Lot
+
+pytestmark = pytest.mark.xdist_group("inventory")
 
 
 def test_private_attrs(seeded_lots: list[Lot]):

--- a/tests/resources/test_notebooks.py
+++ b/tests/resources/test_notebooks.py
@@ -14,6 +14,8 @@ from albert.resources.notebooks import (
     TableContent,
 )
 
+pytestmark = pytest.mark.xdist_group("projects")
+
 
 def test_put_datum_content_matches_type():
     with pytest.raises(AlbertException, match="The content type and block type do not match."):

--- a/tests/resources/test_sheets.py
+++ b/tests/resources/test_sheets.py
@@ -13,6 +13,8 @@ from albert.resources.sheets import (
     Sheet,
 )
 
+pytestmark = pytest.mark.xdist_group("sheets")
+
 
 def test_get_current_cell_exact_row_match():
     sheet = Sheet(

--- a/tests/resources/test_smart_projects.py
+++ b/tests/resources/test_smart_projects.py
@@ -1,8 +1,12 @@
+import pytest
+
 from albert.client import Albert
 from albert.resources.data_templates import DataTemplate
 from albert.resources.projects import Project
 from albert.resources.smart_projects import SmartProject
 from albert.resources.targets import ComparisonOperator, Criterion, Target, TargetType
+
+pytestmark = pytest.mark.xdist_group("datatemplates")
 
 
 def _scope_target_ids(smart: SmartProject) -> set[str]:

--- a/tests/utils/wait.py
+++ b/tests/utils/wait.py
@@ -1,0 +1,16 @@
+import time
+from collections.abc import Callable
+
+
+def poll_until(fetch: Callable[[], list], *, timeout: float = 30.0, interval: float = 1.0) -> list:
+    """Poll ``fetch`` until it returns a non-empty result or the timeout elapses.
+
+    Search-index-backed endpoints lag behind seeding; tests asserting on fresh
+    seeds poll instead of assuming immediate visibility. Returns the last result.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        result = fetch()
+        if result or time.monotonic() >= deadline:
+            return result
+        time.sleep(interval)


### PR DESCRIPTION
## Summary
- Run the integration suite with `pytest -n 4` and `--dist loadgroup`, cutting local wall time from 23:16 to ~11 min (CI expected ~7-8 min from 15 min). Test files are grouped by shared fixture chains via `xdist_group` marks so each worker seeds only its own tier.
- Parallelize fixture seeding in `conftest.py` (`_pmap` create/delete helpers with a one-shot 5xx retry, since urllib3 does not retry POSTs) and keep contention-prone shared static fixtures sequential with a create-or-fetch fallback.
- Fix parallel-safety bugs: tests that mutated or deleted shared session-scoped seeds now use private entities with `try/finally` cleanup, unscoped search-then-hydrate and exact-count tests are scoped to the worker's `seed_prefix`, and every seed-consuming file carries a group mark (unmarked tests scatter per-test under loadgroup).
- Make `AlbertSession` auth thread-safe: `Authorization` is sent as a per-request header instead of mutating the shared session, and token refresh is serialized with a lock (double-checked). Real fix for any client shared across threads.