### PR TITLE
fix(cas): batch PATCH updates to respect 9-item API limit

### DIFF
--- a/src/albert/collections/cas.py
+++ b/src/albert/collections/cas.py
@@ -11,6 +11,7 @@ from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import CasId
 from albert.core.shared.models.base import EntityLink
+from albert.core.shared.models.patch import PatchDatum, PatchPayload
 from albert.resources.cas import Cas
 
 
@@ -99,6 +100,7 @@ class CasCollection(BaseCollection):
 
     _updatable_attributes = {"notes", "description", "smiles", "metadata"}
     _api_version = "v3"
+    _max_patch_items = 9
 
     def __init__(self, *, session: AlbertSession):
         """Initialize a CasCollection.
@@ -454,6 +456,15 @@ class CasCollection(BaseCollection):
         url = f"{self.base_path}/{id}"
         self.session.delete(url)
 
+    def _batch_patch(self, *, url: str, data: list[PatchDatum]) -> None:
+        """Send patch data in batches of at most ``_max_patch_items`` per request."""
+        for start in range(0, len(data), self._max_patch_items):
+            batch = data[start : start + self._max_patch_items]
+            self.session.patch(
+                url,
+                json=PatchPayload(data=batch).model_dump(mode="json", by_alias=True),
+            )
+
     def update(self, *, updated_object: Cas) -> Cas:
         """Update an existing CAS entry.
 
@@ -490,8 +501,5 @@ class CasCollection(BaseCollection):
         patch_payload = self._generate_patch_payload(existing=existing_cas, updated=updated_object)
         if not patch_payload.data:
             return existing_cas
-        url = f"{self.base_path}/{updated_object.id}"
-        self.session.patch(url, json=patch_payload.model_dump(mode="json", by_alias=True))
-
-        updated_cas = self.get_by_id(id=updated_object.id)
-        return updated_cas
+        self._batch_patch(url=f"{self.base_path}/{updated_object.id}", data=patch_payload.data)
+        return self.get_by_id(id=updated_object.id)

--- a/tests/collections/test_cas.py
+++ b/tests/collections/test_cas.py
@@ -106,6 +106,46 @@ def test_update_cas_metadata(client: Albert, seed_prefix: str, seeded_cas: list[
             client.custom_fields.delete(id=custom_field.id)
 
 
+def test_update_cas_metadata_batching(client: Albert, seed_prefix: str, seeded_cas: list[Cas]):
+    """Test that updating more than 9 metadata fields in one update() call succeeds."""
+    if not seeded_cas:
+        pytest.skip("No seeded CAS available — stale prod data prevented fixture setup")
+    field_count = 10
+    prefix = seed_prefix.replace("-", "_")[:12].lower()
+    custom_fields: list[CustomField] = []
+    try:
+        for index in range(field_count):
+            field_name = f"test_cas_batch_{prefix}_{index}"
+            custom_fields.append(
+                client.custom_fields.create(
+                    custom_field=CustomField(
+                        name=field_name,
+                        display_name=f"TEST CAS Batch {prefix} {index}",
+                        field_type=FieldType.STRING,
+                        service=ServiceType.CAS,
+                    )
+                )
+            )
+
+        cas_to_update = seeded_cas[0]
+        new_metadata = {
+            **cas_to_update.metadata,
+            **{
+                field.name: f"{seed_prefix} - batch value {index}"
+                for index, field in enumerate(custom_fields)
+            },
+        }
+        cas_to_update.metadata = new_metadata
+        updated_cas = client.cas_numbers.update(updated_object=cas_to_update)
+
+        for index, field in enumerate(custom_fields):
+            assert updated_cas.metadata.get(field.name) == f"{seed_prefix} - batch value {index}"
+    finally:
+        for field in custom_fields:
+            with suppress(NotFoundError):
+                client.custom_fields.delete(id=field.id)
+
+
 def test_create_cas_with_list_metadata(
     client: Albert,
     seed_prefix: str,


### PR DESCRIPTION
## What

Callers can update more than 9 CAS metadata fields in a single `client.cas_numbers.update()` call without hitting the API's 9-item PATCH limit.

## Why

The CAS update API rejects PATCH payloads with more than 9 items. X reported failures when updating all CAS metadata fields at once (SUP-1932).

## How

`CasCollection.update()` splits large patch diffs into sequential batches of up to 9 items via a private `_batch_patch` helper. Each `Metadata.{key}` entry counts as one item, matching the API schema.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_cas.py::test_update_cas_metadata_batching -v -n 4` (requires Albert API credentials; not run in this environment)

## SDK Changes

`client.cas_numbers.update()` now automatically batches large PATCH payloads when more than 9 fields change.