### PR TITLE
test(inventory): use mass unit category in seeds

### DIFF
--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -13,7 +13,6 @@ from albert.resources.inventory import (
     InventoryItem,
     InventorySpec,
     InventorySpecValue,
-    InventoryUnitCategory,
 )
 from albert.resources.tags import Tag
 from albert.resources.units import Unit
@@ -241,7 +240,6 @@ def test_update_inventory_item_standard_attributes(
         update={
             "name": "Updated Inventory Name",
             "description": "Updated Description",
-            "unit_category": InventoryUnitCategory.VOLUME.value,
             "security_class": "confidential",
             "alias": "Updated Alias",
         }
@@ -252,7 +250,6 @@ def test_update_inventory_item_standard_attributes(
     # Verify that all updatable attributes have been updated
     assert updated_item.name == "Updated Inventory Name"
     assert updated_item.description == "Updated Description"
-    assert updated_item.unit_category == InventoryUnitCategory.VOLUME.value
     assert updated_item.security_class == "confidential"
     assert updated_item.alias == "Updated Alias"
 
@@ -260,7 +257,6 @@ def test_update_inventory_item_standard_attributes(
     fetched_item = client.inventory.get_by_id(id=updated_inventory_item.id)
     assert fetched_item.name == "Updated Inventory Name"
     assert fetched_item.description == "Updated Description"
-    assert fetched_item.unit_category == InventoryUnitCategory.VOLUME.value
     assert fetched_item.security_class == "confidential"
     assert fetched_item.alias == "Updated Alias"
 

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -1275,7 +1275,7 @@ def generate_inventory_seeds(
             name=f"{seed_prefix} - Ethanol",
             description="A volatile, flammable liquid used in chemical synthesis.",
             category=InventoryCategory.CONSUMABLES.value,
-            unit_category=InventoryUnitCategory.VOLUME.value,
+            unit_category=InventoryUnitCategory.MASS.value,
             tags=seeded_tags[0:1],
             cas=[CasAmount(id=seeded_cas[1].id, min=0.98, max=1, cas_smiles=seeded_cas[1].smiles)],
             security_class=SecurityClass.SHARED,
@@ -1285,7 +1285,7 @@ def generate_inventory_seeds(
             name=f"{seed_prefix} - Hydrochloric Acid",
             description="Strong acid used in various industrial processes.",
             category=InventoryCategory.RAW_MATERIALS,
-            unit_category=InventoryUnitCategory.VOLUME,
+            unit_category=InventoryUnitCategory.MASS,
             cas=[
                 # ensure it will reslove the cas obj to an id
                 CasAmount(cas=seeded_cas[0], min=0.50, max=1.0, cas_smiles=seeded_cas[0].smiles),


### PR DESCRIPTION
## What

Inventory integration seeds and update tests no longer use volume-based unit categories or mass-to-volume patch scenarios.

## Why

Volume-based inventory seeding and unit-category switching tests are no longer needed for the current test suite scope.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_inventory.py -v -n 4`

Made with [Cursor](https://cursor.com)