### PR TITLE
feat(collections): add missing search filters for tasks and lots

### DIFF
--- a/src/albert/collections/lots.py
+++ b/src/albert/collections/lots.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from decimal import Decimal
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import validate_call
 
@@ -294,6 +294,19 @@ class LotCollection(BaseCollection):
         search_field: str | list[str] | None = None,
         source_field: str | list[str] | None = None,
         additional_field: str | list[str] | None = None,
+        contains_field: list[str] | None = None,
+        contains_text: list[str] | None = None,
+        created_by: list[str] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        inventory: list[str] | None = None,
+        location: list[str] | None = None,
+        storage_location: list[str] | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        owner: list[str] | None = None,
+        status: list[str] | None = None,
+        to_expiration_date: str | None = None,
         is_drop_down: bool | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
@@ -341,6 +354,32 @@ class LotCollection(BaseCollection):
             Restrict which fields are returned in the response.
         additional_field : str or list[str], optional
             Request additional columns from the search index.
+        contains_field : list[str], optional
+            Fields to search inside.
+        contains_text : list[str], optional
+            Values to search for within ``contains_field``.
+        created_by : list[str], optional
+            Filter by creator display name(s) or UserId(s).
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values. Requires POST search.
+        facet_field : str, optional
+            Facet field to filter on.
+        facet_text : str, optional
+            Facet text to search for.
+        inventory : list[str], optional
+            Filter by parent inventory name(s).
+        location : list[str], optional
+            Filter by location name(s).
+        storage_location : list[str], optional
+            Filter by storage location name(s).
+        metadata_filters : dict[str, Any], optional
+            Filter by custom field (metadata) values. Requires POST search.
+        owner : list[str], optional
+            Filter by lot owner display name(s) or UserId(s).
+        status : list[str], optional
+            Filter by lot status values.
+        to_expiration_date : str, optional
+            Only include lots expiring on or before this date (ISO 8601).
         is_drop_down : bool, optional
             Apply dropdown sanitization to the search text when True.
         order_by : OrderBy, optional
@@ -359,7 +398,7 @@ class LotCollection(BaseCollection):
 
         search_text = text if (text is None or len(text) < 50) else text[:50]
 
-        params = {
+        params: dict[str, Any] = {
             "offset": offset,
             "order": order_by,
             "text": search_text,
@@ -375,6 +414,41 @@ class LotCollection(BaseCollection):
             "sourceField": ensure_list(source_field),
             "additionalField": ensure_list(additional_field),
         }
+
+        post_only_params: dict[str, Any] = {
+            "containsField": contains_field,
+            "containsText": contains_text,
+            "createdBy": created_by,
+            "facetField": facet_field,
+            "facetText": facet_text,
+            "inventory": inventory,
+            "location": location,
+            "storageLocation": storage_location,
+            "owner": owner,
+            "status": status,
+            "toExpirationDate": to_expiration_date,
+        }
+
+        deserialize = lambda items: [
+            LotSearchItem(**item)._bind_collection(self) for item in items
+        ]
+
+        if metadata_filters is not None or custom_fields is not None:
+            payload: dict[str, Any] = {**params, **post_only_params}
+            if metadata_filters is not None:
+                payload["metadataFilters"] = {"metadata": metadata_filters}
+            if custom_fields is not None:
+                payload["customFields"] = {"metadata": custom_fields}
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=f"{self.base_path}/search",
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
+
         params = {key: value for key, value in params.items() if value is not None}
 
         return AlbertPaginator(
@@ -383,9 +457,7 @@ class LotCollection(BaseCollection):
             session=self.session,
             params=params,
             max_items=max_items,
-            deserialize=lambda items: [
-                LotSearchItem(**item)._bind_collection(self) for item in items
-            ],
+            deserialize=deserialize,
         )
 
     @validate_call

--- a/src/albert/collections/lots.py
+++ b/src/albert/collections/lots.py
@@ -361,7 +361,7 @@ class LotCollection(BaseCollection):
         created_by : list[str], optional
             Filter by creator display name(s) or UserId(s).
         custom_fields : dict[str, Any], optional
-            Filter by custom field values. Requires POST search.
+            Filter by custom field values.
         facet_field : str, optional
             Facet field to filter on.
         facet_text : str, optional
@@ -373,7 +373,7 @@ class LotCollection(BaseCollection):
         storage_location : list[str], optional
             Filter by storage location name(s).
         metadata_filters : dict[str, Any], optional
-            Filter by custom field (metadata) values. Requires POST search.
+            Filter by custom field (metadata) values.
         owner : list[str], optional
             Filter by lot owner display name(s) or UserId(s).
         status : list[str], optional
@@ -433,31 +433,20 @@ class LotCollection(BaseCollection):
             LotSearchItem(**item)._bind_collection(self) for item in items
         ]
 
-        if metadata_filters is not None or custom_fields is not None:
-            payload: dict[str, Any] = {**params, **post_only_params}
-            if metadata_filters is not None:
-                payload["metadataFilters"] = {"metadata": metadata_filters}
-            if custom_fields is not None:
-                payload["customFields"] = {"metadata": custom_fields}
-            return AlbertPaginator(
-                mode=PaginationMode.OFFSET,
-                path=f"{self.base_path}/search",
-                session=self.session,
-                max_items=max_items,
-                deserialize=deserialize,
-                method="POST",
-                json=payload,
-            )
-
-        params = {key: value for key, value in params.items() if value is not None}
+        payload: dict[str, Any] = {**params, **post_only_params}
+        if metadata_filters is not None:
+            payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
 
         return AlbertPaginator(
             mode=PaginationMode.OFFSET,
             path=f"{self.base_path}/search",
             session=self.session,
-            params=params,
             max_items=max_items,
             deserialize=deserialize,
+            method="POST",
+            json=payload,
         )
 
     @validate_call

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -848,6 +848,9 @@ class TaskCollection(BaseCollection):
             TaskSearchItem(**item)._bind_collection(self) for item in items
         ]
 
+        # TODO(SDK-89): always POST task search once POST SearchTask accepts
+        # updatedBy, fromUpdatedAt, and toUpdatedAt.
+
         if metadata_filters is not None:
             payload: dict[str, Any] = {
                 **params,

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -689,8 +689,8 @@ class TaskCollection(BaseCollection):
         due_date_duration: str | None = None,
         facet_field: str | None = None,
         facet_text: str | None = None,
-        has_attachment: bool | None = None,
-        has_notes: bool | None = None,
+        has_attachment: str | list[str] | None = None,
+        has_notes: str | list[str] | None = None,
         linked_to: list[str] | None = None,
         source_field: str | list[str] | None = None,
         witness_status: list[str] | None = None,
@@ -776,10 +776,10 @@ class TaskCollection(BaseCollection):
             Facet field to filter on.
         facet_text : str, optional
             Facet text to search for.
-        has_attachment : bool, optional
-            When set, filter tasks by attachment presence.
-        has_notes : bool, optional
-            When set, filter tasks by note presence.
+        has_attachment : str or list[str], optional
+            Filter tasks by attachment presence.
+        has_notes : str or list[str], optional
+            Filter tasks by note presence.
         linked_to : list[str], optional
             Filter by linked entity ID(s).
         source_field : str or list[str], optional
@@ -834,8 +834,8 @@ class TaskCollection(BaseCollection):
             "dueDateDuration": due_date_duration,
             "facetField": facet_field,
             "facetText": facet_text,
-            "hasAttachment": has_attachment,
-            "hasNotes": has_notes,
+            "hasAttachment": ensure_list(has_attachment),
+            "hasNotes": ensure_list(has_notes),
             "linkedTo": linked_to,
             "sourceField": ensure_list(source_field),
             "witnessStatus": witness_status,
@@ -903,8 +903,8 @@ class TaskCollection(BaseCollection):
         due_date_duration: str | None = None,
         facet_field: str | None = None,
         facet_text: str | None = None,
-        has_attachment: bool | None = None,
-        has_notes: bool | None = None,
+        has_attachment: str | list[str] | None = None,
+        has_notes: str | list[str] | None = None,
         linked_to: list[str] | None = None,
         source_field: str | list[str] | None = None,
         witness_status: list[str] | None = None,
@@ -990,10 +990,10 @@ class TaskCollection(BaseCollection):
             Facet field to filter on.
         facet_text : str, optional
             Facet text to search for.
-        has_attachment : bool, optional
-            When set, filter tasks by attachment presence.
-        has_notes : bool, optional
-            When set, filter tasks by note presence.
+        has_attachment : str or list[str], optional
+            Filter tasks by attachment presence.
+        has_notes : str or list[str], optional
+            Filter tasks by note presence.
         linked_to : list[str], optional
             Filter by linked entity ID(s).
         source_field : str or list[str], optional

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -670,6 +670,7 @@ class TaskCollection(BaseCollection):
         albert_id: list[str] | None = None,
         data_template: list[str] | None = None,
         assigned_to: list[str] | None = None,
+        assigned_to_id: list[str] | None = None,
         location: list[str] | None = None,
         priority: list[str] | None = None,
         status: list[str] | None = None,
@@ -681,6 +682,18 @@ class TaskCollection(BaseCollection):
         updated_by: str | list[str] | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        additional_field: str | list[str] | None = None,
+        collaborator_pop_up: bool | None = None,
+        contains_field: list[str] | None = None,
+        contains_text: list[str] | None = None,
+        due_date_duration: str | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        has_attachment: bool | None = None,
+        has_notes: bool | None = None,
+        linked_to: list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        witness_status: list[str] | None = None,
         metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
@@ -747,6 +760,32 @@ class TaskCollection(BaseCollection):
             Only include items updated on or after this date (ISO 8601).
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
+        assigned_to_id : list[str], optional
+            Filter by assigned user ID(s) (e.g. ``"USR4227"``).
+        additional_field : str or list[str], optional
+            Request additional columns from the search index.
+        collaborator_pop_up : bool, optional
+            When True, restrict results for the collaborator pop-up UI.
+        contains_field : list[str], optional
+            Fields to search inside.
+        contains_text : list[str], optional
+            Values to search for within ``contains_field``.
+        due_date_duration : str, optional
+            Filter by due date duration bucket.
+        facet_field : str, optional
+            Facet field to filter on.
+        facet_text : str, optional
+            Facet text to search for.
+        has_attachment : bool, optional
+            When set, filter tasks by attachment presence.
+        has_notes : bool, optional
+            When set, filter tasks by note presence.
+        linked_to : list[str], optional
+            Filter by linked entity ID(s).
+        source_field : str or list[str], optional
+            Restrict which fields are returned in the response.
+        witness_status : list[str], optional
+            Filter by witness status (e.g. ``"witnessed"``).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
         order_by : OrderBy, optional
@@ -776,6 +815,7 @@ class TaskCollection(BaseCollection):
             "albertId": albert_id,
             "dataTemplate": data_template,
             "assignedTo": assigned_to,
+            "assignedToId": assigned_to_id,
             "location": location,
             "priority": priority,
             "status": status,
@@ -787,6 +827,18 @@ class TaskCollection(BaseCollection):
             "updatedBy": ensure_list(updated_by),
             "fromUpdatedAt": from_updated_at,
             "toUpdatedAt": to_updated_at,
+            "additionalField": ensure_list(additional_field),
+            "collaboratorPopUp": collaborator_pop_up,
+            "containsField": contains_field,
+            "containsText": contains_text,
+            "dueDateDuration": due_date_duration,
+            "facetField": facet_field,
+            "facetText": facet_text,
+            "hasAttachment": has_attachment,
+            "hasNotes": has_notes,
+            "linkedTo": linked_to,
+            "sourceField": ensure_list(source_field),
+            "witnessStatus": witness_status,
         }
 
         category_values = ensure_list(category)
@@ -832,6 +884,7 @@ class TaskCollection(BaseCollection):
         albert_id: list[str] | None = None,
         data_template: list[str] | None = None,
         assigned_to: list[str] | None = None,
+        assigned_to_id: list[str] | None = None,
         location: list[str] | None = None,
         priority: list[str] | None = None,
         status: list[str] | None = None,
@@ -843,6 +896,18 @@ class TaskCollection(BaseCollection):
         updated_by: str | list[str] | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        additional_field: str | list[str] | None = None,
+        collaborator_pop_up: bool | None = None,
+        contains_field: list[str] | None = None,
+        contains_text: list[str] | None = None,
+        due_date_duration: str | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        has_attachment: bool | None = None,
+        has_notes: bool | None = None,
+        linked_to: list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        witness_status: list[str] | None = None,
         metadata_filters: dict[str, Any] | None = None,
         order_by: OrderBy = OrderBy.DESCENDING,
         sort_by: str | None = None,
@@ -909,6 +974,32 @@ class TaskCollection(BaseCollection):
             Only include items updated on or after this date (ISO 8601).
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
+        assigned_to_id : list[str], optional
+            Filter by assigned user ID(s) (e.g. ``"USR4227"``).
+        additional_field : str or list[str], optional
+            Request additional columns from the search index.
+        collaborator_pop_up : bool, optional
+            When True, restrict results for the collaborator pop-up UI.
+        contains_field : list[str], optional
+            Fields to search inside.
+        contains_text : list[str], optional
+            Values to search for within ``contains_field``.
+        due_date_duration : str, optional
+            Filter by due date duration bucket.
+        facet_field : str, optional
+            Facet field to filter on.
+        facet_text : str, optional
+            Facet text to search for.
+        has_attachment : bool, optional
+            When set, filter tasks by attachment presence.
+        has_notes : bool, optional
+            When set, filter tasks by note presence.
+        linked_to : list[str], optional
+            Filter by linked entity ID(s).
+        source_field : str or list[str], optional
+            Restrict which fields are returned in the response.
+        witness_status : list[str], optional
+            Filter by witness status (e.g. ``"witnessed"``).
         metadata_filters : dict[str, Any], optional
             Filter by custom field (metadata) values.
         order_by : OrderBy, optional
@@ -946,6 +1037,7 @@ class TaskCollection(BaseCollection):
                 albert_id=albert_id,
                 data_template=data_template,
                 assigned_to=assigned_to,
+                assigned_to_id=assigned_to_id,
                 location=location,
                 priority=priority,
                 status=status,
@@ -957,6 +1049,18 @@ class TaskCollection(BaseCollection):
                 updated_by=updated_by,
                 from_updated_at=from_updated_at,
                 to_updated_at=to_updated_at,
+                additional_field=additional_field,
+                collaborator_pop_up=collaborator_pop_up,
+                contains_field=contains_field,
+                contains_text=contains_text,
+                due_date_duration=due_date_duration,
+                facet_field=facet_field,
+                facet_text=facet_text,
+                has_attachment=has_attachment,
+                has_notes=has_notes,
+                linked_to=linked_to,
+                source_field=source_field,
+                witness_status=witness_status,
                 metadata_filters=metadata_filters,
                 order_by=order_by,
                 sort_by=sort_by,


### PR DESCRIPTION
## What

Task search gains UI-oriented filters (facets, witness status, due date, attachments, and more). Lot search gains a POST path for metadata/custom-field and facet filters.

## Why

Task and lot APIs document filters the SDK did not expose; lots POST `/search` was entirely unavailable.

## How

- **Tasks**: 13 new filters on `search()`; `get_all()` inherits them via delegation.
- **Lots**: POST `/search` when `metadata_filters` or `custom_fields` is set, with POST-only filters; GET path unchanged.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_tasks.py tests/collections/test_lots.py -n 4 -v`

## SDK Changes

Expands `TaskCollection.search()` and adds POST-based lot search filters on `LotCollection.search()`.