### PR TITLE
feat(collections): add missing search filters for projects and users

### DIFF
--- a/src/albert/collections/projects.py
+++ b/src/albert/collections/projects.py
@@ -306,7 +306,6 @@ class ProjectCollection(BaseCollection):
         custom_fields: dict[str, Any] | None = None,
         formula_access: list[str] | None = None,
         linked_to_grid: str | None = None,
-        search_field: list[str] | None = None,
         source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
@@ -396,8 +395,6 @@ class ProjectCollection(BaseCollection):
             Filter by formula access level.
         linked_to_grid : str, optional
             Text for linked-to dropdown search in grid/report flows.
-        search_field : list[str], optional
-            Restrict which fields the ``text`` query searches.
         source_field : list[str], optional
             Restrict which fields are returned in the response.
         order_by : OrderBy, optional
@@ -442,7 +439,6 @@ class ProjectCollection(BaseCollection):
             "additionalField": additional_field,
             "formulaAccess": formula_access,
             "linkedToGrid": linked_to_grid,
-            "searchField": search_field,
             "sourceField": source_field,
         }
         if metadata_filters is not None:
@@ -468,6 +464,9 @@ class ProjectCollection(BaseCollection):
         *,
         linked_to: SearchProjectId,
         text: str | None = None,
+        source_field: list[str] | None = None,
+        additional_field: list[str] | None = None,
+        search_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
         offset: int | None = None,
@@ -492,6 +491,12 @@ class ProjectCollection(BaseCollection):
             ``"PRO123"``).
         text : str, optional
             Full-text search query for document names.
+        source_field : list[str], optional
+            Restrict which fields are returned in the response.
+        additional_field : list[str], optional
+            Request additional columns from the search index.
+        search_field : list[str], optional
+            Restrict which fields the ``text`` query searches.
         order_by : OrderBy, optional
             Sort order. Default is DESCENDING.
         sort_by : str, optional
@@ -507,6 +512,9 @@ class ProjectCollection(BaseCollection):
         query_params = {
             "linkedTo": linked_to,
             "text": text,
+            "sourceField": source_field,
+            "additionalField": additional_field,
+            "searchField": search_field,
             "order": order_by,
             "sortBy": sort_by,
             "offset": offset,
@@ -551,7 +559,6 @@ class ProjectCollection(BaseCollection):
         custom_fields: dict[str, Any] | None = None,
         formula_access: list[str] | None = None,
         linked_to_grid: str | None = None,
-        search_field: list[str] | None = None,
         source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
@@ -633,8 +640,6 @@ class ProjectCollection(BaseCollection):
             Filter by formula access level.
         linked_to_grid : str, optional
             Text for linked-to dropdown search in grid/report flows.
-        search_field : list[str], optional
-            Restrict which fields the ``text`` query searches.
         source_field : list[str], optional
             Restrict which fields are returned in the response.
         order_by : OrderBy, optional
@@ -690,7 +695,6 @@ class ProjectCollection(BaseCollection):
                 custom_fields=custom_fields,
                 formula_access=formula_access,
                 linked_to_grid=linked_to_grid,
-                search_field=search_field,
                 source_field=source_field,
                 order_by=order_by,
                 sort_by=sort_by,

--- a/src/albert/collections/projects.py
+++ b/src/albert/collections/projects.py
@@ -302,6 +302,12 @@ class ProjectCollection(BaseCollection):
         my_project: bool | None = None,
         my_role: list[str] | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        additional_field: list[str] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        formula_access: list[str] | None = None,
+        linked_to_grid: str | None = None,
+        search_field: list[str] | None = None,
+        source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
         offset: int | None = None,
@@ -382,6 +388,18 @@ class ProjectCollection(BaseCollection):
             !!! warning
                 Do not use this for application, technology, program, technical lead, or
                 market segment. Use their corresponding query parameters instead.
+        additional_field : list[str], optional
+            Request additional columns from the search index.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        formula_access : list[str], optional
+            Filter by formula access level.
+        linked_to_grid : str, optional
+            Text for linked-to dropdown search in grid/report flows.
+        search_field : list[str], optional
+            Restrict which fields the ``text`` query searches.
+        source_field : list[str], optional
+            Restrict which fields are returned in the response.
         order_by : OrderBy, optional
             Sort order. Default is DESCENDING.
         sort_by : str, optional
@@ -421,9 +439,16 @@ class ProjectCollection(BaseCollection):
             "linkedTo": linked_to,
             "myProject": my_project,
             "myRole": my_role,
+            "additionalField": additional_field,
+            "formulaAccess": formula_access,
+            "linkedToGrid": linked_to_grid,
+            "searchField": search_field,
+            "sourceField": source_field,
         }
         if metadata_filters is not None:
             payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
@@ -521,6 +546,13 @@ class ProjectCollection(BaseCollection):
         linked_to: str | None = None,
         my_project: bool | None = None,
         my_role: list[str] | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        additional_field: list[str] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        formula_access: list[str] | None = None,
+        linked_to_grid: str | None = None,
+        search_field: list[str] | None = None,
+        source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
         offset: int | None = None,
@@ -591,6 +623,20 @@ class ProjectCollection(BaseCollection):
             If True, return only projects owned by current user.
         my_role : list[str], optional
             User roles to filter by.
+        metadata_filters : dict[str, Any], optional
+            Filter by custom field (metadata) values.
+        additional_field : list[str], optional
+            Request additional columns from the search index.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        formula_access : list[str], optional
+            Filter by formula access level.
+        linked_to_grid : str, optional
+            Text for linked-to dropdown search in grid/report flows.
+        search_field : list[str], optional
+            Restrict which fields the ``text`` query searches.
+        source_field : list[str], optional
+            Restrict which fields are returned in the response.
         order_by : OrderBy, optional
             Sort order. Default is DESCENDING.
         sort_by : str, optional
@@ -639,6 +685,13 @@ class ProjectCollection(BaseCollection):
                 linked_to=linked_to,
                 my_project=my_project,
                 my_role=my_role,
+                metadata_filters=metadata_filters,
+                additional_field=additional_field,
+                custom_fields=custom_fields,
+                formula_access=formula_access,
+                linked_to_grid=linked_to_grid,
+                search_field=search_field,
+                source_field=source_field,
                 order_by=order_by,
                 sort_by=sort_by,
                 offset=offset,

--- a/src/albert/collections/users.py
+++ b/src/albert/collections/users.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import validate_call
 
@@ -156,6 +157,11 @@ class UserCollection(BaseCollection):
         contains_field: list[str] | None = None,
         contains_text: list[str] | None = None,
         mentions: bool | None = None,
+        additional_field: list[str] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        source_field: list[str] | None = None,
+        witnesser: list[str] | None = None,
         offset: int = 0,
         max_items: int | None = None,
     ) -> Iterator[UserSearchItem]:
@@ -206,6 +212,16 @@ class UserCollection(BaseCollection):
             Substrings to match within the corresponding ``contains_field``.
         mentions : bool, optional
             When True, restrict to users who are mentioned.
+        additional_field : list[str], optional
+            Request additional columns from the search index.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        metadata_filters : dict[str, Any], optional
+            Filter by custom field (metadata) values.
+        source_field : list[str], optional
+            Restrict which fields are returned in the response.
+        witnesser : list[str], optional
+            Filter by witnesser status.
         max_items : int, optional
             Maximum total number of users to return. If None, returns all
             matches.
@@ -231,8 +247,31 @@ class UserCollection(BaseCollection):
             "containsField": contains_field,
             "containsText": contains_text,
             "mentions": mentions,
+            "additionalField": additional_field,
+            "sourceField": source_field,
+            "witnesser": witnesser,
             "offset": offset,
         }
+
+        deserialize = lambda items: [
+            UserSearchItem(**item)._bind_collection(self) for item in items
+        ]
+
+        if metadata_filters is not None or custom_fields is not None:
+            payload: dict[str, Any] = {**params}
+            if metadata_filters is not None:
+                payload["metadataFilters"] = {"metadata": metadata_filters}
+            if custom_fields is not None:
+                payload["customFields"] = {"metadata": custom_fields}
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=f"{self.base_path}/search",
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
@@ -240,9 +279,7 @@ class UserCollection(BaseCollection):
             session=self.session,
             params=params,
             max_items=max_items,
-            deserialize=lambda items: [
-                UserSearchItem(**item)._bind_collection(self) for item in items
-            ],
+            deserialize=deserialize,
         )
 
     @validate_call

--- a/src/albert/collections/users.py
+++ b/src/albert/collections/users.py
@@ -257,29 +257,20 @@ class UserCollection(BaseCollection):
             UserSearchItem(**item)._bind_collection(self) for item in items
         ]
 
-        if metadata_filters is not None or custom_fields is not None:
-            payload: dict[str, Any] = {**params}
-            if metadata_filters is not None:
-                payload["metadataFilters"] = {"metadata": metadata_filters}
-            if custom_fields is not None:
-                payload["customFields"] = {"metadata": custom_fields}
-            return AlbertPaginator(
-                mode=PaginationMode.OFFSET,
-                path=f"{self.base_path}/search",
-                session=self.session,
-                max_items=max_items,
-                deserialize=deserialize,
-                method="POST",
-                json=payload,
-            )
+        payload: dict[str, Any] = {**params}
+        if metadata_filters is not None:
+            payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
             path=f"{self.base_path}/search",
             session=self.session,
-            params=params,
             max_items=max_items,
             deserialize=deserialize,
+            method="POST",
+            json=payload,
         )
 
     @validate_call


### PR DESCRIPTION
## What

Callers can pass the remaining project and user search filters that the API already supports (custom fields, source/additional field projection, formula access, witnesser, and more).

## Why

Search parity drift left several OpenAPI-documented filters unavailable in the SDK, so callers could not express the same queries as the UI.

## How

- **Projects**: six new filters on `search()` and `get_all()`; `get_all()` also forwards `metadata_filters` to `search()`.
- **Users**: five new filters on `search()`; `metadata_filters` / `custom_fields` use POST when set (same pattern as tasks).

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_projects.py tests/collections/test_users.py -n 4 -v`

## SDK Changes

Adds optional search filters to `ProjectCollection.search()` / `get_all()` and `UserCollection.search()`.