### PR TITLE
chore(pre-commit): align ruff hooks with CI at v0.16.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,13 +10,13 @@ repos:
     -   id: trailing-whitespace
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.3
+  rev: v0.16.0
   hooks:
     - id: ruff-check
       types_or: [ python, pyi ]
       args: [ --fix ]
     - id: ruff-format
-      types_or: [ python, pyi ]
+      types_or: [ python, pyi, markdown ]
 
 - repo: https://github.com/compilerla/conventional-pre-commit
   rev: v4.2.0


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Pre-commit now uses Ruff 0.16.0 and formats Markdown code blocks, matching CircleCI's `uv run ruff format . --check` behavior.

## Why

The pre-commit hook was pinned to Ruff v0.12.3 while CI installs `ruff>=0.16.0,<0.17` from `pyproject.toml`. That mismatch caused local commits to pass pre-commit but fail CI formatting checks, especially for Python examples in Markdown docs.

## Testing

- [ ] `uv run ruff format .`
- [ ] `uv run ruff check . --fix`
- [x] `uv run pre-commit run ruff-format --all-files`
- [x] `uv run pre-commit run ruff-check --all-files`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-361e7a6e-d450-4667-812f-a7019783329c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-361e7a6e-d450-4667-812f-a7019783329c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

