### PR TITLE
feat(collections): add missing search filters for attributes and btinsight

### DIFF
--- a/src/albert/collections/attributes.py
+++ b/src/albert/collections/attributes.py
@@ -325,6 +325,10 @@ class AttributeCollection(BaseCollection):
         parameter: list[str] | None = None,
         unit: list[str] | None = None,
         data_type: list[DataType] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: list[str] | None = None,
+        contains_text: list[str] | None = None,
         max_items: int | None = None,
     ) -> Iterator[AttributeSearchItem]:
         """Search the central attribute catalogue.
@@ -350,6 +354,14 @@ class AttributeCollection(BaseCollection):
             Filter by unit name(s) (e.g., ``["cP", "MPa"]``).
         data_type : list[DataType], optional
             Filter by data type(s).
+        facet_text : str, optional
+            Facet text to search for.
+        facet_field : str, optional
+            Facet field to filter on.
+        contains_field : list[str], optional
+            Fields to search inside.
+        contains_text : list[str], optional
+            Values to search for within the ``contains_field``.
         max_items : int, optional
             Maximum number of items to return.
 
@@ -373,6 +385,14 @@ class AttributeCollection(BaseCollection):
             body["unit"] = unit
         if data_type is not None:
             body["dataType"] = data_type
+        if facet_text is not None:
+            body["facetText"] = facet_text
+        if facet_field is not None:
+            body["facetField"] = facet_field
+        if contains_field is not None:
+            body["containsField"] = contains_field
+        if contains_text is not None:
+            body["containsText"] = contains_text
 
         return AlbertPaginator(
             path=f"{self.base_path}/search",

--- a/src/albert/collections/btinsight.py
+++ b/src/albert/collections/btinsight.py
@@ -163,6 +163,8 @@ class BTInsightCollection(BaseCollection):
         to_created_at: str | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        model_session: str | list[str] | None = None,
+        tag: str | list[str] | None = None,
         offset: int | None = None,
         max_items: int | None = None,
     ) -> Iterator[BTInsight]:
@@ -211,6 +213,10 @@ class BTInsightCollection(BaseCollection):
             Only include insights updated on or after this date (ISO 8601).
         to_updated_at : str, optional
             Only include insights updated on or before this date (ISO 8601).
+        model_session : str or list[str], optional
+            Filter by model session ID(s) (format ``MDS...``).
+        tag : str or list[str], optional
+            Filter by tag name(s).
         max_items : int, optional
             Maximum number of items to return in total. If None, iterates over all
             matches.
@@ -239,6 +245,8 @@ class BTInsightCollection(BaseCollection):
         params["toCreatedAt"] = to_created_at
         params["fromUpdatedAt"] = from_updated_at
         params["toUpdatedAt"] = to_updated_at
+        params["modelSession"] = ensure_list(model_session)
+        params["tag"] = ensure_list(tag)
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,


### PR DESCRIPTION
## What

Callers can use facet/contains filters on attribute search and filter BT insights by model session and tag.

## Why

The API exposes these search parameters but the SDK omitted them, limiting parity with backend search.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_attributes.py tests/collections/test_btinsight.py -n 4 -v`

## SDK Changes

Adds facet/contains filters to `AttributeCollection.search()` and `model_session` / `tag` to `BTInsightCollection.search()`.