### PR TITLE
fix(sheets): allow first PRG on empty Process Design

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -1331,7 +1331,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
         ------
         AlbertException
             If ``design`` is ``DesignType.RESULTS`` or ``DesignType.PROCESS``.
-            Process Design only accepts parameter-group (PRG) rows — use
+            Process Design only accepts parameter-group (PRG) rows: use
             [`add_parameter_group_row`][albert.resources.sheets.Sheet.add_parameter_group_row].
         """
         if design == DesignType.RESULTS:
@@ -1580,7 +1580,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
         reference_id : str, optional
             The row ID to insert relative to. Defaults to the first Process Design
             row when one exists. Omit (or leave ``None``) when Process Design is
-            empty — the first PRG does not need a reference row.
+            empty (the first PRG does not need a reference row).
         position : RowPosition, optional
             Whether to insert ``ABOVE`` or ``BELOW`` the reference row.
             Default is ``ABOVE``. Ignored when Process Design has no rows and

--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -1330,10 +1330,17 @@ class Sheet(BaseSessionResource):  # noqa:F811
         Raises
         ------
         AlbertException
-            If ``design`` is ``DesignType.RESULTS``.
+            If ``design`` is ``DesignType.RESULTS`` or ``DesignType.PROCESS``.
+            Process Design only accepts parameter-group (PRG) rows — use
+            [`add_parameter_group_row`][albert.resources.sheets.Sheet.add_parameter_group_row].
         """
         if design == DesignType.RESULTS:
             raise AlbertException("You cannot add rows to the results design")
+        if design == DesignType.PROCESS or design == DesignType.PROCESS.value:
+            raise AlbertException(
+                "Blank rows cannot be added to Process Design; "
+                "use add_parameter_group_row to attach a parameter group"
+            )
         if position is None:
             position = {"reference_id": "ROW1", "position": "above"}
         endpoint = f"/api/v3/worksheet/design/{self._get_design_id(design=design)}/rows"
@@ -1572,10 +1579,12 @@ class Sheet(BaseSessionResource):  # noqa:F811
             The Parameter Group ID to add (format ``PRG...``).
         reference_id : str, optional
             The row ID to insert relative to. Defaults to the first Process Design
-            row (safer than assuming ``"ROW1"`` exists).
+            row when one exists. Omit (or leave ``None``) when Process Design is
+            empty — the first PRG does not need a reference row.
         position : RowPosition, optional
             Whether to insert ``ABOVE`` or ``BELOW`` the reference row.
-            Default is ``ABOVE``.
+            Default is ``ABOVE``. Ignored when Process Design has no rows and
+            ``reference_id`` is omitted.
 
         Returns
         -------
@@ -1585,30 +1594,27 @@ class Sheet(BaseSessionResource):  # noqa:F811
         Raises
         ------
         AlbertException
-            If the sheet has no Process Design section, Process Design has no rows
-            to reference, or the response has no rows.
+            If the sheet has no Process Design section, or the response has no rows.
         """
         design_obj = self.process_design
         if design_obj is None:
             raise AlbertException(
                 "Sheet has no Process Design section; cannot add a parameter group row"
             )
+        payload_item: dict[str, str] = {
+            "type": CellType.PRG.value,
+            "id": parameter_group_id,
+        }
         if reference_id is None:
             existing_rows = design_obj.rows
-            if not existing_rows:
-                raise AlbertException(
-                    "Process Design has no rows; pass reference_id to insert a parameter group row"
-                )
-            reference_id = existing_rows[0].row_id
+            if existing_rows:
+                reference_id = existing_rows[0].row_id
+        if reference_id is not None:
+            # Empty Process Design accepts a PRG with no referenceId/position.
+            payload_item["referenceId"] = reference_id
+            payload_item["position"] = position.value
 
-        payload = [
-            {
-                "type": CellType.PRG.value,
-                "id": parameter_group_id,
-                "referenceId": reference_id,
-                "position": position.value,
-            }
-        ]
+        payload = [payload_item]
         response = self.session.post(f"/api/v3/designs/{design_obj.id}/rows", json=payload)
         self.grid = None
         rows = response.json()

--- a/tests/resources/test_sheets.py
+++ b/tests/resources/test_sheets.py
@@ -375,6 +375,75 @@ def test_add_parameter_group_row_empty_response_raises():
         sheet.add_parameter_group_row(parameter_group_id="PRG1", reference_id="ROW1")
 
 
+def test_add_parameter_group_row_empty_process_design_omits_reference():
+    """First PRG on an empty Process Design must not send referenceId/position."""
+    session = FakeAlbertSession()
+    session.configure_response(
+        "POST",
+        "/api/v3/designs/DES4/rows",
+        json.dumps(
+            [{"rowId": "ROW5", "id": "PRG1", "type": "PRG", "name": "Mix", "labelName": "Mix"}]
+        ).encode(),
+    )
+    # Empty grid → process_design.rows is empty.
+    session.configure_response(
+        "GET",
+        "/api/v3/designs/DES4/grid",
+        json.dumps(
+            {
+                "total": 0,
+                "designId": "DES4",
+                "Items": [],
+                "Formulas": [],
+                "RowSequence": [],
+            }
+        ).encode(),
+    )
+    sheet = Sheet(
+        albertId="SHEET1",
+        name="Test",
+        Formulas=[],
+        hidden=False,
+        Designs=[
+            {"albertId": "DES1", "designType": "products", "state": {}},
+            {"albertId": "DES2", "designType": "results", "state": {}},
+            {"albertId": "DES3", "designType": "apps", "state": {}},
+            {"albertId": "DES4", "designType": "process", "state": {}},
+        ],
+        projectId="PRJ1",
+        session=session,
+    )
+    # FakeAlbertSession is not always copied onto nested Designs by validators.
+    for design in sheet.designs:
+        design._session = session
+
+    row = sheet.add_parameter_group_row(parameter_group_id="PRG1")
+
+    assert row.row_id == "ROW5"
+    assert row.type == CellType.PRG
+    posted = [r for r in session.requests if r["method"] == "POST" and r["url"].endswith("/rows")]
+    assert len(posted) == 1
+    assert posted[0]["json"] == [{"type": "PRG", "id": "PRG1"}]
+
+
+def test_add_blank_row_rejects_process_design():
+    sheet = Sheet(
+        albertId="SHEET1",
+        name="Test",
+        Formulas=[],
+        hidden=False,
+        Designs=[
+            {"albertId": "DES1", "designType": "products", "state": {}},
+            {"albertId": "DES2", "designType": "results", "state": {}},
+            {"albertId": "DES3", "designType": "apps", "state": {}},
+            {"albertId": "DES4", "designType": "process", "state": {}},
+        ],
+        projectId="PRJ1",
+    )
+    with pytest.raises(AlbertException, match="add_parameter_group_row"):
+        sheet.add_blank_row(row_name="Blank", design=DesignType.PROCESS)
+
+
 def test_add_parameter_group_row(
     seeded_sheet: Sheet,
     seeded_parameter_groups: list,


### PR DESCRIPTION
## Summary
- `Sheet.add_parameter_group_row` no longer requires an existing process row / `reference_id` when Process Design is empty — posts `[{type, id}]` (verified against the design-engine API).
- `Sheet.add_blank_row(design=PROCESS)` now fails fast: BLK rows are not allowed on Process Design.

## Why
Ask Albert tried to seed a blank row before adding a parameter group; the API rejects BLK on process designs (`Input row Type not allowed for the given Design`). Empty Process Designs accept a first PRG with no `referenceId`.

## Test plan
- [x] Unit: empty process design omits `referenceId`
- [x] Unit: blank row rejects process design
- [x] Live smoke on empty Process Design (`PROMO129344` / `WKS103150`)


Made with [Cursor](https://cursor.com)