### PR TITLE
feat(attachments): add upload_and_attach_script_to_data_template

### DIFF
--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -845,7 +845,7 @@ class AttachmentCollection(BaseCollection):
         data_template_id : DataTemplateId
             The Albert ID of the data template (format ``DAT...``).
         file_path : Path
-            Local path to the script file to upload.
+            Local path to the Python script file to upload. Must have a ``.py`` extension.
         name : str
             Display name for the script attachment.
         extension_names : list[str]
@@ -862,11 +862,17 @@ class AttachmentCollection(BaseCollection):
         FileNotFoundError
             If ``file_path`` does not exist.
         ValueError
-            If an extension name cannot be resolved in the extensions list.
+            If ``file_path`` does not have a ``.py`` extension, or if an extension name
+            cannot be resolved in the extensions list.
         """
         resolved_path = file_path.expanduser()
         if not resolved_path.is_file():
             raise FileNotFoundError(f"File not found at '{resolved_path}'")
+
+        if resolved_path.suffix.lower() != ".py":
+            raise ValueError(
+                f"Script file must have a .py extension, got '{resolved_path.suffix}'."
+            )
 
         lists_collection = self._get_lists_collection()
         available_extensions = {
@@ -886,13 +892,10 @@ class AttachmentCollection(BaseCollection):
                 )
             extension_links.append(EntityLinkWithName(id=list_item.id, name=list_item.name))
 
-        file_key = f"{data_template_id}/automated_scripts/{resolved_path.name}"
-        if resolved_path.suffix.lower() == ".py":
-            content_type = "text/x-python-script"
-        else:
-            content_type = (
-                mimetypes.guess_type(resolved_path.name)[0] or "application/octet-stream"
-            )
+        file_key = (
+            f"{data_template_id}/automated_scripts/{resolved_path.stem}{resolved_path.suffix}"
+        )
+        content_type = "text/x-python-script"
 
         file_collection = self._get_file_collection()
         with resolved_path.open("rb") as file_handle:

--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -835,7 +835,7 @@ class AttachmentCollection(BaseCollection):
             attachment = client.attachments.upload_and_attach_script_to_data_template(
                 data_template_id="DAT27984",
                 file_path=Path("etl.py"),
-                name="SDK-team-1",
+                name="CSV import script",
                 extension_names=["csv"],
             )
             ```

--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -8,8 +8,16 @@ from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
 from albert.collections.files import FileCollection
+from albert.collections.lists import ListsCollection
 from albert.collections.notes import NotesCollection
-from albert.core.shared.identifiers import AttachmentId, DataColumnId, InventoryId, ProjectId
+from albert.core.shared.identifiers import (
+    AttachmentId,
+    DataColumnId,
+    DataTemplateId,
+    InventoryId,
+    ProjectId,
+)
+from albert.core.shared.models.base import EntityLinkWithName
 from albert.core.shared.models.patch import PatchDatum, PatchOperation, PatchPayload
 from albert.core.shared.types import MetadataItem
 from albert.resources.attachments import (
@@ -19,6 +27,7 @@ from albert.resources.attachments import (
 )
 from albert.resources.files import FileCategory, FileNamespace
 from albert.resources.hazards import HazardStatement, HazardSymbol
+from albert.resources.lists import ListItemCategory
 from albert.resources.notes import Note
 
 
@@ -75,6 +84,8 @@ class AttachmentCollection(BaseCollection):
         Upload a document and attach it to an inventory item.
     upload_and_attach_document_to_project(project_id, file_path) -> Attachment
         Upload a file and attach it as a document to a project.
+    upload_and_attach_script_to_data_template(data_template_id, file_path, name, extension_names) -> Attachment
+        Upload a script and attach it to a data template.
     get_jurisdiction_codes() -> dict[str, str]
         Get available SDS jurisdiction codes.
     get_language_codes() -> dict[str, str]
@@ -104,6 +115,9 @@ class AttachmentCollection(BaseCollection):
 
     def _get_note_collection(self):
         return NotesCollection(session=self.session)
+
+    def _get_lists_collection(self):
+        return ListsCollection(session=self.session)
 
     @validate_call
     def get_by_id(self, *, id: AttachmentId) -> Attachment:
@@ -797,5 +811,104 @@ class AttachmentCollection(BaseCollection):
             key=file_key,
             namespace=FileNamespace.RESULT.value,
             category=AttachmentCategory.OTHER,
+        )
+        return self.create(attachment=attachment)
+
+    @validate_call
+    def upload_and_attach_script_to_data_template(
+        self,
+        *,
+        data_template_id: DataTemplateId,
+        file_path: Path,
+        name: str,
+        extension_names: list[str],
+    ) -> Attachment:
+        """Upload a script and attach it to a data template.
+
+        The script is stored under ``{data_template_id}/automated_scripts/`` and
+        registered as a ``Script`` attachment. Allowed input file extensions are
+        resolved from the platform extensions list (``list_type="extensions"``).
+
+        !!! example
+            ```python
+            from pathlib import Path
+            attachment = client.attachments.upload_and_attach_script_to_data_template(
+                data_template_id="DAT27984",
+                file_path=Path("etl.py"),
+                name="SDK-team-1",
+                extension_names=["csv"],
+            )
+            ```
+
+        Parameters
+        ----------
+        data_template_id : DataTemplateId
+            The Albert ID of the data template (format ``DAT...``).
+        file_path : Path
+            Local path to the script file to upload.
+        name : str
+            Display name for the script attachment.
+        extension_names : list[str]
+            Allowed input file extensions for the script (e.g. ``["csv"]``). Each
+            name is resolved via the extensions list.
+
+        Returns
+        -------
+        Attachment
+            The created script attachment linked to the data template.
+
+        Raises
+        ------
+        FileNotFoundError
+            If ``file_path`` does not exist.
+        ValueError
+            If an extension name cannot be resolved in the extensions list.
+        """
+        resolved_path = file_path.expanduser()
+        if not resolved_path.is_file():
+            raise FileNotFoundError(f"File not found at '{resolved_path}'")
+
+        lists_collection = self._get_lists_collection()
+        available_extensions = {
+            item.name.lower(): item
+            for item in lists_collection.get_all(
+                category=ListItemCategory.EXTENSIONS,
+                list_type="extensions",
+            )
+            if item.name
+        }
+        extension_links: list[EntityLinkWithName] = []
+        for extension_name in extension_names:
+            list_item = available_extensions.get(extension_name.lower())
+            if list_item is None:
+                raise ValueError(
+                    f"Extension '{extension_name}' was not found in the extensions list."
+                )
+            extension_links.append(EntityLinkWithName(id=list_item.id, name=list_item.name))
+
+        file_key = f"{data_template_id}/automated_scripts/{resolved_path.name}"
+        if resolved_path.suffix.lower() == ".py":
+            content_type = "text/x-python-script"
+        else:
+            content_type = (
+                mimetypes.guess_type(resolved_path.name)[0] or "application/octet-stream"
+            )
+
+        file_collection = self._get_file_collection()
+        with resolved_path.open("rb") as file_handle:
+            file_collection.sign_and_upload_file(
+                data=file_handle,
+                name=file_key,
+                namespace=FileNamespace.RESULT,
+                content_type=content_type,
+            )
+
+        attachment = Attachment(
+            parent_id=data_template_id,
+            name=name,
+            key=file_key,
+            namespace=FileNamespace.RESULT.value,
+            category=AttachmentCategory.SCRIPT,
+            metadata=AttachmentMetadata(extensions=extension_links),
         )
         return self.create(attachment=attachment)

--- a/src/albert/resources/attachments.py
+++ b/src/albert/resources/attachments.py
@@ -163,6 +163,3 @@ class Attachment(BaseResource):
 
     metadata: AttachmentMetadata | None = Field(default=None, alias="Metadata")
     """Optional safety and classification metadata. See [`AttachmentMetadata`][albert.resources.attachments.AttachmentMetadata]."""
-
-
-# TO DO: Script and SDS attachment

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -705,3 +705,19 @@ def test_upload_and_attach_script_to_data_template_unknown_extension(
             name=f"{seed_prefix} invalid extension script",
             extension_names=["not-a-real-extension"],
         )
+
+
+def test_upload_and_attach_script_to_data_template_requires_py_suffix(
+    client: Albert,
+    seeded_data_templates: list[DataTemplate],
+    seed_prefix: str,
+):
+    """Test non-Python script files are rejected."""
+    data_template = seeded_data_templates[0]
+    with pytest.raises(ValueError, match="must have a .py extension"):
+        client.attachments.upload_and_attach_script_to_data_template(
+            data_template_id=data_template.id,
+            file_path=Path("tests/data/dontpanic.jpg"),
+            name=f"{seed_prefix} invalid script file",
+            extension_names=["csv"],
+        )

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -1,16 +1,19 @@
 from contextlib import suppress
+from pathlib import Path
 
 import pytest
 
 from albert import Albert
 from albert.core.shared.models.base import EntityLink
 from albert.exceptions import NotFoundError
+from albert.resources.attachments import Attachment, AttachmentCategory
 from albert.resources.data_columns import DataColumn
 from albert.resources.data_templates import (
     DataColumnValue,
     DataTemplate,
     DataTemplateSearchItem,
 )
+from albert.resources.lists import ListItemCategory
 from albert.resources.parameter_groups import (
     DataType,
     EnumValidationValue,
@@ -645,3 +648,60 @@ def test_add_parameters_enum_ids_populated(
     assert len(added_param.validation[0].value) == 2
     for v in added_param.validation[0].value:
         assert v.id is not None, f"Enum value '{v.text}' has no ID"
+
+
+def test_upload_and_attach_script_to_data_template(
+    client: Albert,
+    seeded_data_templates: list[DataTemplate],
+    seed_prefix: str,
+):
+    """Test uploading a script and attaching it to a data template."""
+    data_template = seeded_data_templates[0]
+    available_extensions = list(
+        client.lists.get_all(
+            category=ListItemCategory.EXTENSIONS,
+            list_type="extensions",
+            max_items=1,
+        )
+    )
+    if not available_extensions:
+        pytest.skip("No extensions configured in tenant")
+    extension = available_extensions[0]
+
+    attachment = client.attachments.upload_and_attach_script_to_data_template(
+        data_template_id=data_template.id,
+        file_path=Path("tests/data/etl.py"),
+        name=f"{seed_prefix} etl script",
+        extension_names=[extension.name],
+    )
+    try:
+        assert isinstance(attachment, Attachment)
+        assert attachment.parent_id == data_template.id
+        assert attachment.category == AttachmentCategory.SCRIPT
+        assert attachment.key == f"{data_template.id}/automated_scripts/etl.py"
+        assert attachment.metadata is not None
+        assert attachment.metadata.extensions is not None
+        assert any(ext.id == extension.id for ext in attachment.metadata.extensions)
+
+        by_parent = client.attachments.get_by_parent_ids(parent_ids=[data_template.id])
+        attached_ids = {item.id for item in by_parent.get(data_template.id, [])}
+        assert attachment.id in attached_ids
+    finally:
+        with suppress(NotFoundError):
+            client.attachments.delete(id=attachment.id)
+
+
+def test_upload_and_attach_script_to_data_template_unknown_extension(
+    client: Albert,
+    seeded_data_templates: list[DataTemplate],
+    seed_prefix: str,
+):
+    """Test unknown extension names raise a clear error."""
+    data_template = seeded_data_templates[0]
+    with pytest.raises(ValueError, match="not found in the extensions list"):
+        client.attachments.upload_and_attach_script_to_data_template(
+            data_template_id=data_template.id,
+            file_path=Path("tests/data/etl.py"),
+            name=f"{seed_prefix} invalid extension script",
+            extension_names=["not-a-real-extension"],
+        )

--- a/tests/data/etl.py
+++ b/tests/data/etl.py
@@ -1,0 +1,5 @@
+"""Sample ETL script for attachment integration tests."""
+
+
+def transform(data):
+    return data


### PR DESCRIPTION
## What

Callers can upload a script file and attach it to a data template in one SDK call via `client.attachments.upload_and_attach_script_to_data_template`, instead of manually chaining file upload and attachment creation.

## Why

Attaching automation scripts to data templates is a common workflow in the UI/API, but the SDK only exposed lower-level `files.sign_and_upload_file` and `attachments.create` helpers. A dedicated method makes script attachment discoverable and handles extension metadata resolution.

## How

Extension names are resolved by scanning the platform extensions list (`category=extensions`, `listType=extensions`) rather than fuzzy list search, so exact extension names like `csv` match reliably.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_data_templates.py::test_upload_and_attach_script_to_data_template tests/collections/test_data_templates.py::test_upload_and_attach_script_to_data_template_unknown_extension -v -n 4`

## SDK Changes

Added `AttachmentCollection.upload_and_attach_script_to_data_template(data_template_id, file_path, name, extension_names)` to upload a script under `{DAT}/automated_scripts/` and create a `Script` attachment with resolved extension metadata.