### PR TITLE
feat(inventory): add missing search filters for parity with API

### DIFF
--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -1081,11 +1081,11 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filter by custom field (metadata) values (POST search only).
+            Filter by custom field (metadata) values.
         albert_id : str or list[str], optional
             Filter by Albert ID(s).
         attribute_id : str or list[str], optional
-            Filter by attribute ID(s). Cannot be combined with POST-only filters (``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, ``composite_search``).
+            Filter by attribute ID(s). Cannot be combined with ``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, or ``composite_search``.
         cas_smile : str or list[str], optional
             Filter by CAS SMILES string(s).
         collaborator_pop_up : bool, optional
@@ -1148,13 +1148,13 @@ class InventoryCollection(BaseCollection):
         to_on_hand : str, optional
             Maximum on-hand quantity filter.
         custom_fields : dict[str, Any], optional
-            Filter by custom field values (POST search only).
+            Filter by custom field values.
         additional_field : str or list[str], optional
-            Request additional columns from the search index (POST search only).
+            Request additional columns from the search index.
         project_facets : dict[str, Any], optional
-            Project facet filters (POST search only).
+            Project facet filters.
         composite_search : dict[str, Any], optional
-            Composite search specification (POST search only).
+            Composite search specification.
 
         Returns
         -------
@@ -1368,11 +1368,11 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filter by custom field (metadata) values (POST search only).
+            Filter by custom field (metadata) values.
         albert_id : str or list[str], optional
             Filter by Albert ID(s).
         attribute_id : str or list[str], optional
-            Filter by attribute ID(s). Cannot be combined with POST-only filters (``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, ``composite_search``).
+            Filter by attribute ID(s). Cannot be combined with ``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, or ``composite_search``.
         cas_smile : str or list[str], optional
             Filter by CAS SMILES string(s).
         collaborator_pop_up : bool, optional
@@ -1435,13 +1435,13 @@ class InventoryCollection(BaseCollection):
         to_on_hand : str, optional
             Maximum on-hand quantity filter.
         custom_fields : dict[str, Any], optional
-            Filter by custom field values (POST search only).
+            Filter by custom field values.
         additional_field : str or list[str], optional
-            Request additional columns from the search index (POST search only).
+            Request additional columns from the search index.
         project_facets : dict[str, Any], optional
-            Project facet filters (POST search only).
+            Project facet filters.
         composite_search : dict[str, Any], optional
-            Composite search specification (POST search only).
+            Composite search specification.
 
         Returns
         -------

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -571,7 +571,7 @@ class InventoryCollection(BaseCollection):
         contains_field: str | list[str] | None = None,
         contains_text: str | list[str] | None = None,
         created_by_id: str | list[str] | None = None,
-        details: str | list[str] | None = None,
+        details: bool | None = None,
         drop_down_text: str | None = None,
         drop_down_text_prop: str | None = None,
         dup_detection: bool | None = None,
@@ -592,7 +592,7 @@ class InventoryCollection(BaseCollection):
         source_field: str | list[str] | None = None,
         status: str | list[str] | None = None,
         sub_category: str | list[str] | None = None,
-        synthesis_product_created: bool | None = None,
+        synthesis_product_created: str | list[str] | None = None,
         to_expiration_date: str | None = None,
         to_lot_created_at: str | None = None,
         to_on_hand: str | None = None,
@@ -658,7 +658,7 @@ class InventoryCollection(BaseCollection):
             "containsField": ensure_list(contains_field),
             "containsText": ensure_list(contains_text),
             "createdById": ensure_list(created_by_id),
-            "details": ensure_list(details),
+            "details": details,
             "dropDownText": drop_down_text,
             "dropDownTextProp": drop_down_text_prop,
             "dupDetection": dup_detection,
@@ -679,7 +679,7 @@ class InventoryCollection(BaseCollection):
             "sourceField": ensure_list(source_field),
             "status": ensure_list(status),
             "subCategory": ensure_list(sub_category),
-            "synthesisProductCreated": synthesis_product_created,
+            "synthesisProductCreated": ensure_list(synthesis_product_created),
             "toExpirationDate": to_expiration_date,
             "toLotCreatedAt": to_lot_created_at,
             "toOnHand": to_on_hand,
@@ -718,6 +718,7 @@ class InventoryCollection(BaseCollection):
                     "composite_search)."
                 )
             payload: dict[str, Any] = dict(query_params)
+            payload.pop("attributeId", None)
             if metadata_filters is not None:
                 payload["metadataFilters"] = {"metadata": metadata_filters}
             if custom_fields is not None:
@@ -966,7 +967,7 @@ class InventoryCollection(BaseCollection):
         contains_field: str | list[str] | None = None,
         contains_text: str | list[str] | None = None,
         created_by_id: str | list[str] | None = None,
-        details: str | list[str] | None = None,
+        details: bool | None = None,
         drop_down_text: str | None = None,
         drop_down_text_prop: str | None = None,
         dup_detection: bool | None = None,
@@ -987,7 +988,7 @@ class InventoryCollection(BaseCollection):
         source_field: str | list[str] | None = None,
         status: str | list[str] | None = None,
         sub_category: str | list[str] | None = None,
-        synthesis_product_created: bool | None = None,
+        synthesis_product_created: str | list[str] | None = None,
         to_expiration_date: str | None = None,
         to_lot_created_at: str | None = None,
         to_on_hand: str | None = None,
@@ -1089,8 +1090,8 @@ class InventoryCollection(BaseCollection):
             Text value(s) paired with ``contains_field``.
         created_by_id : str or list[str], optional
             Filter by creator UserId(s).
-        details : str or list[str], optional
-            Filter by detail field value(s).
+        details : bool, optional
+            Invoke custom logic for the worksheet details view.
         drop_down_text : str, optional
             Dropdown search text.
         drop_down_text_prop : str, optional
@@ -1132,8 +1133,8 @@ class InventoryCollection(BaseCollection):
             Filter by status value(s).
         sub_category : str or list[str], optional
             Filter by sub-category.
-        synthesis_product_created : bool, optional
-            Filter by synthesis product creation flag.
+        synthesis_product_created : str or list[str], optional
+            Filter by synthesis product creation value(s).
         to_expiration_date : str, optional
             Only include lots expiring on or before this date (``YYYY-MM-DD``).
         to_lot_created_at : str, optional
@@ -1258,7 +1259,7 @@ class InventoryCollection(BaseCollection):
         contains_field: str | list[str] | None = None,
         contains_text: str | list[str] | None = None,
         created_by_id: str | list[str] | None = None,
-        details: str | list[str] | None = None,
+        details: bool | None = None,
         drop_down_text: str | None = None,
         drop_down_text_prop: str | None = None,
         dup_detection: bool | None = None,
@@ -1279,7 +1280,7 @@ class InventoryCollection(BaseCollection):
         source_field: str | list[str] | None = None,
         status: str | list[str] | None = None,
         sub_category: str | list[str] | None = None,
-        synthesis_product_created: bool | None = None,
+        synthesis_product_created: str | list[str] | None = None,
         to_expiration_date: str | None = None,
         to_lot_created_at: str | None = None,
         to_on_hand: str | None = None,
@@ -1376,8 +1377,8 @@ class InventoryCollection(BaseCollection):
             Text value(s) paired with ``contains_field``.
         created_by_id : str or list[str], optional
             Filter by creator UserId(s).
-        details : str or list[str], optional
-            Filter by detail field value(s).
+        details : bool, optional
+            Invoke custom logic for the worksheet details view.
         drop_down_text : str, optional
             Dropdown search text.
         drop_down_text_prop : str, optional
@@ -1419,8 +1420,8 @@ class InventoryCollection(BaseCollection):
             Filter by status value(s).
         sub_category : str or list[str], optional
             Filter by sub-category.
-        synthesis_product_created : bool, optional
-            Filter by synthesis product creation flag.
+        synthesis_product_created : str or list[str], optional
+            Filter by synthesis product creation value(s).
         to_expiration_date : str, optional
             Only include lots expiring on or before this date (``YYYY-MM-DD``).
         to_lot_created_at : str, optional

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -700,6 +700,7 @@ class InventoryCollection(BaseCollection):
         project_facets: dict[str, Any] | None = None,
         composite_search: dict[str, Any] | None = None,
     ) -> AlbertPaginator:
+        # TODO(SDK-90): always POST inventory search once POST SearchInventory accepts attributeId.
         uses_post = any(
             value is not None
             for value in (
@@ -717,8 +718,13 @@ class InventoryCollection(BaseCollection):
                     "(metadata_filters, custom_fields, additional_field, project_facets, "
                     "composite_search)."
                 )
+            if query_params.get("attributeId") is not None:
+                raise ValueError(
+                    "attribute_id cannot be used with POST-only search filters "
+                    "(metadata_filters, custom_fields, additional_field, project_facets, "
+                    "composite_search)."
+                )
             payload: dict[str, Any] = dict(query_params)
-            payload.pop("attributeId", None)
             if metadata_filters is not None:
                 payload["metadataFilters"] = {"metadata": metadata_filters}
             if custom_fields is not None:
@@ -1079,7 +1085,7 @@ class InventoryCollection(BaseCollection):
         albert_id : str or list[str], optional
             Filter by Albert ID(s).
         attribute_id : str or list[str], optional
-            Filter by attribute ID(s).
+            Filter by attribute ID(s). Cannot be combined with POST-only filters (``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, ``composite_search``).
         cas_smile : str or list[str], optional
             Filter by CAS SMILES string(s).
         collaborator_pop_up : bool, optional
@@ -1366,7 +1372,7 @@ class InventoryCollection(BaseCollection):
         albert_id : str or list[str], optional
             Filter by Albert ID(s).
         attribute_id : str or list[str], optional
-            Filter by attribute ID(s).
+            Filter by attribute ID(s). Cannot be combined with POST-only filters (``metadata_filters``, ``custom_fields``, ``additional_field``, ``project_facets``, ``composite_search``).
         cas_smile : str or list[str], optional
             Filter by CAS SMILES string(s).
         collaborator_pop_up : bool, optional

--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -564,6 +564,38 @@ class InventoryCollection(BaseCollection):
         updated_by: str | list[str] | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        albert_id: str | list[str] | None = None,
+        attribute_id: str | list[str] | None = None,
+        cas_smile: str | list[str] | None = None,
+        collaborator_pop_up: bool | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        created_by_id: str | list[str] | None = None,
+        details: str | list[str] | None = None,
+        drop_down_text: str | None = None,
+        drop_down_text_prop: str | None = None,
+        dup_detection: bool | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        from_expiration_date: str | None = None,
+        from_lot_created_at: str | None = None,
+        from_on_hand: str | None = None,
+        gslo_group: str | list[str] | None = None,
+        idh: str | list[str] | None = None,
+        is_pop_up: bool | None = None,
+        lot_created_by: list[User] | User | str | list[str] | None = None,
+        material_category: str | list[str] | None = None,
+        pack_size: str | list[str] | None = None,
+        pictogram_name: str | list[str] | None = None,
+        result: str | list[str] | None = None,
+        rsn: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        status: str | list[str] | None = None,
+        sub_category: str | list[str] | None = None,
+        synthesis_product_created: bool | None = None,
+        to_expiration_date: str | None = None,
+        to_lot_created_at: str | None = None,
+        to_on_hand: str | None = None,
     ):
         if isinstance(cas, Cas):
             cas = [cas]
@@ -578,13 +610,13 @@ class InventoryCollection(BaseCollection):
         if isinstance(storage_location, StorageLocation):
             storage_location = [storage_location]
 
-        # created_by accepts legacy User objects, display names, or UserIds as
-        # strings. User objects prefer display name (matching pre-SEA-158 behavior);
-        # strings pass through unchanged so callers can supply either form.
-        created_by_values: list[str] | None = None
-        if created_by is not None:
+        def _resolve_user_values(
+            value: list[User] | User | str | list[str] | None,
+        ) -> list[str] | None:
+            if value is None:
+                return None
             wire: list[str] = []
-            for item in ensure_list(created_by) or []:
+            for item in ensure_list(value) or []:
                 if isinstance(item, str):
                     if item:
                         wire.append(item)
@@ -592,7 +624,10 @@ class InventoryCollection(BaseCollection):
                     resolved = item.name or item.id
                     if resolved:
                         wire.append(resolved)
-            created_by_values = wire or None
+            return wire or None
+
+        created_by_values = _resolve_user_values(created_by)
+        lot_created_by_values = _resolve_user_values(lot_created_by)
 
         params = {
             "text": text,
@@ -616,9 +651,104 @@ class InventoryCollection(BaseCollection):
             "updatedBy": ensure_list(updated_by),
             "fromUpdatedAt": from_updated_at if from_updated_at is not None else None,
             "toUpdatedAt": to_updated_at if to_updated_at is not None else None,
+            "albertId": ensure_list(albert_id),
+            "attributeId": ensure_list(attribute_id),
+            "casSmile": ensure_list(cas_smile),
+            "collaboratorPopUp": collaborator_pop_up,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "createdById": ensure_list(created_by_id),
+            "details": ensure_list(details),
+            "dropDownText": drop_down_text,
+            "dropDownTextProp": drop_down_text_prop,
+            "dupDetection": dup_detection,
+            "facetField": facet_field,
+            "facetText": facet_text,
+            "fromExpirationDate": from_expiration_date,
+            "fromLotCreatedAt": from_lot_created_at,
+            "fromOnHand": from_on_hand,
+            "gsloGroup": ensure_list(gslo_group),
+            "idh": ensure_list(idh),
+            "isPopUp": is_pop_up,
+            "lotCreatedBy": lot_created_by_values,
+            "materialCategory": ensure_list(material_category),
+            "packSize": ensure_list(pack_size),
+            "pictogramName": ensure_list(pictogram_name),
+            "result": ensure_list(result),
+            "rsn": ensure_list(rsn),
+            "sourceField": ensure_list(source_field),
+            "status": ensure_list(status),
+            "subCategory": ensure_list(sub_category),
+            "synthesisProductCreated": synthesis_product_created,
+            "toExpirationDate": to_expiration_date,
+            "toLotCreatedAt": to_lot_created_at,
+            "toOnHand": to_on_hand,
         }
 
         return params
+
+    def _paginate_inventory_search(
+        self,
+        *,
+        deserialize,
+        query_params: dict[str, Any],
+        match_all_conditions: bool,
+        max_items: int | None,
+        metadata_filters: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        additional_field: str | list[str] | None = None,
+        project_facets: dict[str, Any] | None = None,
+        composite_search: dict[str, Any] | None = None,
+    ) -> AlbertPaginator:
+        uses_post = any(
+            value is not None
+            for value in (
+                metadata_filters,
+                custom_fields,
+                additional_field,
+                project_facets,
+                composite_search,
+            )
+        )
+        if uses_post:
+            if match_all_conditions:
+                raise ValueError(
+                    "match_all_conditions cannot be used with POST-only search filters "
+                    "(metadata_filters, custom_fields, additional_field, project_facets, "
+                    "composite_search)."
+                )
+            payload: dict[str, Any] = dict(query_params)
+            if metadata_filters is not None:
+                payload["metadataFilters"] = {"metadata": metadata_filters}
+            if custom_fields is not None:
+                payload["customFields"] = {"metadata": custom_fields}
+            if additional_field is not None:
+                payload["additionalField"] = ensure_list(additional_field)
+            if project_facets is not None:
+                payload["projectFacets"] = project_facets
+            if composite_search is not None:
+                payload["compositeSearch"] = composite_search
+            return AlbertPaginator(
+                mode=PaginationMode.OFFSET,
+                path=f"{self.base_path}/search",
+                session=self.session,
+                max_items=max_items,
+                deserialize=deserialize,
+                method="POST",
+                json=payload,
+            )
+
+        path = (
+            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
+        )
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=path,
+            params=query_params,
+            session=self.session,
+            max_items=max_items,
+            deserialize=deserialize,
+        )
 
     @validate_call
     def get_all_facets(
@@ -829,7 +959,43 @@ class InventoryCollection(BaseCollection):
         updated_by: str | list[str] | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        albert_id: str | list[str] | None = None,
+        attribute_id: str | list[str] | None = None,
+        cas_smile: str | list[str] | None = None,
+        collaborator_pop_up: bool | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        created_by_id: str | list[str] | None = None,
+        details: str | list[str] | None = None,
+        drop_down_text: str | None = None,
+        drop_down_text_prop: str | None = None,
+        dup_detection: bool | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        from_expiration_date: str | None = None,
+        from_lot_created_at: str | None = None,
+        from_on_hand: str | None = None,
+        gslo_group: str | list[str] | None = None,
+        idh: str | list[str] | None = None,
+        is_pop_up: bool | None = None,
+        lot_created_by: list[User] | User | str | list[str] | None = None,
+        material_category: str | list[str] | None = None,
+        pack_size: str | list[str] | None = None,
+        pictogram_name: str | list[str] | None = None,
+        result: str | list[str] | None = None,
+        rsn: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        status: str | list[str] | None = None,
+        sub_category: str | list[str] | None = None,
+        synthesis_product_created: bool | None = None,
+        to_expiration_date: str | None = None,
+        to_lot_created_at: str | None = None,
+        to_on_hand: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        additional_field: str | list[str] | None = None,
+        project_facets: dict[str, Any] | None = None,
+        composite_search: dict[str, Any] | None = None,
     ) -> Iterator[InventorySearchItem]:
         """Search for inventory items matching the given filters.
 
@@ -908,7 +1074,80 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filter by custom field (metadata) values.
+            Filter by custom field (metadata) values (POST search only).
+        albert_id : str or list[str], optional
+            Filter by Albert ID(s).
+        attribute_id : str or list[str], optional
+            Filter by attribute ID(s).
+        cas_smile : str or list[str], optional
+            Filter by CAS SMILES string(s).
+        collaborator_pop_up : bool, optional
+            Apply collaborator popup search behavior.
+        contains_field : str or list[str], optional
+            Field(s) for contains-style filtering.
+        contains_text : str or list[str], optional
+            Text value(s) paired with ``contains_field``.
+        created_by_id : str or list[str], optional
+            Filter by creator UserId(s).
+        details : str or list[str], optional
+            Filter by detail field value(s).
+        drop_down_text : str, optional
+            Dropdown search text.
+        drop_down_text_prop : str, optional
+            Dropdown search property name.
+        dup_detection : bool, optional
+            Enable duplicate-detection text sanitization.
+        facet_field : str, optional
+            Facet field to filter on.
+        facet_text : str, optional
+            Facet text to match.
+        from_expiration_date : str, optional
+            Only include lots expiring on or after this date (``YYYY-MM-DD``).
+        from_lot_created_at : str, optional
+            Only include lots created on or after this date (``YYYY-MM-DD``).
+        from_on_hand : str, optional
+            Minimum on-hand quantity filter.
+        gslo_group : str or list[str], optional
+            Filter by GSLO group(s).
+        idh : str or list[str], optional
+            Filter by IDH value(s).
+        is_pop_up : bool, optional
+            Apply popup search behavior.
+        lot_created_by : User, list[User], str, or list[str], optional
+            Filter by lot creator. Accepts display name(s), UserId(s), or
+            [`User`][albert.resources.users.User] object(s).
+        material_category : str or list[str], optional
+            Filter by material category.
+        pack_size : str or list[str], optional
+            Filter by pack size.
+        pictogram_name : str or list[str], optional
+            Filter by pictogram name(s).
+        result : str or list[str], optional
+            Filter by result value(s).
+        rsn : str or list[str], optional
+            Filter by RSN value(s).
+        source_field : str or list[str], optional
+            Restrict which fields are returned in search results.
+        status : str or list[str], optional
+            Filter by status value(s).
+        sub_category : str or list[str], optional
+            Filter by sub-category.
+        synthesis_product_created : bool, optional
+            Filter by synthesis product creation flag.
+        to_expiration_date : str, optional
+            Only include lots expiring on or before this date (``YYYY-MM-DD``).
+        to_lot_created_at : str, optional
+            Only include lots created on or before this date (``YYYY-MM-DD``).
+        to_on_hand : str, optional
+            Maximum on-hand quantity filter.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values (POST search only).
+        additional_field : str or list[str], optional
+            Request additional columns from the search index (POST search only).
+        project_facets : dict[str, Any], optional
+            Project facet filters (POST search only).
+        composite_search : dict[str, Any], optional
+            Composite search specification (POST search only).
 
         Returns
         -------
@@ -941,35 +1180,50 @@ class InventoryCollection(BaseCollection):
             updated_by=updated_by,
             from_updated_at=from_updated_at,
             to_updated_at=to_updated_at,
+            albert_id=albert_id,
+            attribute_id=attribute_id,
+            cas_smile=cas_smile,
+            collaborator_pop_up=collaborator_pop_up,
+            contains_field=contains_field,
+            contains_text=contains_text,
+            created_by_id=created_by_id,
+            details=details,
+            drop_down_text=drop_down_text,
+            drop_down_text_prop=drop_down_text_prop,
+            dup_detection=dup_detection,
+            facet_field=facet_field,
+            facet_text=facet_text,
+            from_expiration_date=from_expiration_date,
+            from_lot_created_at=from_lot_created_at,
+            from_on_hand=from_on_hand,
+            gslo_group=gslo_group,
+            idh=idh,
+            is_pop_up=is_pop_up,
+            lot_created_by=lot_created_by,
+            material_category=material_category,
+            pack_size=pack_size,
+            pictogram_name=pictogram_name,
+            result=result,
+            rsn=rsn,
+            source_field=source_field,
+            status=status,
+            sub_category=sub_category,
+            synthesis_product_created=synthesis_product_created,
+            to_expiration_date=to_expiration_date,
+            to_lot_created_at=to_lot_created_at,
+            to_on_hand=to_on_hand,
         )
 
-        if metadata_filters is not None:
-            if match_all_conditions:
-                raise ValueError("match_all_conditions cannot be used with metadata_filters.")
-            payload: dict[str, Any] = {
-                **query_params,
-                "metadataFilters": {"metadata": metadata_filters},
-            }
-            return AlbertPaginator(
-                mode=PaginationMode.OFFSET,
-                path=f"{self.base_path}/search",
-                session=self.session,
-                max_items=max_items,
-                deserialize=deserialize,
-                method="POST",
-                json=payload,
-            )
-
-        path = (
-            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
-        )
-        return AlbertPaginator(
-            mode=PaginationMode.OFFSET,
-            path=path,
-            params=query_params,
-            session=self.session,
-            max_items=max_items,
+        return self._paginate_inventory_search(
             deserialize=deserialize,
+            query_params=query_params,
+            match_all_conditions=match_all_conditions,
+            max_items=max_items,
+            metadata_filters=metadata_filters,
+            custom_fields=custom_fields,
+            additional_field=additional_field,
+            project_facets=project_facets,
+            composite_search=composite_search,
         )
 
     @validate_call
@@ -997,7 +1251,43 @@ class InventoryCollection(BaseCollection):
         updated_by: str | list[str] | None = None,
         from_updated_at: str | None = None,
         to_updated_at: str | None = None,
+        albert_id: str | list[str] | None = None,
+        attribute_id: str | list[str] | None = None,
+        cas_smile: str | list[str] | None = None,
+        collaborator_pop_up: bool | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        created_by_id: str | list[str] | None = None,
+        details: str | list[str] | None = None,
+        drop_down_text: str | None = None,
+        drop_down_text_prop: str | None = None,
+        dup_detection: bool | None = None,
+        facet_field: str | None = None,
+        facet_text: str | None = None,
+        from_expiration_date: str | None = None,
+        from_lot_created_at: str | None = None,
+        from_on_hand: str | None = None,
+        gslo_group: str | list[str] | None = None,
+        idh: str | list[str] | None = None,
+        is_pop_up: bool | None = None,
+        lot_created_by: list[User] | User | str | list[str] | None = None,
+        material_category: str | list[str] | None = None,
+        pack_size: str | list[str] | None = None,
+        pictogram_name: str | list[str] | None = None,
+        result: str | list[str] | None = None,
+        rsn: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        status: str | list[str] | None = None,
+        sub_category: str | list[str] | None = None,
+        synthesis_product_created: bool | None = None,
+        to_expiration_date: str | None = None,
+        to_lot_created_at: str | None = None,
+        to_on_hand: str | None = None,
         metadata_filters: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        additional_field: str | list[str] | None = None,
+        project_facets: dict[str, Any] | None = None,
+        composite_search: dict[str, Any] | None = None,
     ) -> Iterator[InventoryItem]:
         """Get fully populated inventory items matching the given filters.
 
@@ -1071,7 +1361,80 @@ class InventoryCollection(BaseCollection):
         to_updated_at : str, optional
             Only include items updated on or before this date (ISO 8601).
         metadata_filters : dict[str, Any], optional
-            Filter by custom field (metadata) values.
+            Filter by custom field (metadata) values (POST search only).
+        albert_id : str or list[str], optional
+            Filter by Albert ID(s).
+        attribute_id : str or list[str], optional
+            Filter by attribute ID(s).
+        cas_smile : str or list[str], optional
+            Filter by CAS SMILES string(s).
+        collaborator_pop_up : bool, optional
+            Apply collaborator popup search behavior.
+        contains_field : str or list[str], optional
+            Field(s) for contains-style filtering.
+        contains_text : str or list[str], optional
+            Text value(s) paired with ``contains_field``.
+        created_by_id : str or list[str], optional
+            Filter by creator UserId(s).
+        details : str or list[str], optional
+            Filter by detail field value(s).
+        drop_down_text : str, optional
+            Dropdown search text.
+        drop_down_text_prop : str, optional
+            Dropdown search property name.
+        dup_detection : bool, optional
+            Enable duplicate-detection text sanitization.
+        facet_field : str, optional
+            Facet field to filter on.
+        facet_text : str, optional
+            Facet text to match.
+        from_expiration_date : str, optional
+            Only include lots expiring on or after this date (``YYYY-MM-DD``).
+        from_lot_created_at : str, optional
+            Only include lots created on or after this date (``YYYY-MM-DD``).
+        from_on_hand : str, optional
+            Minimum on-hand quantity filter.
+        gslo_group : str or list[str], optional
+            Filter by GSLO group(s).
+        idh : str or list[str], optional
+            Filter by IDH value(s).
+        is_pop_up : bool, optional
+            Apply popup search behavior.
+        lot_created_by : User, list[User], str, or list[str], optional
+            Filter by lot creator. Accepts display name(s), UserId(s), or
+            [`User`][albert.resources.users.User] object(s).
+        material_category : str or list[str], optional
+            Filter by material category.
+        pack_size : str or list[str], optional
+            Filter by pack size.
+        pictogram_name : str or list[str], optional
+            Filter by pictogram name(s).
+        result : str or list[str], optional
+            Filter by result value(s).
+        rsn : str or list[str], optional
+            Filter by RSN value(s).
+        source_field : str or list[str], optional
+            Restrict which fields are returned in search results.
+        status : str or list[str], optional
+            Filter by status value(s).
+        sub_category : str or list[str], optional
+            Filter by sub-category.
+        synthesis_product_created : bool, optional
+            Filter by synthesis product creation flag.
+        to_expiration_date : str, optional
+            Only include lots expiring on or before this date (``YYYY-MM-DD``).
+        to_lot_created_at : str, optional
+            Only include lots created on or before this date (``YYYY-MM-DD``).
+        to_on_hand : str, optional
+            Maximum on-hand quantity filter.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values (POST search only).
+        additional_field : str or list[str], optional
+            Request additional columns from the search index (POST search only).
+        project_facets : dict[str, Any], optional
+            Project facet filters (POST search only).
+        composite_search : dict[str, Any], optional
+            Composite search specification (POST search only).
 
         Returns
         -------
@@ -1104,35 +1467,50 @@ class InventoryCollection(BaseCollection):
             updated_by=updated_by,
             from_updated_at=from_updated_at,
             to_updated_at=to_updated_at,
+            albert_id=albert_id,
+            attribute_id=attribute_id,
+            cas_smile=cas_smile,
+            collaborator_pop_up=collaborator_pop_up,
+            contains_field=contains_field,
+            contains_text=contains_text,
+            created_by_id=created_by_id,
+            details=details,
+            drop_down_text=drop_down_text,
+            drop_down_text_prop=drop_down_text_prop,
+            dup_detection=dup_detection,
+            facet_field=facet_field,
+            facet_text=facet_text,
+            from_expiration_date=from_expiration_date,
+            from_lot_created_at=from_lot_created_at,
+            from_on_hand=from_on_hand,
+            gslo_group=gslo_group,
+            idh=idh,
+            is_pop_up=is_pop_up,
+            lot_created_by=lot_created_by,
+            material_category=material_category,
+            pack_size=pack_size,
+            pictogram_name=pictogram_name,
+            result=result,
+            rsn=rsn,
+            source_field=source_field,
+            status=status,
+            sub_category=sub_category,
+            synthesis_product_created=synthesis_product_created,
+            to_expiration_date=to_expiration_date,
+            to_lot_created_at=to_lot_created_at,
+            to_on_hand=to_on_hand,
         )
 
-        if metadata_filters is not None:
-            if match_all_conditions:
-                raise ValueError("match_all_conditions cannot be used with metadata_filters.")
-            payload: dict[str, Any] = {
-                **query_params,
-                "metadataFilters": {"metadata": metadata_filters},
-            }
-            return AlbertPaginator(
-                mode=PaginationMode.OFFSET,
-                path=f"{self.base_path}/search",
-                session=self.session,
-                max_items=max_items,
-                deserialize=deserialize,
-                method="POST",
-                json=payload,
-            )
-
-        path = (
-            f"{self.base_path}/llmsearch" if match_all_conditions else f"{self.base_path}/search"
-        )
-        return AlbertPaginator(
-            mode=PaginationMode.OFFSET,
-            path=path,
-            params=query_params,
-            session=self.session,
-            max_items=max_items,
+        return self._paginate_inventory_search(
             deserialize=deserialize,
+            query_params=query_params,
+            match_all_conditions=match_all_conditions,
+            max_items=max_items,
+            metadata_filters=metadata_filters,
+            custom_fields=custom_fields,
+            additional_field=additional_field,
+            project_facets=project_facets,
+            composite_search=composite_search,
         )
 
     def _generate_inventory_patch_payload(


### PR DESCRIPTION
## What

Inventory `search()` and `get_all()` expose the full set of API search filters (on-hand ranges, expiration, facets, hazmat, status, and more).

## Why

Inventory had the largest search filter gap (37+ missing parameters) versus `api-inventory`.

## How

Extended `_prepare_parameters()` and centralized GET vs POST routing. POST triggers when `metadata_filters`, `custom_fields`, `additional_field`, `project_facets`, or `composite_search` is set. `match_all_conditions` / `llmsearch` behavior unchanged.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_inventory.py -n 4 -v`

## SDK Changes

Adds optional inventory search filters across `InventoryCollection.search()` and `get_all()`.