### PR TITLE
fix(projects): support ACL updates via update()

### DIFF
--- a/src/albert/collections/projects.py
+++ b/src/albert/collections/projects.py
@@ -11,6 +11,7 @@ from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import ProjectId, SearchProjectId
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError
+from albert.resources.acls import ACL
 from albert.resources.projects import DocumentSearchItem, Project, ProjectSearchItem
 
 
@@ -174,15 +175,85 @@ class ProjectCollection(BaseCollection):
         Notes
         -----
         The following fields can be updated: ``description``, ``grid``,
-        ``metadata``, ``state``.
+        ``metadata``, ``state``, ``acl``.
         """
         existing_project = self.get_by_id(id=project.id)
         patch_data = self._generate_patch_payload(existing=existing_project, updated=project)
         url = f"{self.base_path}/{project.id}"
+        patch_payload = patch_data.model_dump(mode="json", by_alias=True)
 
-        self.session.patch(url, json=patch_data.model_dump(mode="json", by_alias=True))
+        acl_operations: list[dict[str, Any]] = []
+        if "acl" in project.model_fields_set:
+            acl_operations = self._generate_acl_patch_operations(
+                existing=existing_project.acl,
+                updated=project.acl,
+            )
+
+        if patch_payload["data"]:
+            self.session.patch(url, json=patch_payload)
+
+        if acl_operations:
+            self.session.patch(f"{url}/acl", json={"data": acl_operations})
+
+        if not patch_payload["data"] and not acl_operations:
+            return existing_project
 
         return self.get_by_id(id=project.id)
+
+    def _generate_acl_patch_operations(
+        self,
+        *,
+        existing: list[ACL] | None,
+        updated: list[ACL] | None,
+    ) -> list[dict[str, Any]]:
+        """Build PATCH operations for project ACL changes."""
+        existing_entries = existing or []
+        updated_entries = updated or []
+        existing_ids = [entry.id for entry in existing_entries]
+        updated_ids = [entry.id for entry in updated_entries]
+        to_add = set(updated_ids) - set(existing_ids)
+        to_delete = set(existing_ids) - set(updated_ids)
+        to_update = set(existing_ids).intersection(updated_ids)
+
+        operations: list[dict[str, Any]] = []
+
+        if to_add:
+            operations.append(
+                {
+                    "attribute": "ACL",
+                    "operation": "add",
+                    "newValue": [
+                        entry.model_dump(by_alias=True, exclude_none=True)
+                        for entry in updated_entries
+                        if entry.id in to_add
+                    ],
+                }
+            )
+
+        if to_delete:
+            operations.append(
+                {
+                    "attribute": "ACL",
+                    "operation": "delete",
+                    "oldValue": [{"id": entry_id} for entry_id in to_delete],
+                }
+            )
+
+        for entry_id in to_update:
+            existing_fgc = next(entry.fgc for entry in existing_entries if entry.id == entry_id)
+            updated_fgc = next(entry.fgc for entry in updated_entries if entry.id == entry_id)
+            if existing_fgc != updated_fgc:
+                operations.append(
+                    {
+                        "attribute": "fgc",
+                        "id": entry_id,
+                        "operation": "update",
+                        "oldValue": existing_fgc.value if existing_fgc is not None else None,
+                        "newValue": updated_fgc.value if updated_fgc is not None else None,
+                    }
+                )
+
+        return operations
 
     @validate_call
     def delete(self, *, id: ProjectId) -> None:

--- a/tests/collections/test_projects.py
+++ b/tests/collections/test_projects.py
@@ -5,6 +5,7 @@ import pytest
 from albert.client import Albert
 from albert.core.shared.models.base import EntityLink
 from albert.exceptions import NotFoundError
+from albert.resources.acls import ACL, AccessControlLevel
 from albert.resources.attachments import Attachment
 from albert.resources.projects import DocumentSearchItem, Project, ProjectSearchItem
 from tests.utils.wait import poll_until
@@ -126,6 +127,69 @@ def test_update_project(seeded_locations, client: Albert, seed_prefix: str):
     finally:
         with suppress(NotFoundError):
             client.projects.delete(id=project.id)
+
+
+def test_update_project_acl(
+    client: Albert,
+    seeded_locations,
+    seed_prefix: str,
+):
+    """Test updating a project's ACL via update()."""
+    team = client.teams.create(name=f"{seed_prefix} - project ACL team")
+    project = client.projects.create(
+        project=Project(
+            description=f"{seed_prefix} - ACL update project",
+            locations=[EntityLink(id=seeded_locations[0].id)],
+            acl=[ACL(id=team.id, fgc=AccessControlLevel.PROJECT_VIEWER)],
+        )
+    )
+    try:
+        fetched = client.projects.get_by_id(id=project.id)
+        updated_acl = [
+            ACL(
+                id=entry.id,
+                fgc=(
+                    AccessControlLevel.PROJECT_STRICT_VIEWER if entry.id == team.id else entry.fgc
+                ),
+            )
+            for entry in fetched.acl or []
+        ]
+        updated = client.projects.update(project=fetched.model_copy(update={"acl": updated_acl}))
+        entry = next(entry for entry in updated.acl or [] if entry.id == team.id)
+        assert entry.fgc == AccessControlLevel.PROJECT_STRICT_VIEWER
+    finally:
+        with suppress(NotFoundError):
+            client.projects.delete(id=project.id)
+        with suppress(NotFoundError):
+            client.teams.delete(id=team.id)
+
+
+def test_update_project_acl_in_place(
+    client: Albert,
+    seeded_locations,
+    seed_prefix: str,
+):
+    """Test in-place ACL edits trigger update without reassigning acl."""
+    team = client.teams.create(name=f"{seed_prefix} - in-place ACL team")
+    project = client.projects.create(
+        project=Project(
+            description=f"{seed_prefix} - in-place ACL project",
+            locations=[EntityLink(id=seeded_locations[0].id)],
+            acl=[ACL(id=team.id, fgc=AccessControlLevel.PROJECT_VIEWER)],
+        )
+    )
+    try:
+        fetched = client.projects.get_by_id(id=project.id)
+        team_entry = next(entry for entry in fetched.acl or [] if entry.id == team.id)
+        team_entry.fgc = AccessControlLevel.PROJECT_STRICT_VIEWER
+        updated = client.projects.update(project=fetched)
+        entry = next(entry for entry in updated.acl or [] if entry.id == team.id)
+        assert entry.fgc == AccessControlLevel.PROJECT_STRICT_VIEWER
+    finally:
+        with suppress(NotFoundError):
+            client.projects.delete(id=project.id)
+        with suppress(NotFoundError):
+            client.teams.delete(id=team.id)
 
 
 def test_delete_project(client: Albert, seeded_locations):


### PR DESCRIPTION
## What

Callers can now add, remove, and change project ACL entries through `client.projects.update()` instead of hand-rolling PATCH requests to `/acl`.

## Why

Fixes #665. Modifying `project.acl` and calling `update()` previously ignored ACL changes and sent an empty `{"data": []}` payload to the main project endpoint, which the API rejects with 400.

## How

ACL diffs follow the same `model_fields_set` gate used elsewhere in the SDK. Add/delete operations use `attribute: "ACL"`; role changes use `attribute: "fgc"`. ACL patches are sent to `PATCH /projects/{id}/acl`; other fields still patch the main project route. Empty payloads are skipped entirely.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_projects.py::test_update_project_acl tests/collections/test_projects.py::test_update_project_acl_in_place -n 4 -v`

## SDK Changes

`ProjectCollection.update()` now supports patching `acl` (add/remove entries and update FGC roles).