### PR TITLE
fix(inventory): preserve metadata list item names

### DIFF
--- a/src/albert/core/shared/types.py
+++ b/src/albert/core/shared/types.py
@@ -5,7 +5,9 @@ from pydantic import PlainSerializer
 from albert.core.shared.models.base import BaseResource, EntityLink, EntityLinkWithName
 
 EntityType = TypeVar("EntityType", bound=BaseResource)
-MetadataItem = float | int | str | EntityLink | list[EntityLink]
+MetadataItem = (
+    float | int | str | EntityLinkWithName | EntityLink | list[EntityLinkWithName | EntityLink]
+)
 
 
 def convert_to_entity_link(value: BaseResource | EntityLink) -> EntityLink:

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -8,8 +8,8 @@ from pydantic import Field, field_validator, model_validator
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.enums import SecurityClass
 from albert.core.shared.identifiers import InventoryId
-from albert.core.shared.models.base import AuditFields, EntityLink, EntityLinkWithName
-from albert.core.shared.types import SerializeAsEntityLink
+from albert.core.shared.models.base import AuditFields
+from albert.core.shared.types import MetadataItem, SerializeAsEntityLink
 from albert.resources._mixins import HydrationMixin
 from albert.resources.acls import ACL
 from albert.resources.cas import Cas
@@ -18,10 +18,6 @@ from albert.resources.lists import ListItem
 from albert.resources.locations import Location
 from albert.resources.tagged_base import BaseTaggedResource
 from albert.resources.tags import Tag
-
-InventoryMetadataItem = (
-    float | int | str | EntityLinkWithName | EntityLink | list[EntityLinkWithName | EntityLink]
-)
 
 
 class InventoryMergeModule(str, Enum):
@@ -324,7 +320,7 @@ class InventoryItem(BaseTaggedResource):
     is_formula_override: bool | None = Field(default=None, alias="isFormulaOverride")
     """Whether the substance/CAS-level breakdown for this formula has been overridden from the auto-calculated value; commonly set to indicate the formula is not a non-reactive homogeneous mixture."""
 
-    metadata: dict[str, InventoryMetadataItem] | None = Field(alias="Metadata", default=None)
+    metadata: dict[str, MetadataItem] | None = Field(alias="Metadata", default=None)
     """Custom metadata fields. Allowed keys are defined by the workspace's CustomFields configuration."""
 
     project_id: str | None = Field(default=None, alias="parentId")

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -8,8 +8,8 @@ from pydantic import Field, field_validator, model_validator
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.enums import SecurityClass
 from albert.core.shared.identifiers import InventoryId
-from albert.core.shared.models.base import AuditFields
-from albert.core.shared.types import MetadataItem, SerializeAsEntityLink
+from albert.core.shared.models.base import AuditFields, EntityLink, EntityLinkWithName
+from albert.core.shared.types import SerializeAsEntityLink
 from albert.resources._mixins import HydrationMixin
 from albert.resources.acls import ACL
 from albert.resources.cas import Cas
@@ -18,6 +18,10 @@ from albert.resources.lists import ListItem
 from albert.resources.locations import Location
 from albert.resources.tagged_base import BaseTaggedResource
 from albert.resources.tags import Tag
+
+InventoryMetadataItem = (
+    float | int | str | EntityLinkWithName | EntityLink | list[EntityLinkWithName | EntityLink]
+)
 
 
 class InventoryMergeModule(str, Enum):
@@ -320,7 +324,7 @@ class InventoryItem(BaseTaggedResource):
     is_formula_override: bool | None = Field(default=None, alias="isFormulaOverride")
     """Whether the substance/CAS-level breakdown for this formula has been overridden from the auto-calculated value; commonly set to indicate the formula is not a non-reactive homogeneous mixture."""
 
-    metadata: dict[str, MetadataItem] | None = Field(alias="Metadata", default=None)
+    metadata: dict[str, InventoryMetadataItem] | None = Field(alias="Metadata", default=None)
     """Custom metadata fields. Allowed keys are defined by the workspace's CustomFields configuration."""
 
     project_id: str | None = Field(default=None, alias="parentId")

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -3,9 +3,11 @@ import pytest
 from albert.client import Albert
 from albert.collections.inventory import InventoryCategory
 from albert.core.shared.identifiers import ensure_inventory_id
+from albert.core.shared.models.base import EntityLink
 from albert.exceptions import BadRequestError
 from albert.resources.cas import Cas
 from albert.resources.companies import Company
+from albert.resources.custom_fields import FieldType, ServiceType
 from albert.resources.data_columns import DataColumn
 from albert.resources.facet import FacetItem, FacetValue
 from albert.resources.inventory import (
@@ -198,6 +200,43 @@ def test_get_by_id(client: Albert, seeded_inventory):
     assert isinstance(get_by_id, InventoryItem)
     assert seeded_inventory[0].name == get_by_id.name
     assert seeded_inventory[0].id == get_by_id.id
+
+
+def test_get_by_id_preserves_metadata_list_item_names(
+    client: Albert,
+    seed_prefix: str,
+    static_custom_fields,
+    static_lists,
+    seeded_companies,
+):
+    """Test list metadata includes names when an inventory item is retrieved."""
+    custom_field = next(
+        field
+        for field in static_custom_fields
+        if field.service == ServiceType.INVENTORIES and field.field_type == FieldType.LIST
+    )
+    list_item = next(item for item in static_lists if item.list_type == custom_field.name)
+    created = client.inventory.create(
+        inventory_item=InventoryItem(
+            name=f"{seed_prefix} - Metadata names",
+            category=InventoryCategory.RAW_MATERIALS,
+            company=seeded_companies[0],
+            metadata={custom_field.name: [EntityLink(id=list_item.id)]},
+        ),
+        avoid_duplicates=False,
+    )
+
+    try:
+        retrieved = client.inventory.get_by_id(id=created.id)
+        metadata_link = retrieved.metadata[custom_field.name][0]
+
+        assert metadata_link.id == list_item.id
+        assert metadata_link.name == list_item.name
+        assert retrieved.model_dump(mode="json", by_alias=True)["Metadata"][custom_field.name] == [
+            {"id": list_item.id, "name": list_item.name}
+        ]
+    finally:
+        client.inventory.delete(id=created.id)
 
 
 def test_get_by_ids(client: Albert, seeded_inventory):

--- a/tests/resources/test_inventory.py
+++ b/tests/resources/test_inventory.py
@@ -1,6 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
+from albert.core.shared.models.base import EntityLink
 from albert.resources.cas import Cas
 from albert.resources.inventory import (
     CasAmount,
@@ -65,3 +66,20 @@ def test_formula_requirements():
             description="Test",
             category=InventoryCategory.FORMULAS,
         )
+
+
+def test_inventory_metadata_preserves_named_links_and_supports_id_only_links():
+    item = InventoryItem(
+        name="Test",
+        category=InventoryCategory.RAW_MATERIALS,
+        metadata={
+            "named": [{"id": "LST1", "name": "United States"}],
+            "id_only": [EntityLink(id="LST2")],
+        },
+    )
+
+    assert item.metadata["named"][0].name == "United States"
+    assert item.model_dump(mode="json", by_alias=True)["Metadata"] == {
+        "named": [{"id": "LST1", "name": "United States"}],
+        "id_only": [{"id": "LST2"}],
+    }


### PR DESCRIPTION
## What

Inventory metadata list values now preserve the names returned by the Albert API when inventory items are retrieved and serialized.

## Why

The API already returns readable names for list-based custom-field values, but the SDK's `EntityLink` serialization excluded those names. This caused consumers such as the inventory data agent to receive only list-item IDs. This addresses AI-1336.

## How

- Use an inventory-specific metadata type that accepts named links while remaining compatible with existing ID-only links.
- Do not add extra list or custom-field API calls.
- Keep the existing `InventoryItem.metadata` structure unchanged for callers.

## Testing

- `uv --directory albert-python run ruff format src/albert/resources/inventory.py tests/collections/test_inventory.py`
- `uv --directory albert-python run ruff check src/albert/resources/inventory.py tests/collections/test_inventory.py`
- Live integration test with `-n 4`: passed.


Made with [Cursor](https://cursor.com)