### PR TITLE
fix(pricings): support default field via update

### DIFF
--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -67,6 +67,7 @@ class PricingCollection(BaseCollection):
         "lead_time",
         "lead_time_unit",
         "inventory_id",
+        "default",
     }
 
     def __init__(self, *, session: AlbertSession):
@@ -288,9 +289,9 @@ class PricingCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``currency``, ``description``,
-        ``expiration_date``, ``fob``, ``inventory_id``, ``lead_time``,
-        ``lead_time_unit``, ``pack_size``, ``price``.
+        The following fields can be updated: ``currency``, ``default``,
+        ``description``, ``expiration_date``, ``fob``, ``inventory_id``,
+        ``lead_time``, ``lead_time_unit``, ``pack_size``, ``price``.
         """
         current_pricing = self.get_by_id(id=pricing.id)
         patch_payload = self._pricing_patch_payload(existing=current_pricing, updated=pricing)

--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -67,6 +67,7 @@ class PricingCollection(BaseCollection):
         "lead_time",
         "lead_time_unit",
         "inventory_id",
+        "default",
     }
 
     def __init__(self, *, session: AlbertSession):
@@ -104,7 +105,8 @@ class PricingCollection(BaseCollection):
         pricing : Pricing
             The pricing to create. ``inventory_id``, ``company``, ``location``, and
             ``price`` identify the item, source, site, and cost; see
-            [`Pricing`][albert.resources.pricings.Pricing].
+            [`Pricing`][albert.resources.pricings.Pricing]. ``default`` cannot be
+            set on create; use [`update`][albert.collections.pricings.PricingCollection.update].
 
         Returns
         -------
@@ -250,6 +252,20 @@ class PricingCollection(BaseCollection):
 
     def _pricing_patch_payload(self, *, existing: Pricing, updated: Pricing) -> PatchPayload:
         patch_payload = self._generate_patch_payload(existing=existing, updated=updated)
+        data = []
+        for datum in patch_payload.data:
+            if datum.attribute == "default":
+                data.append(
+                    PatchDatum(
+                        operation=datum.operation,
+                        attribute=datum.attribute,
+                        old_value=str(datum.old_value) if datum.old_value is not None else None,
+                        new_value=str(datum.new_value) if datum.new_value is not None else None,
+                    )
+                )
+            else:
+                data.append(datum)
+        patch_payload = PatchPayload(data=data)
         for attr in ("company", "location"):
             # These must be set, so we don't need to worry about add or delete
             existing_attr = getattr(existing, attr).id
@@ -293,9 +309,9 @@ class PricingCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``currency``, ``description``,
-        ``expiration_date``, ``fob``, ``inventory_id``, ``lead_time``,
-        ``lead_time_unit``, ``pack_size``, ``price``.
+        The following fields can be updated: ``currency``, ``default``,
+        ``description``, ``expiration_date``, ``fob``, ``inventory_id``,
+        ``lead_time``, ``lead_time_unit``, ``pack_size``, ``price``.
         """
         current_pricing = self.get_by_id(id=pricing.id)
         patch_payload = self._pricing_patch_payload(existing=current_pricing, updated=pricing)

--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -311,8 +311,8 @@ class PricingCollection(BaseCollection):
         ``description``, ``expiration_date``, ``fob``, ``inventory_id``,
         ``lead_time``, ``lead_time_unit``, ``pack_size``, ``price``.
 
-        ``default`` must be ``0`` (not default) or ``1`` (default). Set via
-        PATCH only (not on create).
+        ``default`` must be ``0`` (not default) or ``1`` (default). Can only be
+        set via update, not on create.
         """
         current_pricing = self.get_by_id(id=pricing.id)
         patch_payload = self._pricing_patch_payload(existing=current_pricing, updated=pricing)

--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -252,19 +252,17 @@ class PricingCollection(BaseCollection):
 
     def _pricing_patch_payload(self, *, existing: Pricing, updated: Pricing) -> PatchPayload:
         patch_payload = self._generate_patch_payload(existing=existing, updated=updated)
-        data = []
-        for datum in patch_payload.data:
-            if datum.attribute == "default":
-                data.append(
-                    PatchDatum(
-                        operation=datum.operation,
-                        attribute=datum.attribute,
-                        old_value=str(datum.old_value) if datum.old_value is not None else None,
-                        new_value=str(datum.new_value) if datum.new_value is not None else None,
-                    )
-                )
-            else:
-                data.append(datum)
+        data = [
+            PatchDatum(
+                operation=datum.operation,
+                attribute=datum.attribute,
+                old_value=Pricing.default_patch_value(datum.old_value),
+                new_value=Pricing.default_patch_value(datum.new_value),
+            )
+            if datum.attribute == "default"
+            else datum
+            for datum in patch_payload.data
+        ]
         patch_payload = PatchPayload(data=data)
         for attr in ("company", "location"):
             # These must be set, so we don't need to worry about add or delete
@@ -312,6 +310,9 @@ class PricingCollection(BaseCollection):
         The following fields can be updated: ``currency``, ``default``,
         ``description``, ``expiration_date``, ``fob``, ``inventory_id``,
         ``lead_time``, ``lead_time_unit``, ``pack_size``, ``price``.
+
+        ``default`` must be ``0`` (not default) or ``1`` (default). Set via
+        PATCH only (not on create).
         """
         current_pricing = self.get_by_id(id=pricing.id)
         patch_payload = self._pricing_patch_payload(existing=current_pricing, updated=pricing)

--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -67,7 +67,6 @@ class PricingCollection(BaseCollection):
         "lead_time",
         "lead_time_unit",
         "inventory_id",
-        "default",
     }
 
     def __init__(self, *, session: AlbertSession):
@@ -112,7 +111,12 @@ class PricingCollection(BaseCollection):
         Pricing
             The newly created pricing, populated with its assigned ID.
         """
-        payload = pricing.model_dump(by_alias=True, exclude_none=True, mode="json")
+        payload = pricing.model_dump(
+            by_alias=True,
+            exclude_none=True,
+            mode="json",
+            exclude={"default"},
+        )
         response = self.session.post(self.base_path, json=payload)
         return Pricing(**response.json())
 
@@ -289,9 +293,9 @@ class PricingCollection(BaseCollection):
 
         Notes
         -----
-        The following fields can be updated: ``currency``, ``default``,
-        ``description``, ``expiration_date``, ``fob``, ``inventory_id``,
-        ``lead_time``, ``lead_time_unit``, ``pack_size``, ``price``.
+        The following fields can be updated: ``currency``, ``description``,
+        ``expiration_date``, ``fob``, ``inventory_id``, ``lead_time``,
+        ``lead_time_unit``, ``pack_size``, ``price``.
         """
         current_pricing = self.get_by_id(id=pricing.id)
         patch_payload = self._pricing_patch_payload(existing=current_pricing, updated=pricing)

--- a/src/albert/collections/pricings.py
+++ b/src/albert/collections/pricings.py
@@ -256,8 +256,8 @@ class PricingCollection(BaseCollection):
             PatchDatum(
                 operation=datum.operation,
                 attribute=datum.attribute,
-                old_value=Pricing.default_patch_value(datum.old_value),
-                new_value=Pricing.default_patch_value(datum.new_value),
+                old_value=Pricing._default_patch_value(datum.old_value),
+                new_value=Pricing._default_patch_value(datum.new_value),
             )
             if datum.attribute == "default"
             else datum

--- a/src/albert/resources/pricings.py
+++ b/src/albert/resources/pricings.py
@@ -87,8 +87,8 @@ class Pricing(BaseResource):
     expiration_date: str | None = Field(default=None, alias="expirationDate")
     """The date the pricing expires, in ``YYYY-MM-DD`` format."""
 
-    default: int | None = Field(default=None)
-    """When ``1``, this pricing is the default for its inventory item."""
+    default: int | None = Field(default=None, frozen=True)
+    """When ``1``, this pricing is the default for its inventory item. Read-only."""
 
 
 class InventoryPricings(BaseAlbertModel):

--- a/src/albert/resources/pricings.py
+++ b/src/albert/resources/pricings.py
@@ -87,8 +87,8 @@ class Pricing(BaseResource):
     expiration_date: str | None = Field(default=None, alias="expirationDate")
     """The date the pricing expires, in ``YYYY-MM-DD`` format."""
 
-    default: int | None = Field(default=None, frozen=True)
-    """When ``1``, this pricing is the default for its inventory item. Read-only."""
+    default: int | None = Field(default=None)
+    """When ``1``, this pricing is the default for its inventory item."""
 
 
 class InventoryPricings(BaseAlbertModel):

--- a/src/albert/resources/pricings.py
+++ b/src/albert/resources/pricings.py
@@ -87,9 +87,8 @@ class Pricing(BaseResource):
     expiration_date: str | None = Field(default=None, alias="expirationDate")
     """The date the pricing expires, in ``YYYY-MM-DD`` format."""
 
-    # Read-only fields
-    default: int | None = Field(default=None, exclude=True, frozen=True)
-    """Whether the default price is being used rather than an overridden price (a flag)."""
+    default: int | None = Field(default=None)
+    """When ``1``, this pricing is the default for its inventory item."""
 
 
 class InventoryPricings(BaseAlbertModel):

--- a/src/albert/resources/pricings.py
+++ b/src/albert/resources/pricings.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Literal
 
 from pydantic import Field
 
@@ -87,8 +88,18 @@ class Pricing(BaseResource):
     expiration_date: str | None = Field(default=None, alias="expirationDate")
     """The date the pricing expires, in ``YYYY-MM-DD`` format."""
 
-    default: int | None = Field(default=None)
-    """When ``1``, this pricing is the default for its inventory item."""
+    default: Literal[0, 1] | None = Field(default=None)
+    """Whether this pricing is the default for its inventory item.
+
+    ``0``: not the default pricing. ``1``: the default pricing for the item
+    (only one pricing per item should be default). Cannot be set on create; use
+    [`update`][albert.collections.pricings.PricingCollection.update].
+    """
+
+    @staticmethod
+    def default_patch_value(value: Literal[0, 1] | None) -> str | None:
+        """Serialize ``default`` for PATCH (API expects string ``"0"``/``"1"``)."""
+        return None if value is None else str(value)
 
 
 class InventoryPricings(BaseAlbertModel):

--- a/src/albert/resources/pricings.py
+++ b/src/albert/resources/pricings.py
@@ -97,8 +97,7 @@ class Pricing(BaseResource):
     """
 
     @staticmethod
-    def default_patch_value(value: Literal[0, 1] | None) -> str | None:
-        """Serialize ``default`` for PATCH (API expects string ``"0"``/``"1"``)."""
+    def _default_patch_value(value: Literal[0, 1] | None) -> str | None:
         return None if value is None else str(value)
 
 

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -1,8 +1,10 @@
 import uuid
+from contextlib import suppress
 
 import pytest
 
 from albert import Albert
+from albert.exceptions import NotFoundError
 from albert.resources.inventory import InventoryItem
 from albert.resources.locations import Location
 from albert.resources.pricings import Pricing
@@ -37,6 +39,32 @@ def test_update(client: Albert, seeded_pricings: list[Pricing], seeded_locations
 
 
 def test_get_by_id_includes_default(client: Albert, seeded_pricings: list[Pricing]):
-    """Test get_by_id exposes the read-only default flag."""
+    """Test get_by_id exposes the default flag."""
     found = client.pricings.get_by_id(id=seeded_pricings[0].id)
     assert found.default is None or isinstance(found.default, int)
+
+
+def test_update_default(
+    client: Albert,
+    seed_prefix: str,
+    seeded_inventory: list[InventoryItem],
+    seeded_locations: list[Location],
+):
+    """Test update can set default=1 via PATCH."""
+    pricing = Pricing(
+        inventory_id=seeded_inventory[0].id,
+        company=seeded_inventory[0].company,
+        location=seeded_locations[0],
+        description=f"{seed_prefix} - default pricing update",
+        price=88.0,
+    )
+    created = client.pricings.create(pricing=pricing)
+    try:
+        created.default = 1
+        updated = client.pricings.update(pricing=created)
+        assert updated.default == 1
+        fetched = client.pricings.get_by_id(id=created.id)
+        assert fetched.default == 1
+    finally:
+        with suppress(NotFoundError):
+            client.pricings.delete(id=created.id)

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -1,10 +1,8 @@
 import uuid
-from contextlib import suppress
 
 import pytest
 
 from albert import Albert
-from albert.exceptions import NotFoundError
 from albert.resources.inventory import InventoryItem
 from albert.resources.locations import Location
 from albert.resources.pricings import Pricing
@@ -38,52 +36,7 @@ def test_update(client: Albert, seeded_pricings: list[Pricing], seeded_locations
     assert updated.location.id == seeded_locations[1].id
 
 
-def test_create_with_default(
-    client: Albert,
-    seed_prefix: str,
-    seeded_inventory: list[InventoryItem],
-    seeded_locations: list[Location],
-):
-    """Test create accepts default=1 and returns it on get_by_id."""
-    pricing = Pricing(
-        inventory_id=seeded_inventory[0].id,
-        company=seeded_inventory[0].company,
-        location=seeded_locations[0],
-        description=f"{seed_prefix} - default pricing create",
-        price=99.0,
-        default=1,
-    )
-    created = client.pricings.create(pricing=pricing)
-    try:
-        assert created.default == 1
-        fetched = client.pricings.get_by_id(id=created.id)
-        assert fetched.default == 1
-    finally:
-        with suppress(NotFoundError):
-            client.pricings.delete(id=created.id)
-
-
-def test_update_default(
-    client: Albert,
-    seed_prefix: str,
-    seeded_inventory: list[InventoryItem],
-    seeded_locations: list[Location],
-):
-    """Test update can set default=1 on an existing pricing."""
-    pricing = Pricing(
-        inventory_id=seeded_inventory[0].id,
-        company=seeded_inventory[0].company,
-        location=seeded_locations[0],
-        description=f"{seed_prefix} - default pricing update",
-        price=88.0,
-    )
-    created = client.pricings.create(pricing=pricing)
-    try:
-        created.default = 1
-        updated = client.pricings.update(pricing=created)
-        assert updated.default == 1
-        fetched = client.pricings.get_by_id(id=created.id)
-        assert fetched.default == 1
-    finally:
-        with suppress(NotFoundError):
-            client.pricings.delete(id=created.id)
+def test_get_by_id_includes_default(client: Albert, seeded_pricings: list[Pricing]):
+    """Test get_by_id exposes the read-only default flag."""
+    found = client.pricings.get_by_id(id=seeded_pricings[0].id)
+    assert found.default is None or isinstance(found.default, int)

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -1,10 +1,8 @@
 import uuid
-from contextlib import suppress
 
 import pytest
 
 from albert import Albert
-from albert.exceptions import NotFoundError
 from albert.resources.inventory import InventoryItem
 from albert.resources.locations import Location
 from albert.resources.pricings import Pricing
@@ -28,43 +26,20 @@ def test_get_by_id(client: Albert, seeded_pricings: list[Pricing]):
 
 
 def test_update(client: Albert, seeded_pricings: list[Pricing], seeded_locations: list[Location]):
-    pricing = seeded_pricings[0]
+    """Test update changes description, location, and default."""
+    pricing = client.pricings.get_by_id(id=seeded_pricings[0].id)
     updated_description = f"TEST - {uuid.uuid4()}"
     pricing.description = updated_description
     pricing.location = seeded_locations[1]
+    pricing.default = 1
     assert client.pricings.update(pricing=pricing)
     updated = client.pricings.get_by_id(id=pricing.id)
     assert updated.description == updated_description
     assert updated.location.id == seeded_locations[1].id
+    assert updated.default == 1
 
 
 def test_get_by_id_includes_default(client: Albert, seeded_pricings: list[Pricing]):
     """Test get_by_id exposes the default flag."""
     found = client.pricings.get_by_id(id=seeded_pricings[0].id)
-    assert found.default is None or isinstance(found.default, int)
-
-
-def test_update_default(
-    client: Albert,
-    seed_prefix: str,
-    seeded_inventory: list[InventoryItem],
-    seeded_locations: list[Location],
-):
-    """Test update can set default=1 via PATCH."""
-    pricing = Pricing(
-        inventory_id=seeded_inventory[0].id,
-        company=seeded_inventory[0].company,
-        location=seeded_locations[0],
-        description=f"{seed_prefix} - default pricing update",
-        price=88.0,
-    )
-    created = client.pricings.create(pricing=pricing)
-    try:
-        created.default = 1
-        updated = client.pricings.update(pricing=created)
-        assert updated.default == 1
-        fetched = client.pricings.get_by_id(id=created.id)
-        assert fetched.default == 1
-    finally:
-        with suppress(NotFoundError):
-            client.pricings.delete(id=created.id)
+    assert found.default is None or found.default in (0, 1)

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -1,8 +1,10 @@
 import uuid
+from contextlib import suppress
 
 import pytest
 
 from albert import Albert
+from albert.exceptions import NotFoundError
 from albert.resources.inventory import InventoryItem
 from albert.resources.locations import Location
 from albert.resources.pricings import Pricing
@@ -34,3 +36,54 @@ def test_update(client: Albert, seeded_pricings: list[Pricing], seeded_locations
     updated = client.pricings.get_by_id(id=pricing.id)
     assert updated.description == updated_description
     assert updated.location.id == seeded_locations[1].id
+
+
+def test_create_with_default(
+    client: Albert,
+    seed_prefix: str,
+    seeded_inventory: list[InventoryItem],
+    seeded_locations: list[Location],
+):
+    """Test create accepts default=1 and returns it on get_by_id."""
+    pricing = Pricing(
+        inventory_id=seeded_inventory[0].id,
+        company=seeded_inventory[0].company,
+        location=seeded_locations[0],
+        description=f"{seed_prefix} - default pricing create",
+        price=99.0,
+        default=1,
+    )
+    created = client.pricings.create(pricing=pricing)
+    try:
+        assert created.default == 1
+        fetched = client.pricings.get_by_id(id=created.id)
+        assert fetched.default == 1
+    finally:
+        with suppress(NotFoundError):
+            client.pricings.delete(id=created.id)
+
+
+def test_update_default(
+    client: Albert,
+    seed_prefix: str,
+    seeded_inventory: list[InventoryItem],
+    seeded_locations: list[Location],
+):
+    """Test update can set default=1 on an existing pricing."""
+    pricing = Pricing(
+        inventory_id=seeded_inventory[0].id,
+        company=seeded_inventory[0].company,
+        location=seeded_locations[0],
+        description=f"{seed_prefix} - default pricing update",
+        price=88.0,
+    )
+    created = client.pricings.create(pricing=pricing)
+    try:
+        created.default = 1
+        updated = client.pricings.update(pricing=created)
+        assert updated.default == 1
+        fetched = client.pricings.get_by_id(id=created.id)
+        assert fetched.default == 1
+    finally:
+        with suppress(NotFoundError):
+            client.pricings.delete(id=created.id)

--- a/tests/collections/test_pricings.py
+++ b/tests/collections/test_pricings.py
@@ -37,9 +37,3 @@ def test_update(client: Albert, seeded_pricings: list[Pricing], seeded_locations
     assert updated.description == updated_description
     assert updated.location.id == seeded_locations[1].id
     assert updated.default == 1
-
-
-def test_get_by_id_includes_default(client: Albert, seeded_pricings: list[Pricing]):
-    """Test get_by_id exposes the default flag."""
-    found = client.pricings.get_by_id(id=seeded_pricings[0].id)
-    assert found.default is None or found.default in (0, 1)


### PR DESCRIPTION
## What

Callers can read and update `Pricing.default` (`0` or `1`) on existing pricings. Set `pricing.default = 1` and call `update()` to mark a pricing as the default for its inventory item.

## Why

SDK-75: the pricing API exposes a `default` flag that was previously read-only in the SDK (`exclude=True`, `frozen=True`). The API rejects `default` on create but accepts PATCH updates with string `"0"`/`"1"` values.

## How

- Exclude `default` from create payloads (POST read-only).
- Add `default` to updatable attributes; stringify to `"0"`/`"1"` in patch payloads only.
- Type as `Literal[0, 1] | None` with documented semantics.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] Verified PATCH unset/set default on dev (`PRC20675`)
- [ ] `uv run pytest tests/collections/test_pricings.py -v`

## SDK Changes

`Pricing.default` is `0` (not default) or `1` (default). Cannot be set on create; use `client.pricings.update()` after create.
