### PR TITLE
docs: clarify workflow registration and WFL1 default

### DIFF
--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -215,7 +215,8 @@ class TaskCollection(BaseCollection):
             (format ``DAT...``).
         workflow_id : WorkflowId
             The Workflow supplying the block's parameter conditions
-            (format ``WFL...``).
+            (format ``WFL...``). When no parameter groups apply, use ``WFL1``, the
+            platform default ("No Parameter Group").
 
         Returns
         -------
@@ -264,7 +265,8 @@ class TaskCollection(BaseCollection):
         block_id : BlockId
             The block to update (format ``BLK...``).
         workflow_id : WorkflowId
-            The new Workflow to assign to the block (format ``WFL...``).
+            The new Workflow to assign to the block (format ``WFL...``). When no
+            parameter groups apply, use ``WFL1``, the platform default ("No Parameter Group").
 
         Returns
         -------

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -41,6 +41,11 @@ class WorkflowCollection(BaseCollection):
     workflow ID, build the Workflow object you want and let [`create`][albert.collections.workflows.WorkflowCollection.create] return
     the existing match or make a new one.
 
+    Every tenant also includes a built-in workflow ``WFL1`` ("No Parameter Group") with no
+    parameter groups. Use it for tasks and blocks that do not involve parameter groups; it
+    does not need to be created via
+    [`create`][albert.collections.workflows.WorkflowCollection.create].
+
     **Intervals.** When one or two parameters are "intervalized" (varied across
     several values), the workflow acts as a *parent* that carries the resulting
     *interval combinations*. Each combination has an interval ID of the form

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -279,7 +279,11 @@ class Block(BaseAlbertModel):
     """The block's ID (``"BLK..."``). Assigned by Albert; ``None`` before the block is created."""
 
     workflow: list[SerializeAsEntityLink[Workflow]] = Field(alias="Workflow", min_length=1)
-    """The workflow(s) defining the parameter conditions for the block. At least one is required."""
+    """The workflow(s) defining the parameter conditions for the block. At least one is required.
+
+    Each workflow link must reference an existing workflow registered via
+    [`create`][albert.collections.workflows.WorkflowCollection.create] (it must have an ID).
+    """
 
     data_template: (
         list[BlockDataTemplateInfo]
@@ -511,7 +515,11 @@ class BatchTask(BaseTask):
     """Quality-control data associated with the batch task. Notes ----- All other fields (``location``, ``priority``, ``due_date``, ``state``, ``assigned_to``, dates, and so on) are inherited from [`BaseTask`][albert.resources.tasks.BaseTask]."""
 
     workflows: list[SerializeAsEntityLink[Workflow]] | None = Field(alias="Workflow", default=None)
-    """Workflow(s) associated with the batch task."""
+    """Workflow(s) associated with the batch task.
+
+    Workflows must be registered via [`create`][albert.collections.workflows.WorkflowCollection.create]
+    before use; only workflows with a returned ID may be linked.
+    """
 
     blocks: list[Block] | None = Field(alias="Blocks", default=None)
     """Blocks associated with the batch task, when it captures data."""

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -279,10 +279,11 @@ class Block(BaseAlbertModel):
     """The block's ID (``"BLK..."``). Assigned by Albert; ``None`` before the block is created."""
 
     workflow: list[SerializeAsEntityLink[Workflow]] = Field(alias="Workflow", min_length=1)
-    """The workflow(s) defining the parameter conditions for the block. At least one is required.
+    """The workflow(s) defining the parameter conditions for the block.
 
-    Each workflow link must reference an existing workflow registered via
-    [`create`][albert.collections.workflows.WorkflowCollection.create] (it must have an ID).
+    At least one is required. Each workflow link must reference an existing workflow
+    registered via [`create`][albert.collections.workflows.WorkflowCollection.create]
+    (it must have an ID).
     """
 
     data_template: (

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -281,9 +281,12 @@ class Block(BaseAlbertModel):
     workflow: list[SerializeAsEntityLink[Workflow]] = Field(alias="Workflow", min_length=1)
     """The workflow(s) defining the parameter conditions for the block.
 
-    At least one is required. Each workflow link must reference an existing workflow
-    registered via [`create`][albert.collections.workflows.WorkflowCollection.create]
-    (it must have an ID).
+    At least one is required. When no parameter groups apply, use ``WFL1``, the
+    platform default workflow with no parameter groups ("No Parameter Group").
+    It is pre-provisioned and does not need to be created via
+    [`create`][albert.collections.workflows.WorkflowCollection.create].
+    For custom setpoints, register a workflow via
+    [`create`][albert.collections.workflows.WorkflowCollection.create] and link by ID.
     """
 
     data_template: (
@@ -518,8 +521,13 @@ class BatchTask(BaseTask):
     workflows: list[SerializeAsEntityLink[Workflow]] | None = Field(alias="Workflow", default=None)
     """Workflow(s) associated with the batch task.
 
-    Workflows must be registered via [`create`][albert.collections.workflows.WorkflowCollection.create]
-    before use; only workflows with a returned ID may be linked.
+    When the task does not involve parameter groups, use ``WFL1``, the platform
+    default workflow with no parameter groups ("No Parameter Group"). It is
+    pre-provisioned and does not need to be created via
+    [`create`][albert.collections.workflows.WorkflowCollection.create].
+    For workflows with parameter setpoints, register via
+    [`create`][albert.collections.workflows.WorkflowCollection.create] and link by
+    the returned ID.
     """
 
     blocks: list[Block] | None = Field(alias="Blocks", default=None)

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -315,6 +315,11 @@ class Workflow(BaseResource):
     [`create`][albert.collections.workflows.WorkflowCollection.create], which returns the
     existing match or makes a new one. IDs look like ``WFL...``.
 
+    Every tenant includes a built-in workflow ``WFL1`` ("No Parameter Group") with no
+    parameter groups or setpoints. Use it when a task or block does not involve parameter
+    groups; it does not need to be created via
+    [`create`][albert.collections.workflows.WorkflowCollection.create].
+
     When one or two parameters are intervalized, the workflow acts as a *parent* that carries
     the resulting [`IntervalCombination`][albert.resources.workflows.IntervalCombination] entries. Each combination has an interval ID of
     the form ``ROW1`` (one intervalized parameter) or ``ROW1XROW2`` (product of two). Use


### PR DESCRIPTION
## What

Add come color to Task Docstrings around Workflows

## Why

Ask Albert was not first registering WFLs before using them
## How


## Testing

- [ ] `uv run ruff format .`
- [ ] `uv run ruff check . --fix`
- [ ] `uv run pytest <relevant_test_file>.py -v`

## SDK Changes


