### PR TITLE
feat(collections): add missing search filters for data templates and parameter groups

### DIFF
--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -384,6 +384,16 @@ class DataTemplateCollection(BaseCollection):
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        is_drop_down: bool | None = None,
+        sort_by: str | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        search_field: list[str] | None = None,
+        search_query_string: str | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         max_items: int | None = None,
         offset: int | None = 0,
@@ -435,6 +445,26 @@ class DataTemplateCollection(BaseCollection):
             Only include templates updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
+        is_drop_down : bool, optional
+            When True, apply smart dropdown search behavior.
+        sort_by : str, optional
+            Attribute to sort results by.
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        search_field : list[str], optional
+            Restrict which fields the name query searches.
+        search_query_string : str, optional
+            Filter by custom field query string.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        source_field : list[str], optional
+            Restrict which fields are returned in search results.
         order_by : OrderBy, optional
             The order in which to sort results. Default is ``DESCENDING``.
         max_items : int, optional
@@ -453,10 +483,19 @@ class DataTemplateCollection(BaseCollection):
             "order": order_by,
             "text": name,
             "userId": user_id,
+            "isDropDown": is_drop_down,
+            "sortBy": sort_by,
             "owner": ensure_list(owner),
             "tags": ensure_list(tags),
             "dataColumns": ensure_list(data_columns),
             "standardOrganization": ensure_list(standard_organization),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "searchField": ensure_list(search_field),
+            "searchQueryString": search_query_string,
+            "sourceField": ensure_list(source_field),
             "createdBy": ensure_list(created_by),
             "fromCreatedAt": from_created_at,
             "toCreatedAt": to_created_at,
@@ -471,6 +510,8 @@ class DataTemplateCollection(BaseCollection):
         }
         if metadata_filters is not None:
             payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
@@ -710,6 +751,16 @@ class DataTemplateCollection(BaseCollection):
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        is_drop_down: bool | None = None,
+        sort_by: str | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        search_field: list[str] | None = None,
+        search_query_string: str | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        source_field: list[str] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         max_items: int | None = None,
         offset: int | None = 0,
@@ -760,6 +811,26 @@ class DataTemplateCollection(BaseCollection):
             Only include templates updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
+        is_drop_down : bool, optional
+            When True, apply smart dropdown search behavior.
+        sort_by : str, optional
+            Attribute to sort results by.
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        search_field : list[str], optional
+            Restrict which fields the name query searches.
+        search_query_string : str, optional
+            Filter by custom field query string.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        source_field : list[str], optional
+            Restrict which fields are returned in search results.
         order_by : OrderBy, optional
             The order in which to sort results. Default is ``DESCENDING``.
         max_items : int, optional
@@ -787,6 +858,16 @@ class DataTemplateCollection(BaseCollection):
             from_updated_at=from_updated_at,
             to_updated_at=to_updated_at,
             metadata_filters=metadata_filters,
+            is_drop_down=is_drop_down,
+            sort_by=sort_by,
+            facet_text=facet_text,
+            facet_field=facet_field,
+            contains_field=contains_field,
+            contains_text=contains_text,
+            search_field=search_field,
+            search_query_string=search_query_string,
+            custom_fields=custom_fields,
+            source_field=source_field,
             order_by=order_by,
             max_items=max_items,
             offset=offset,

--- a/src/albert/collections/parameter_groups.py
+++ b/src/albert/collections/parameter_groups.py
@@ -10,7 +10,7 @@ from albert.core.logging import logger
 from albert.core.pagination import AlbertPaginator, MappedPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import ParameterGroupId
+from albert.core.shared.identifiers import ParameterGroupId, UserId
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError
 from albert.resources.parameter_groups import (
@@ -186,6 +186,19 @@ class ParameterGroupCollection(BaseCollection):
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        user_id: UserId | None = None,
+        is_drop_down: bool | None = None,
+        sort_by: str | None = None,
+        data_template: list[str] | None = None,
+        parameter_group: str | None = None,
+        source_field: list[str] | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        is_sam: bool | None = None,
+        search_query_string: str | None = None,
+        custom_fields: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         offset: int | None = None,
         max_items: int | None = None,
@@ -246,6 +259,32 @@ class ParameterGroupCollection(BaseCollection):
             Only include groups updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
+        user_id : UserId, optional
+            Filter by the ID of an associated user.
+        is_drop_down : bool, optional
+            When True, apply smart dropdown search behavior.
+        sort_by : str, optional
+            Attribute to sort results by.
+        data_template : list[str], optional
+            Filter by data template name(s) for smart dropdown search.
+        parameter_group : str, optional
+            Filter by parameter group name for smart dropdown search.
+        source_field : list[str], optional
+            Restrict which fields are returned in search results.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        is_sam : bool, optional
+            When True, filter to equipment-linked parameter groups.
+        search_query_string : str, optional
+            Filter by custom field query string.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         max_items : int, optional
@@ -262,6 +301,18 @@ class ParameterGroupCollection(BaseCollection):
             "offset": offset,
             "order": order_by,
             "text": text,
+            "userId": user_id,
+            "isDropDown": is_drop_down,
+            "sortBy": sort_by,
+            "dataTemplate": ensure_list(data_template),
+            "parameterGroup": parameter_group,
+            "sourceField": ensure_list(source_field),
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "isSAM": is_sam,
+            "searchQueryString": search_query_string,
             "types": ensure_list(types),
             "owner": ensure_list(owner),
             "tags": ensure_list(tags),
@@ -280,6 +331,8 @@ class ParameterGroupCollection(BaseCollection):
         }
         if metadata_filters is not None:
             payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
@@ -310,6 +363,19 @@ class ParameterGroupCollection(BaseCollection):
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        user_id: UserId | None = None,
+        is_drop_down: bool | None = None,
+        sort_by: str | None = None,
+        data_template: list[str] | None = None,
+        parameter_group: str | None = None,
+        source_field: list[str] | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        is_sam: bool | None = None,
+        search_query_string: str | None = None,
+        custom_fields: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         offset: int | None = None,
         max_items: int | None = None,
@@ -361,6 +427,32 @@ class ParameterGroupCollection(BaseCollection):
             Only include groups updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
+        user_id : UserId, optional
+            Filter by the ID of an associated user.
+        is_drop_down : bool, optional
+            When True, apply smart dropdown search behavior.
+        sort_by : str, optional
+            Attribute to sort results by.
+        data_template : list[str], optional
+            Filter by data template name(s) for smart dropdown search.
+        parameter_group : str, optional
+            Filter by parameter group name for smart dropdown search.
+        source_field : list[str], optional
+            Restrict which fields are returned in search results.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        is_sam : bool, optional
+            When True, filter to equipment-linked parameter groups.
+        search_query_string : str, optional
+            Filter by custom field query string.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
         order_by : OrderBy, optional
             Sort direction. Default ``OrderBy.DESCENDING``.
         max_items : int, optional
@@ -396,6 +488,19 @@ class ParameterGroupCollection(BaseCollection):
                 from_updated_at=from_updated_at,
                 to_updated_at=to_updated_at,
                 metadata_filters=metadata_filters,
+                user_id=user_id,
+                is_drop_down=is_drop_down,
+                sort_by=sort_by,
+                data_template=data_template,
+                parameter_group=parameter_group,
+                source_field=source_field,
+                contains_field=contains_field,
+                contains_text=contains_text,
+                facet_text=facet_text,
+                facet_field=facet_field,
+                is_sam=is_sam,
+                search_query_string=search_query_string,
+                custom_fields=custom_fields,
                 order_by=order_by,
                 offset=offset,
                 max_items=max_items,


### PR DESCRIPTION
## What

Data template and parameter group search now expose the full OpenAPI filter set (facets, dropdown mode, SAM flag, custom fields, and more).

## Why

DAT and PG search endpoints support richer filtering than the SDK exposed.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_data_templates.py tests/collections/test_parameter_groups.py -n 4 -v`

## SDK Changes

Adds missing search filters to `DataTemplateCollection` and `ParameterGroupCollection` (`search()` and `get_all()` where applicable).