### PR TITLE
fix(sheets): use None default for Design.state field

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -295,7 +295,7 @@ class Design(BaseSessionResource):
         Get all row groups in this design.
     """
 
-    state: DesignState | None = Field({})
+    state: DesignState | None = Field(default=None)
     """The display state of the design. Optional. Default is None."""
 
     id: str = Field(alias="albertId")


### PR DESCRIPTION
## What

`Design.state` now defaults to `None` instead of an empty dict, so Pydantic no longer emits serializer warnings when Ask Albert builds SDK tool schemas for sheet/design resources.

## Why

Datadog showed a spike of `PydanticSerializationUnexpectedValue` errors on `svc-ai-react-worker`: `Expected DesignState` with `input_value={}`. The root cause was `state: DesignState | None = Field({})` — `{}` is a dict default, not `None` or a `DesignState` instance.

Linear: [AI-1324](https://linear.app/albert-invent/issue/AI-1324/fix-designstate-default-to-stop-designstate-serializer-warnings)

## How

- Changed `Field({})` → `Field(default=None)` on `Design.state` in `sheets.py` to match the documented optional default.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/resources/test_sheets.py -q -k "Design or design"`

## SDK Changes

Fixes noisy Pydantic serializer warnings for `Design.state` when designs are serialized for agent tool schemas. No API behavior change for callers — omitted `state` still means unset/`None`.