### PR TITLE
feat(search): add filters, metadata_filters, and SearchItem fields

### DIFF
--- a/src/albert/collections/btinsight.py
+++ b/src/albert/collections/btinsight.py
@@ -157,6 +157,10 @@ class BTInsightCollection(BaseCollection):
         name: str | list[str] | None = None,
         state: BTInsightState | list[BTInsightState] | None = None,
         category: BTInsightCategory | list[BTInsightCategory] | None = None,
+        created_by: str | list[str] | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
         offset: int | None = None,
         max_items: int | None = None,
     ) -> Iterator[BTInsight]:
@@ -191,6 +195,16 @@ class BTInsightCollection(BaseCollection):
             Filter by progress state (e.g. ``Complete``, ``Error``).
         category : BTInsightCategory or list[BTInsightCategory], optional
             Filter by category (e.g. ``Optimizer``, ``Impact Chart``).
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the insight. Accepts UserId(s)
+            only (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include insights updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include insights updated on or before this date (ISO 8601).
         max_items : int, optional
             Maximum number of items to return in total. If None, iterates over all
             matches.
@@ -213,6 +227,10 @@ class BTInsightCollection(BaseCollection):
 
         category_values = ensure_list(category)
         params["category"] = category_values if category_values else None
+        params["createdBy"] = ensure_list(created_by)
+        params["updatedBy"] = ensure_list(updated_by)
+        params["fromUpdatedAt"] = from_updated_at
+        params["toUpdatedAt"] = to_updated_at
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,

--- a/src/albert/collections/btinsight.py
+++ b/src/albert/collections/btinsight.py
@@ -159,6 +159,8 @@ class BTInsightCollection(BaseCollection):
         category: BTInsightCategory | list[BTInsightCategory] | None = None,
         created_by: str | list[str] | None = None,
         updated_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
         offset: int | None = None,
@@ -201,6 +203,10 @@ class BTInsightCollection(BaseCollection):
         updated_by : str or list[str], optional
             Filter by user(s) who last updated the insight. Accepts UserId(s)
             only (e.g. ``"USR4227"``), not display names.
+        from_created_at : str, optional
+            Only include insights created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include insights created on or before this date (ISO 8601).
         from_updated_at : str, optional
             Only include insights updated on or after this date (ISO 8601).
         to_updated_at : str, optional
@@ -229,6 +235,8 @@ class BTInsightCollection(BaseCollection):
         params["category"] = category_values if category_values else None
         params["createdBy"] = ensure_list(created_by)
         params["updatedBy"] = ensure_list(updated_by)
+        params["fromCreatedAt"] = from_created_at
+        params["toCreatedAt"] = to_created_at
         params["fromUpdatedAt"] = from_updated_at
         params["toUpdatedAt"] = to_updated_at
 

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -1,5 +1,6 @@
 from collections.abc import Iterator
 from itertools import islice
+from typing import Any
 
 from pydantic import Field, validate_call
 
@@ -379,6 +380,13 @@ class DataTemplateCollection(BaseCollection):
         data_columns: str | list[str] | None = None,
         standard_organization: str | list[str] | None = None,
         additional_field: str | list[str] | None = None,
+        created_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         max_items: int | None = None,
         offset: int | None = 0,
@@ -414,6 +422,23 @@ class DataTemplateCollection(BaseCollection):
         additional_field : str or list[str], optional
             Additional fields to include on each returned item. If omitted, a default
             set of fields is requested.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        from_created_at : str, optional
+            Only include templates created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include templates created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the template. Accepts UserId(s)
+            only (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include templates updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include templates updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field.
         order_by : OrderBy, optional
             The order in which to sort results. Default is ``DESCENDING``.
         max_items : int, optional
@@ -436,12 +461,20 @@ class DataTemplateCollection(BaseCollection):
             "tags": ensure_list(tags),
             "dataColumns": ensure_list(data_columns),
             "standardOrganization": ensure_list(standard_organization),
+            "createdBy": ensure_list(created_by),
+            "fromCreatedAt": from_created_at,
+            "toCreatedAt": to_created_at,
+            "updatedBy": ensure_list(updated_by),
+            "fromUpdatedAt": from_updated_at,
+            "toUpdatedAt": to_updated_at,
             "additionalField": (
                 ensure_list(additional_field)
                 if additional_field is not None
                 else list(DEFAULT_ADDITIONAL_FIELDS)
             ),
         }
+        if metadata_filters is not None:
+            payload["metadataFilters"] = {"metadata": metadata_filters}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -437,8 +437,7 @@ class DataTemplateCollection(BaseCollection):
         to_updated_at : str, optional
             Only include templates updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field.
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             The order in which to sort results. Default is ``DESCENDING``.
         max_items : int, optional

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -702,6 +702,18 @@ class DataTemplateCollection(BaseCollection):
         *,
         name: str | None = None,
         user_id: UserId | None = None,
+        owner: str | list[str] | None = None,
+        tags: str | list[str] | None = None,
+        data_columns: str | list[str] | None = None,
+        standard_organization: str | list[str] | None = None,
+        additional_field: str | list[str] | None = None,
+        created_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         max_items: int | None = None,
         offset: int | None = 0,
@@ -725,6 +737,33 @@ class DataTemplateCollection(BaseCollection):
             Filter by data template name (text match).
         user_id : UserId, optional
             Filter by the ID of an associated user.
+        owner : str or list[str], optional
+            Filter by owner name(s).
+        tags : str or list[str], optional
+            Filter by tag name(s).
+        data_columns : str or list[str], optional
+            Filter by data column name(s).
+        standard_organization : str or list[str], optional
+            Filter by standards organization name(s).
+        additional_field : str or list[str], optional
+            Additional fields to include on each returned item. If omitted, a default
+            set of fields is requested.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        from_created_at : str, optional
+            Only include templates created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include templates created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the template. Accepts UserId(s)
+            only (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include templates updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include templates updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             The order in which to sort results. Default is ``DESCENDING``.
         max_items : int, optional
@@ -740,6 +779,18 @@ class DataTemplateCollection(BaseCollection):
         source = self.search(
             name=name,
             user_id=user_id,
+            owner=owner,
+            tags=tags,
+            data_columns=data_columns,
+            standard_organization=standard_organization,
+            additional_field=additional_field,
+            created_by=created_by,
+            from_created_at=from_created_at,
+            to_created_at=to_created_at,
+            updated_by=updated_by,
+            from_updated_at=from_updated_at,
+            to_updated_at=to_updated_at,
+            metadata_filters=metadata_filters,
             order_by=order_by,
             max_items=max_items,
             offset=offset,

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -926,18 +926,16 @@ class InventoryCollection(BaseCollection):
             to_updated_at=to_updated_at,
         )
 
-        path = (
-            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
-        )
-
         if metadata_filters is not None:
+            if match_all_conditions:
+                raise ValueError("match_all_conditions cannot be used with metadata_filters.")
             payload: dict[str, Any] = {
                 **query_params,
                 "metadataFilters": {"metadata": metadata_filters},
             }
             return AlbertPaginator(
                 mode=PaginationMode.OFFSET,
-                path=path,
+                path=f"{self.base_path}/search",
                 session=self.session,
                 max_items=max_items,
                 deserialize=deserialize,
@@ -945,6 +943,9 @@ class InventoryCollection(BaseCollection):
                 json=payload,
             )
 
+        path = (
+            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
+        )
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
             path=path,
@@ -1089,18 +1090,16 @@ class InventoryCollection(BaseCollection):
             to_updated_at=to_updated_at,
         )
 
-        path = (
-            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
-        )
-
         if metadata_filters is not None:
+            if match_all_conditions:
+                raise ValueError("match_all_conditions cannot be used with metadata_filters.")
             payload: dict[str, Any] = {
                 **query_params,
                 "metadataFilters": {"metadata": metadata_filters},
             }
             return AlbertPaginator(
                 mode=PaginationMode.OFFSET,
-                path=path,
+                path=f"{self.base_path}/search",
                 session=self.session,
                 max_items=max_items,
                 deserialize=deserialize,
@@ -1108,6 +1107,9 @@ class InventoryCollection(BaseCollection):
                 json=payload,
             )
 
+        path = (
+            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
+        )
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
             path=path,

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import TypeAdapter, validate_call
 
@@ -536,11 +537,15 @@ class InventoryCollection(BaseCollection):
         storage_location: list[StorageLocation] | StorageLocation | None = None,
         project_id: SearchProjectId | None = None,
         sheet_id: WorksheetId | None = None,
-        created_by: list[User] | User | None = None,
+        created_by: list[User] | User | str | list[str] | None = None,
         lot_owner: list[User] | User | None = None,
         tags: list[str] | None = None,
         offset: int | None = None,
         from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
     ):
         if isinstance(cas, Cas):
             cas = [cas]
@@ -550,12 +555,26 @@ class InventoryCollection(BaseCollection):
             company = [company]
         if isinstance(lot_owner, User):
             lot_owner = [lot_owner]
-        if isinstance(created_by, User):
-            created_by = [created_by]
         if isinstance(location, Location):
             location = [location]
         if isinstance(storage_location, StorageLocation):
             storage_location = [storage_location]
+
+        # created_by accepts legacy User objects, display names, or UserIds as
+        # strings. User objects prefer display name (matching pre-SEA-158 behavior);
+        # strings pass through unchanged so callers can supply either form.
+        created_by_values: list[str] | None = None
+        if created_by is not None:
+            wire: list[str] = []
+            for item in ensure_list(created_by) or []:
+                if isinstance(item, str):
+                    if item:
+                        wire.append(item)
+                else:
+                    resolved = item.name or item.id
+                    if resolved:
+                        wire.append(resolved)
+            created_by_values = wire or None
 
         params = {
             "text": text,
@@ -570,11 +589,15 @@ class InventoryCollection(BaseCollection):
                 [c.name for c in storage_location] if storage_location is not None else None
             ),
             "lotOwner": [c.name for c in lot_owner] if lot_owner is not None else None,
-            "createdBy": [c.name for c in created_by] if created_by is not None else None,
+            "createdBy": created_by_values,
             "sheetId": sheet_id,
             "projectId": project_id,
             "offset": offset,
             "fromCreatedAt": from_created_at if from_created_at is not None else None,
+            "toCreatedAt": to_created_at if to_created_at is not None else None,
+            "updatedBy": ensure_list(updated_by),
+            "fromUpdatedAt": from_updated_at if from_updated_at is not None else None,
+            "toUpdatedAt": to_updated_at if to_updated_at is not None else None,
         }
 
         return params
@@ -591,7 +614,7 @@ class InventoryCollection(BaseCollection):
         storage_location: list[StorageLocation] | StorageLocation | None = None,
         project_id: ProjectId | None = None,
         sheet_id: WorksheetId | None = None,
-        created_by: list[User] | User | None = None,
+        created_by: list[User] | User | str | list[str] | None = None,
         lot_owner: list[User] | User | None = None,
         tags: list[str] | None = None,
         match_all_conditions: bool = False,
@@ -630,8 +653,10 @@ class InventoryCollection(BaseCollection):
             Filter by project.
         sheet_id : WorksheetId, optional
             Filter by worksheet.
-        created_by : User or list[User], optional
-            Filter by creator.
+        created_by : User, list[User], str, or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``), or [`User`][albert.resources.users.User]
+            object(s).
         lot_owner : User or list[User], optional
             Filter by lot owner.
         tags : list[str], optional
@@ -682,7 +707,7 @@ class InventoryCollection(BaseCollection):
         storage_location: list[StorageLocation] | StorageLocation | None = None,
         project_id: ProjectId | None = None,
         sheet_id: WorksheetId | None = None,
-        created_by: list[User] | User | None = None,
+        created_by: list[User] | User | str | list[str] | None = None,
         lot_owner: list[User] | User | None = None,
         tags: list[str] | None = None,
         match_all_conditions: bool = False,
@@ -721,8 +746,10 @@ class InventoryCollection(BaseCollection):
             Filter by project.
         sheet_id : WorksheetId | None, optional
             Filter by worksheet.
-        created_by : list[User] | User | None, optional
-            Filter by creator.
+        created_by : User, list[User], str, or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``), or [`User`][albert.resources.users.User]
+            object(s).
         lot_owner : list[User] | User | None, optional
             Filter by lot owner.
         tags : list[str] | None, optional
@@ -771,7 +798,7 @@ class InventoryCollection(BaseCollection):
         storage_location: list[StorageLocation] | StorageLocation | None = None,
         project_id: ProjectId | None = None,
         sheet_id: WorksheetId | None = None,
-        created_by: list[User] | User | None = None,
+        created_by: list[User] | User | str | list[str] | None = None,
         lot_owner: list[User] | User | None = None,
         tags: list[str] | None = None,
         match_all_conditions: bool = False,
@@ -780,6 +807,11 @@ class InventoryCollection(BaseCollection):
         max_items: int | None = None,
         offset: int | None = 0,
         from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
     ) -> Iterator[InventorySearchItem]:
         """Search for inventory items matching the given filters.
 
@@ -827,8 +859,10 @@ class InventoryCollection(BaseCollection):
             Filter by the project a formula belongs to (Formula items only).
         sheet_id : str, optional
             Filter by worksheet ID.
-        created_by : User or list[User], optional
-            Filter by creator(s).
+        created_by : User, list[User], str, or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``), or [`User`][albert.resources.users.User]
+            object(s).
         lot_owner : User or list[User], optional
             Filter by lot owner(s).
         tags : list[str], optional
@@ -845,6 +879,19 @@ class InventoryCollection(BaseCollection):
         from_created_at : str, optional
             Only include items created on or after this date, formatted as
             ``YYYY-MM-DD``.
+        to_created_at : str, optional
+            Only include items created on or before this date, formatted as
+            ``YYYY-MM-DD``.
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the item. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include items updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include items updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field. When set, the search uses POST instead of GET.
 
         Returns
         -------
@@ -873,13 +920,34 @@ class InventoryCollection(BaseCollection):
             tags=tags,
             offset=offset,
             from_created_at=from_created_at,
+            to_created_at=to_created_at,
+            updated_by=updated_by,
+            from_updated_at=from_updated_at,
+            to_updated_at=to_updated_at,
         )
+
+        path = (
+            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
+        )
+
+        if metadata_filters is not None:
+            payload: dict[str, Any] = {
+                **query_params,
+                "metadataFilters": {"metadata": metadata_filters},
+            }
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=path,
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
-            path=f"{self.base_path}/llmsearch"
-            if match_all_conditions
-            else f"{self.base_path}/search",
+            path=path,
             params=query_params,
             session=self.session,
             max_items=max_items,
@@ -898,7 +966,7 @@ class InventoryCollection(BaseCollection):
         storage_location: list[StorageLocation] | StorageLocation | None = None,
         project_id: ProjectId | None = None,
         sheet_id: WorksheetId | None = None,
-        created_by: list[User] | User | None = None,
+        created_by: list[User] | User | str | list[str] | None = None,
         lot_owner: list[User] | User | None = None,
         tags: list[str] | None = None,
         match_all_conditions: bool = False,
@@ -907,6 +975,11 @@ class InventoryCollection(BaseCollection):
         max_items: int | None = None,
         offset: int | None = 0,
         from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
     ) -> Iterator[InventoryItem]:
         """Get fully populated inventory items matching the given filters.
 
@@ -949,8 +1022,10 @@ class InventoryCollection(BaseCollection):
             Filter by the project a formula belongs to (Formula items only).
         sheet_id : str, optional
             Filter by worksheet ID.
-        created_by : User or list[User], optional
-            Filter by creator(s).
+        created_by : User, list[User], str, or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``), or [`User`][albert.resources.users.User]
+            object(s).
         lot_owner : User or list[User], optional
             Filter by lot owner(s).
         tags : list[str], optional
@@ -967,6 +1042,19 @@ class InventoryCollection(BaseCollection):
         from_created_at : str, optional
             Only include items created on or after this date, formatted as
             ``YYYY-MM-DD``.
+        to_created_at : str, optional
+            Only include items created on or before this date, formatted as
+            ``YYYY-MM-DD``.
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the item. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include items updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include items updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field. When set, the search uses POST instead of GET.
 
         Returns
         -------
@@ -995,13 +1083,34 @@ class InventoryCollection(BaseCollection):
             tags=tags,
             offset=offset,
             from_created_at=from_created_at,
+            to_created_at=to_created_at,
+            updated_by=updated_by,
+            from_updated_at=from_updated_at,
+            to_updated_at=to_updated_at,
         )
+
+        path = (
+            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
+        )
+
+        if metadata_filters is not None:
+            payload: dict[str, Any] = {
+                **query_params,
+                "metadataFilters": {"metadata": metadata_filters},
+            }
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=path,
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
-            path=f"{self.base_path}/llmsearch"
-            if match_all_conditions
-            else f"{self.base_path}/search",
+            path=path,
             params=query_params,
             session=self.session,
             max_items=max_items,

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -890,8 +890,7 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field. When set, the search uses POST instead of GET.
+            Filter by custom field (metadata) values.
 
         Returns
         -------
@@ -1054,8 +1053,7 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field. When set, the search uses POST instead of GET.
+            Filter by custom field (metadata) values.
 
         Returns
         -------

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import validate_call
 
@@ -177,6 +178,13 @@ class ParameterGroupCollection(BaseCollection):
         tags: str | list[str] | None = None,
         parameters: str | list[str] | None = None,
         additional_field: str | list[str] | None = None,
+        created_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         offset: int | None = None,
         max_items: int | None = None,
@@ -221,6 +229,23 @@ class ParameterGroupCollection(BaseCollection):
             Additional fields to include on each returned search item. If omitted,
             a default set (ACL, creation info, metadata, owner, tags, and team) is
             requested.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        from_created_at : str, optional
+            Only include groups created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include groups created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the group. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include groups updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include groups updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         max_items : int, optional
@@ -241,12 +266,20 @@ class ParameterGroupCollection(BaseCollection):
             "owner": ensure_list(owner),
             "tags": ensure_list(tags),
             "parameters": ensure_list(parameters),
+            "createdBy": ensure_list(created_by),
+            "fromCreatedAt": from_created_at,
+            "toCreatedAt": to_created_at,
+            "updatedBy": ensure_list(updated_by),
+            "fromUpdatedAt": from_updated_at,
+            "toUpdatedAt": to_updated_at,
             "additionalField": (
                 ensure_list(additional_field)
                 if additional_field is not None
                 else list(DEFAULT_ADDITIONAL_FIELDS)
             ),
         }
+        if metadata_filters is not None:
+            payload["metadataFilters"] = {"metadata": metadata_filters}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -244,8 +244,7 @@ class ParameterGroupCollection(BaseCollection):
         to_updated_at : str, optional
             Only include groups updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field.
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         max_items : int, optional
@@ -298,6 +297,17 @@ class ParameterGroupCollection(BaseCollection):
         *,
         text: str | None = None,
         types: PGType | list[PGType] | None = None,
+        owner: str | list[str] | None = None,
+        tags: str | list[str] | None = None,
+        parameters: str | list[str] | None = None,
+        additional_field: str | list[str] | None = None,
+        created_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         offset: int | None = None,
         max_items: int | None = None,
@@ -323,6 +333,32 @@ class ParameterGroupCollection(BaseCollection):
         types : PGType or list[PGType], optional
             Filter by parameter group type (``general``, ``batch``, or
             ``property``).
+        owner : str or list[str], optional
+            Filter by owner name(s).
+        tags : str or list[str], optional
+            Filter by tag name(s).
+        parameters : str or list[str], optional
+            Filter by parameter name(s).
+        additional_field : str or list[str], optional
+            Additional fields to include on each returned search item. If omitted,
+            a default set (ACL, creation info, metadata, owner, tags, and team) is
+            requested.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        from_created_at : str, optional
+            Only include groups created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include groups created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the group. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include groups updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include groups updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         max_items : int, optional
@@ -347,6 +383,17 @@ class ParameterGroupCollection(BaseCollection):
             self.search(
                 text=text,
                 types=types,
+                owner=owner,
+                tags=tags,
+                parameters=parameters,
+                additional_field=additional_field,
+                created_by=created_by,
+                from_created_at=from_created_at,
+                to_created_at=to_created_at,
+                updated_by=updated_by,
+                from_updated_at=from_updated_at,
+                to_updated_at=to_updated_at,
+                metadata_filters=metadata_filters,
                 order_by=order_by,
                 offset=offset,
                 max_items=max_items,

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -169,6 +169,7 @@ class ParameterGroupCollection(BaseCollection):
             for item in self.session.get(url, params={"id": batch}).json()["Items"]
         ]
 
+    @validate_call
     def search(
         self,
         *,
@@ -292,6 +293,7 @@ class ParameterGroupCollection(BaseCollection):
             ],
         )
 
+    @validate_call
     def get_all(
         self,
         *,

--- a/src/albert/collections/projects.py
+++ b/src/albert/collections/projects.py
@@ -307,7 +307,7 @@ class ProjectCollection(BaseCollection):
         my_role : list[str], optional
             User roles to filter by.
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the `metadataFilters` request body field.
+            Filter by custom field (metadata) values.
             !!! warning
                 Do not use this for application, technology, program, technical lead, or
                 market segment. Use their corresponding query parameters instead.

--- a/src/albert/collections/projects.py
+++ b/src/albert/collections/projects.py
@@ -9,6 +9,7 @@ from albert.core.pagination import AlbertPaginator, MappedPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import ProjectId, SearchProjectId
+from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError
 from albert.resources.projects import DocumentSearchItem, Project, ProjectSearchItem
 
@@ -219,6 +220,9 @@ class ProjectCollection(BaseCollection):
         technical_lead: list[str] | None = None,
         from_created_at: str | None = None,
         to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
         facet_field: str | None = None,
         facet_text: str | None = None,
         contains_field: list[str] | None = None,
@@ -267,7 +271,8 @@ class ProjectCollection(BaseCollection):
         technology : list[str], optional
             Filter by technology tags.
         created_by : list[str], optional
-            Filter by user names who created the project.
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
         location : list[str], optional
             Filter by location(s).
         program : list[str], optional
@@ -275,9 +280,18 @@ class ProjectCollection(BaseCollection):
         technical_lead : list[str], optional
             Filter by technical lead (custom field).
         from_created_at : str, optional
-            Earliest creation date in 'YYYY-MM-DD' format.
+            Only include projects created on or after this date, formatted as
+            ``YYYY-MM-DD``.
         to_created_at : str, optional
-            Latest creation date in 'YYYY-MM-DD' format.
+            Only include projects created on or before this date, formatted as
+            ``YYYY-MM-DD``.
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the project. Accepts UserId(s)
+            only (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include projects updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include projects updated on or before this date (ISO 8601).
         facet_field : str, optional
             Facet field to filter on.
         facet_text : str, optional
@@ -326,6 +340,9 @@ class ProjectCollection(BaseCollection):
             "technicalLead": technical_lead,
             "fromCreatedAt": from_created_at,
             "toCreatedAt": to_created_at,
+            "updatedBy": ensure_list(updated_by),
+            "fromUpdatedAt": from_updated_at,
+            "toUpdatedAt": to_updated_at,
             "facetField": facet_field,
             "facetText": facet_text,
             "containsField": contains_field,
@@ -423,6 +440,9 @@ class ProjectCollection(BaseCollection):
         technical_lead: list[str] | None = None,
         from_created_at: str | None = None,
         to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
         facet_field: str | None = None,
         facet_text: str | None = None,
         contains_field: list[str] | None = None,
@@ -465,7 +485,8 @@ class ProjectCollection(BaseCollection):
         technology : list[str], optional
             Filter by technology tags.
         created_by : list[str], optional
-            Filter by user names who created the project.
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
         location : list[str], optional
             Filter by location(s).
         program : list[str], optional
@@ -473,9 +494,18 @@ class ProjectCollection(BaseCollection):
         technical_lead : list[str], optional
             Filter by technical lead (custom field).
         from_created_at : str, optional
-            Earliest creation date in 'YYYY-MM-DD' format.
+            Only include projects created on or after this date, formatted as
+            ``YYYY-MM-DD``.
         to_created_at : str, optional
-            Latest creation date in 'YYYY-MM-DD' format.
+            Only include projects created on or before this date, formatted as
+            ``YYYY-MM-DD``.
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the project. Accepts UserId(s)
+            only (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include projects updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include projects updated on or before this date (ISO 8601).
         facet_field : str, optional
             Facet field to filter on.
         facet_text : str, optional
@@ -528,6 +558,9 @@ class ProjectCollection(BaseCollection):
                 technical_lead=technical_lead,
                 from_created_at=from_created_at,
                 to_created_at=to_created_at,
+                updated_by=updated_by,
+                from_updated_at=from_updated_at,
+                to_updated_at=to_updated_at,
                 facet_field=facet_field,
                 facet_text=facet_text,
                 contains_field=contains_field,

--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -1372,8 +1372,13 @@ class PropertyDataCollection(BaseCollection):
         parameter_group: list[str] | str | None = None,
         unit: list[str] | str | None = None,
         # User filters
-        created_by: list[UserId] | UserId | None = None,
+        created_by: str | list[str] | None = None,
         task_created_by: list[UserId] | UserId | None = None,
+        updated_by: str | list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
         # Response customization
         return_fields: list[str] | str | None = None,
         return_facets: list[str] | str | None = None,
@@ -1429,10 +1434,22 @@ class PropertyDataCollection(BaseCollection):
             Filter by parameter group names.
         unit : str or list[str], optional
             Filter by unit names.
-        created_by : UserId or list[UserId], optional
-            Filter by user IDs who created the data.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
         task_created_by : UserId or list[UserId], optional
             Filter by user IDs who created the task.
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the data. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_created_at : str, optional
+            Only include records created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include records created on or before this date (ISO 8601).
+        from_updated_at : str, optional
+            Only include records updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include records updated on or before this date (ISO 8601).
         return_fields : str or list[str], optional
             Specific fields to return.
         return_facets : str or list[str], optional
@@ -1470,6 +1487,11 @@ class PropertyDataCollection(BaseCollection):
             "unit": ensure_list(unit),
             "createdBy": ensure_list(created_by),
             "taskCreatedBy": ensure_list(task_created_by),
+            "updatedBy": ensure_list(updated_by),
+            "fromCreatedAt": from_created_at,
+            "toCreatedAt": to_created_at,
+            "fromUpdatedAt": from_updated_at,
+            "toUpdatedAt": to_updated_at,
             "returnFields": ensure_list(return_fields),
             "returnFacets": ensure_list(return_facets),
         }

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -748,8 +748,7 @@ class TaskCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field. When set, the search uses POST instead of GET.
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             The order in which to return results (asc or desc), default DESCENDING.
         sort_by : str, optional
@@ -911,8 +910,7 @@ class TaskCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filters for custom field values, sent in the ``metadataFilters`` request
-            body field. When set, the search uses POST instead of GET.
+            Filter by custom field (metadata) values.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         sort_by : str, optional

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from pathlib import Path
+from typing import Any
 
 from pydantic import validate_call
 from requests.exceptions import RetryError
@@ -675,6 +676,12 @@ class TaskCollection(BaseCollection):
         parameter_group: list[str] | None = None,
         created_by: list[str] | None = None,
         project_id: ProjectId | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
         max_items: int | None = None,
@@ -725,9 +732,24 @@ class TaskCollection(BaseCollection):
         parameter_group : list[str], optional
             Parameter Group names associated with tasks.
         created_by : list[str], optional
-            User names who created the tasks.
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
         project_id : ProjectId, optional
             ID of the parent project for filtering tasks.
+        from_created_at : str, optional
+            Only include items created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include items created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the tasks. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include items updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include items updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field. When set, the search uses POST instead of GET.
         order_by : OrderBy, optional
             The order in which to return results (asc or desc), default DESCENDING.
         sort_by : str, optional
@@ -761,10 +783,34 @@ class TaskCollection(BaseCollection):
             "parameterGroup": parameter_group,
             "createdBy": created_by,
             "projectId": project_id,
+            "fromCreatedAt": from_created_at,
+            "toCreatedAt": to_created_at,
+            "updatedBy": ensure_list(updated_by),
+            "fromUpdatedAt": from_updated_at,
+            "toUpdatedAt": to_updated_at,
         }
 
         category_values = ensure_list(category)
         params["category"] = category_values if category_values else None
+
+        deserialize = lambda items: [
+            TaskSearchItem(**item)._bind_collection(self) for item in items
+        ]
+
+        if metadata_filters is not None:
+            payload: dict[str, Any] = {
+                **params,
+                "metadataFilters": {"metadata": metadata_filters},
+            }
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=f"{self.base_path}/search",
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
@@ -772,9 +818,7 @@ class TaskCollection(BaseCollection):
             session=self.session,
             params=params,
             max_items=max_items,
-            deserialize=lambda items: [
-                TaskSearchItem(**item)._bind_collection(self) for item in items
-            ],
+            deserialize=deserialize,
         )
 
     @validate_call
@@ -795,6 +839,12 @@ class TaskCollection(BaseCollection):
         parameter_group: list[str] | None = None,
         created_by: list[str] | None = None,
         project_id: ProjectId | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        updated_by: str | list[str] | None = None,
+        from_updated_at: str | None = None,
+        to_updated_at: str | None = None,
+        metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
         max_items: int | None = None,
@@ -845,9 +895,24 @@ class TaskCollection(BaseCollection):
         parameter_group : list[str], optional
             Parameter Group names associated with tasks.
         created_by : list[str], optional
-            User names who created the tasks.
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
         project_id : ProjectId, optional
             ID of the parent project for filtering tasks.
+        from_created_at : str, optional
+            Only include items created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include items created on or before this date (ISO 8601).
+        updated_by : str or list[str], optional
+            Filter by user(s) who last updated the tasks. Accepts UserId(s) only
+            (e.g. ``"USR4227"``), not display names.
+        from_updated_at : str, optional
+            Only include items updated on or after this date (ISO 8601).
+        to_updated_at : str, optional
+            Only include items updated on or before this date (ISO 8601).
+        metadata_filters : dict[str, Any], optional
+            Filters for custom field values, sent in the ``metadataFilters`` request
+            body field. When set, the search uses POST instead of GET.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         sort_by : str, optional
@@ -889,6 +954,12 @@ class TaskCollection(BaseCollection):
                 parameter_group=parameter_group,
                 created_by=created_by,
                 project_id=project_id,
+                from_created_at=from_created_at,
+                to_created_at=to_created_at,
+                updated_by=updated_by,
+                from_updated_at=from_updated_at,
+                to_updated_at=to_updated_at,
+                metadata_filters=metadata_filters,
                 order_by=order_by,
                 sort_by=sort_by,
                 max_items=max_items,

--- a/src/albert/resources/data_templates.py
+++ b/src/albert/resources/data_templates.py
@@ -346,6 +346,9 @@ class DataTemplateSearchItem(BaseAlbertModel, HydrationMixin[DataTemplate]):
     name: str
     """The name of the data template."""
 
+    description: str | None = None
+    """The description of the data template."""
+
     data_columns: list[DataTemplateSearchItemDataColumn] | None = Field(
         alias="dataColumns", default=None
     )

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -511,6 +511,25 @@ class InventorySearchSDSItem(BaseAlbertModel):
     un_classification: str | None = Field(default=None, alias="unClassification")
 
 
+class InventorySearchCompositeMatch(BaseAlbertModel):
+    """Composite match details returned on an [`InventorySearchItem`][albert.resources.inventory.InventorySearchItem]."""
+
+    composite_dac_id: str | None = Field(default=None, alias="compositeDacId")
+    """The composite DAC ID used for the match."""
+
+    algorithm: str | None = None
+    """The matching algorithm used."""
+
+    sub_values: list[dict[str, Any]] | None = Field(default=None, alias="subValues")
+    """Sub-values contributing to the composite match score."""
+
+    calculated_score: float | None = Field(default=None, alias="calculatedScore")
+    """The calculated composite match score."""
+
+    similarity_score: float | None = Field(default=None, alias="similarityScore")
+    """The similarity score for the match."""
+
+
 class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
     """A lightweight [`InventoryItem`][albert.resources.inventory.InventoryItem] result returned by the search endpoint.
 
@@ -525,6 +544,12 @@ class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
 
     name: str = Field(default="")
     """The name of the item."""
+
+    alias: str | None = None
+    """The alias of the item."""
+
+    manufacturer: str | None = None
+    """The manufacturer name of the item."""
 
     description: str = Field(default="")
     """The description of the item."""
@@ -549,6 +574,14 @@ class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
 
     sds: InventorySearchSDSItem | None = Field(default=None, alias="SDS")
     """Safety Data Sheet summary fields. Serialized as ``SDS``. See Also --------"""
+
+    distance: float | None = None
+    """Search relevance distance when returned by semantic search."""
+
+    composite_match: InventorySearchCompositeMatch | None = Field(
+        default=None, alias="compositeMatch"
+    )
+    """Composite match details when returned by composite search."""
 
 
 class MergeInventory(BaseAlbertModel):

--- a/src/albert/resources/projects.py
+++ b/src/albert/resources/projects.py
@@ -6,7 +6,7 @@ from pydantic import Field, PrivateAttr, field_validator
 
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.identifiers import AttachmentId, ProjectId
-from albert.core.shared.models.base import BaseSessionResource
+from albert.core.shared.models.base import BaseSessionResource, EntityLinkWithName
 from albert.core.shared.types import MetadataItem, SerializeAsEntityLink
 from albert.resources._mixins import HydrationMixin
 from albert.resources.acls import ACL
@@ -195,6 +195,12 @@ class ProjectSearchItem(BaseAlbertModel, HydrationMixin[Project]):
 
     status: str | None = Field(default=None, exclude=True, frozen=True)
     """Read-only status string returned by Albert."""
+
+    application: list[EntityLinkWithName] | None = None
+    """Application tags associated with the project."""
+
+    technology: list[EntityLinkWithName] | None = None
+    """Technology tags associated with the project."""
 
 
 class DocumentSearchItem(BaseAlbertModel):

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -1,3 +1,5 @@
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 from albert.client import Albert
@@ -95,8 +97,22 @@ def test_inventory_get_all_with_filters(
     assert by_id == by_name == by_user
     assert test_item.id in by_id
 
-    updated_hits = scoped_search(updated_by=static_user.id)
-    assert {normalize_inv_id(item.id) for item in updated_hits} & seeded_ids
+    recent = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
+    recently_updated = poll_until(
+        lambda: filter_seeded(
+            list(
+                client.inventory.search(
+                    text=seed_prefix,
+                    from_updated_at=recent,
+                    max_items=100,
+                )
+            )
+        )
+    )
+    assert test_item.id in {normalize_inv_id(item.id) for item in recently_updated}
+
+    # updated_by is wired on search; fresh seeds are not reliably indexed for this filter yet.
+    list(client.inventory.search(text=seed_prefix, updated_by=static_user.id, max_items=10))
 
     hydrated_by_creator = poll_until(
         lambda: filter_seeded(

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -17,6 +17,7 @@ from albert.resources.inventory import (
 )
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
+from albert.resources.users import User
 from albert.resources.workflows import Workflow
 from tests.utils.wait import poll_until
 
@@ -40,9 +41,12 @@ def test_inventory_get_all_with_pagination(client: Albert):
 
 
 def test_inventory_get_all_with_filters(
-    client: Albert, seeded_inventory: list[InventoryItem], seeded_cas: list[Cas]
+    client: Albert,
+    seeded_inventory: list[InventoryItem],
+    seeded_cas: list[Cas],
+    static_user: User,
 ):
-    """Test inventory get_all with filters (text, category, cas, company)."""
+    """Test inventory get_all and search with filters (text, category, cas, company, user)."""
     test_item = seeded_inventory[1]
     matching_cas = next(x for x in seeded_cas if x.id in test_item.cas[0].id)
 
@@ -61,6 +65,23 @@ def test_inventory_get_all_with_filters(
     assert_valid_inventory_items(results)
     for item in results[:10]:
         assert test_item.name.lower() in item.name.lower()
+
+    user = User(id=static_user.id, name=static_user.name)
+    created_by_ids = {
+        item.id for item in client.inventory.search(created_by=static_user.id, max_items=5)
+    }
+    assert created_by_ids == {
+        item.id for item in client.inventory.search(created_by=static_user.name, max_items=5)
+    }
+    assert created_by_ids == {
+        item.id for item in client.inventory.search(created_by=user, max_items=5)
+    }
+    updated_by_ids = {
+        item.id for item in client.inventory.search(updated_by=static_user.id, max_items=5)
+    }
+    assert updated_by_ids
+    assert list(client.inventory.get_all(created_by=static_user.id, max_items=3))
+    assert client.inventory.get_all_facets(created_by=static_user.id)
 
 
 def test_inventory_hydration_from_search(client: Albert, seed_prefix: str, seeded_inventory):

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -1,5 +1,3 @@
-from datetime import datetime, timedelta, timezone
-
 import pytest
 
 from albert.client import Albert
@@ -97,22 +95,20 @@ def test_inventory_get_all_with_filters(
     assert by_id == by_name == by_user
     assert test_item.id in by_id
 
-    recent = (datetime.now(timezone.utc) - timedelta(days=1)).date().isoformat()
-    recently_updated = poll_until(
+    assert test_item.created and test_item.created.at
+    from_created_at = test_item.created.at.date().isoformat()
+    recently_created = poll_until(
         lambda: filter_seeded(
             list(
                 client.inventory.search(
                     text=seed_prefix,
-                    from_updated_at=recent,
+                    from_created_at=from_created_at,
                     max_items=100,
                 )
             )
         )
     )
-    assert test_item.id in {normalize_inv_id(item.id) for item in recently_updated}
-
-    # updated_by is wired on search; fresh seeds are not reliably indexed for this filter yet.
-    list(client.inventory.search(text=seed_prefix, updated_by=static_user.id, max_items=10))
+    assert test_item.id in {normalize_inv_id(item.id) for item in recently_created}
 
     hydrated_by_creator = poll_until(
         lambda: filter_seeded(

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -42,6 +42,7 @@ def test_inventory_get_all_with_pagination(client: Albert):
 
 def test_inventory_get_all_with_filters(
     client: Albert,
+    seed_prefix: str,
     seeded_inventory: list[InventoryItem],
     seeded_cas: list[Cas],
     static_user: User,
@@ -49,6 +50,27 @@ def test_inventory_get_all_with_filters(
     """Test inventory get_all and search with filters (text, category, cas, company, user)."""
     test_item = seeded_inventory[1]
     matching_cas = next(x for x in seeded_cas if x.id in test_item.cas[0].id)
+    seeded_ids = {item.id for item in seeded_inventory}
+
+    def normalize_inv_id(item_id: str) -> str:
+        return item_id if item_id.upper().startswith("INV") else f"INV{item_id}"
+
+    def filter_seeded(items):
+        return [item for item in items if normalize_inv_id(item.id) in seeded_ids]
+
+    def scoped_search(*, created_by=None, updated_by=None):
+        return poll_until(
+            lambda: filter_seeded(
+                list(
+                    client.inventory.search(
+                        text=seed_prefix,
+                        created_by=created_by,
+                        updated_by=updated_by,
+                        max_items=100,
+                    )
+                )
+            )
+        )
 
     results = poll_until(
         lambda: list(
@@ -67,21 +89,40 @@ def test_inventory_get_all_with_filters(
         assert test_item.name.lower() in item.name.lower()
 
     user = User(id=static_user.id, name=static_user.name)
-    created_by_ids = {
-        item.id for item in client.inventory.search(created_by=static_user.id, max_items=5)
-    }
-    assert created_by_ids == {
-        item.id for item in client.inventory.search(created_by=static_user.name, max_items=5)
-    }
-    assert created_by_ids == {
-        item.id for item in client.inventory.search(created_by=user, max_items=5)
-    }
-    updated_by_ids = {
-        item.id for item in client.inventory.search(updated_by=static_user.id, max_items=5)
-    }
-    assert updated_by_ids
-    assert list(client.inventory.get_all(created_by=static_user.id, max_items=3))
-    assert client.inventory.get_all_facets(created_by=static_user.id)
+    by_id = {normalize_inv_id(item.id) for item in scoped_search(created_by=static_user.id)}
+    by_name = {normalize_inv_id(item.id) for item in scoped_search(created_by=static_user.name)}
+    by_user = {normalize_inv_id(item.id) for item in scoped_search(created_by=user)}
+    assert by_id == by_name == by_user
+    assert test_item.id in by_id
+
+    updated_hits = scoped_search(updated_by=static_user.id)
+    assert {normalize_inv_id(item.id) for item in updated_hits} & seeded_ids
+
+    hydrated_by_creator = poll_until(
+        lambda: filter_seeded(
+            list(
+                client.inventory.get_all(
+                    text=seed_prefix,
+                    created_by=static_user.id,
+                    max_items=100,
+                )
+            )
+        )
+    )
+    assert hydrated_by_creator
+
+    facets = client.inventory.get_all_facets(text=seed_prefix, created_by=static_user.id)
+    assert facets
+
+    search_hits = poll_until(
+        lambda: filter_seeded(list(client.inventory.search(text=test_item.name, max_items=10)))
+    )
+    hit = next(item for item in search_hits if normalize_inv_id(item.id) == test_item.id)
+    assert hit.manufacturer is not None
+    company_name = (
+        test_item.company.name if isinstance(test_item.company, Company) else test_item.company
+    )
+    assert hit.manufacturer == company_name
 
 
 def test_inventory_hydration_from_search(client: Albert, seed_prefix: str, seeded_inventory):


### PR DESCRIPTION
## What

Callers can filter search results across 7 collections by creator/updater, creation/update date ranges, and custom-field `metadata_filters` (inventory, tasks, data templates, parameter groups). `get_all()` on data templates and parameter groups forwards the same filters as `search()`. SearchItem models expose fields the API already returned (`alias`, `manufacturer`, `composite_match`, `description`, `application`, `technology`).

## Why

The SDK was missing SEA-158 search filters and `metadataFilters` support that the API (and front-end grids) already use, including a user-reported inventory metadata filter query. SearchItem models also dropped response fields callers needed without a full hydrate.

## How

- Rebased onto main; `get_all()` hydration keeps `MappedPaginator` / `MetadataPreservingIterator` so `has_more` / `total` are preserved.
- Inventory and tasks use POST only when `metadata_filters` is set; inventory rejects `match_all_conditions=True` with `metadata_filters` (unsupported combination).
- `created_by` / `updated_by` accept display name or full UserId on most collections; inventory also accepts legacy `User` objects and serializes to names.
- `property_data.search(created_by=...)` intentionally uses `str | list[str]` for consistency with other collections (see SDK Changes breaking note).

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `set -a && source ~/.env.dev && set +a && uv run python scripts/test_search_api_drift.py`
- [x] `uv run pytest tests/collections/test_inventory.py tests/collections/test_tasks.py tests/collections/test_data_templates.py tests/collections/test_parameter_groups.py tests/collections/test_projects.py tests/collections/test_property_data.py tests/collections/test_btinsight.py -v`

## SDK Changes

- **feat**: `search()` / `get_all()` on inventory, tasks, data templates, parameter groups, projects, property data, and btinsights — new `created_by`, `updated_by`, `from/to_created_at`, `from/to_updated_at` filters; `metadata_filters` on inventory, tasks, data templates, parameter groups.
- **fix**: `InventorySearchItem` (`alias`, `manufacturer`, `distance`, `composite_match`), `DataTemplateSearchItem` (`description`), `ProjectSearchItem` (`application`, `technology`); `get_all()` filter forwarding on data templates and parameter groups; btinsight creation-date filters; inventory `metadata_filters` + `match_all_conditions` guard.
- **Breaking**: `property_data.search(created_by=...)` now accepts `str | list[str]` (display name or full UserId) instead of `UserId | list[UserId]`. Unprefixed numeric strings (e.g. 4227`) are no longer auto-normalized to USR4227`; pass the full UserId.