### PR TITLE
fix(locations): exclude read-only fields from create payload

### DIFF
--- a/src/albert/collections/locations.py
+++ b/src/albert/collections/locations.py
@@ -254,7 +254,12 @@ class LocationCollection(BaseCollection):
         Location
             The newly created location, populated with its assigned ``id``.
         """
-        payload = location.model_dump(by_alias=True, exclude_unset=True, mode="json")
+        payload = location.model_dump(
+            by_alias=True,
+            exclude_none=True,
+            mode="json",
+            exclude={"id", "status", "created", "updated"},
+        )
         response = self.session.post(self.base_path, json=payload)
 
         return Location(**response.json())


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`LocationCollection.create` and `get_or_create` no longer send server-assigned fields when creating a location from a fully populated `Location` object.

## Why

When `get_or_create` missed an existing location and fell through to `create` with a `get_by_id` result, the POST body included read-only fields (`albertId`, `status`, `Created`), causing intermittent 400 errors in CI (`test_get_or_create_location`).

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_locations.py -v` (requires Albert API credentials; not run in this environment)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-629e5f29-c8aa-4cea-b831-31ab5d9d8736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-629e5f29-c8aa-4cea-b831-31ab5d9d8736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

