### PR TITLE
fix: keep substance ids and region-scoped fields the substance v4 API returns

### DIFF
--- a/src/albert/resources/product_design.py
+++ b/src/albert/resources/product_design.py
@@ -12,8 +12,25 @@ class CasLevelSubstance(BaseAlbertModel):
     cas_id: str | None = Field(default=None, alias="casID")
     """The CAS identifier for the substance (format ``CAS...``)."""
 
+    substance_id: str | None = Field(default=None, alias="substanceId")
+    """The Regulatory DB substance identifier for this CAS entry.
+
+    Prefer this over ``cas_id`` when looking a substance up in the Regulatory DB
+    (see [`SubstanceV4Collection`][albert.collections.substance_v4.SubstanceV4Collection]):
+    a single CAS number can map to more than one substance record, so the substance
+    ID is the precise key."""
+
+    albert_id: str | None = Field(default=None, alias="albertId")
+    """The Inventory ID of the ingredient this substance was unpacked from."""
+
     amount: float | None = Field(default=None)
     """The amount of this substance in the unpacked composition."""
+
+    min: float | None = Field(default=None)
+    """The minimum proportion of this substance in the unpacked composition."""
+
+    target: float | None = Field(default=None)
+    """The target proportion of this substance in the unpacked composition."""
 
 
 class NormalizedCAS(BaseAlbertModel):
@@ -53,6 +70,9 @@ class UnpackedCasInfo(BaseAlbertModel):
 
     id: str | None = Field(default=None)
     """The Albert identifier for the CAS record."""
+
+    substance_id: str | None = Field(default=None, alias="substanceId")
+    """The Regulatory DB substance identifier for this CAS entry."""
 
     name: str | None = Field(default=None)
     """The name of the CAS substance."""

--- a/src/albert/resources/substance_v4.py
+++ b/src/albert/resources/substance_v4.py
@@ -56,6 +56,12 @@ class SubstanceV4Info(BaseAlbertModel):
     hazards: list[dict] | None = None
     """Hazard classifications."""
 
+    wgk: str | None = Field(None, alias="WGK")
+    """Water hazard class (WGK).
+
+    Only returned when the request is scoped to the German region
+    (``region="DE"``); other regions omit it."""
+
     specific_concentration_limit: list[dict] | None = Field(
         None, alias="specificConcentrationLimit"
     )
@@ -349,11 +355,15 @@ class SubstanceV4Info(BaseAlbertModel):
     pcr_regulated: bool | None = Field(None, alias="pcrRegulated")
     """Whether the substance is PCR regulated."""
 
-    pdscl: str | None = None
-    """PDSCL classification."""
+    pdscl: dict | None = None
+    """PDSCL classification, with keys ``maxValue`` and ``unit``.
 
-    prtr: str | None = None
-    """PRTR classification."""
+    Returned when the request is scoped to the Japanese region (``region="JP"``)."""
+
+    prtr: dict | None = None
+    """PRTR classification, with keys ``className``, ``controlNumber``, ``maxValue`` and ``unit``.
+
+    Returned when the request is scoped to the Japanese region (``region="JP"``)."""
 
     page_number: int | None = Field(None, alias="pageNumber")
     """Reference page number."""

--- a/tests/unit/test_api_response_field_coverage.py
+++ b/tests/unit/test_api_response_field_coverage.py
@@ -1,0 +1,101 @@
+"""Guard that models keep the API response fields their consumers depend on.
+
+``BaseAlbertModel`` does not set an ``extra`` policy, so Pydantic defaults to
+``extra="ignore"`` and any field a model fails to declare is dropped at validation
+and is not recoverable from ``model_extra``. These tests pin the fields that were
+silently lost, using payload fragments recorded from the live API.
+"""
+
+import pytest
+
+from albert.resources.product_design import (
+    CasLevelSubstance,
+    UnpackedCasInfo,
+    UnpackedProductDesign,
+)
+from albert.resources.substance_v4 import SubstanceV4Info, SubstanceV4SearchItem
+
+# Recorded from GET /api/v3/productdesign/DESIGN/unpack?formulaId=INVP603-004
+CAS_LEVEL_SUBSTANCE_PAYLOAD = {
+    "casPrimaryKeyId": "CAS39928",
+    "casID": "68585-34-2",
+    "amount": 0.24642857,
+    "min": 0.19714286,
+    "aggregatedFunc": [],
+    "target": 0,
+    "albertId": "INVA42942",
+    "substanceId": "1f11f9e7-a897-6a80-9724-8f1c8e925e4b",
+}
+
+
+def test_cas_level_substance_keeps_substance_id():
+    """The Regulatory DB key must survive validation, not be dropped as an extra."""
+    substance = CasLevelSubstance.model_validate(CAS_LEVEL_SUBSTANCE_PAYLOAD)
+
+    assert substance.substance_id == "1f11f9e7-a897-6a80-9724-8f1c8e925e4b"
+    assert substance.cas_id == "68585-34-2"
+    assert substance.albert_id == "INVA42942"
+    assert substance.min == pytest.approx(0.19714286)
+    assert substance.target == pytest.approx(0)
+
+
+def test_unpacked_product_design_exposes_substance_ids():
+    """substance_id survives through the top-level unpack response model."""
+    unpacked = UnpackedProductDesign.model_validate(
+        {"casLevelSubstances": [CAS_LEVEL_SUBSTANCE_PAYLOAD]}
+    )
+
+    assert unpacked.cas_level_substances is not None
+    assert unpacked.cas_level_substances[0].substance_id == (
+        "1f11f9e7-a897-6a80-9724-8f1c8e925e4b"
+    )
+
+
+def test_unpacked_cas_info_keeps_substance_id():
+    cas_info = UnpackedCasInfo.model_validate(
+        {"id": "CAS39928", "substanceId": "1f11f9e7-a897-6a80-9724-8f1c8e925e4b"}
+    )
+
+    assert cas_info.substance_id == "1f11f9e7-a897-6a80-9724-8f1c8e925e4b"
+
+
+def test_substance_v4_info_declares_wgk():
+    """``SubstanceV4Info`` must expose WGK as a typed field, matching its search sibling.
+
+    Only ``region="DE"`` returns the field; the models must agree on the attribute
+    name so callers do not need to know which endpoint produced the record.
+    """
+    info = SubstanceV4Info.model_validate({"casID": "64-18-6", "WGK": "WGK 1"})
+    search_item = SubstanceV4SearchItem.model_validate({"casID": "64-18-6", "WGK": "WGK 1"})
+
+    assert info.wgk == "WGK 1"
+    assert search_item.wgk == "WGK 1"
+
+
+def test_substance_v4_info_wgk_absent_outside_german_region():
+    """Regions other than DE omit WGK; the model must not invent a value."""
+    info = SubstanceV4Info.model_validate({"casID": "64-18-6"})
+
+    assert info.wgk is None
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("pdscl", {"maxValue": 1, "unit": "%"}),
+        (
+            "prtr",
+            {
+                "className": "Specified Class 1,Class 1",
+                "unit": "%",
+                "controlNumber": 411,
+                "maxValue": 0.1,
+            },
+        ),
+    ],
+)
+def test_substance_v4_info_accepts_japanese_object_fields(field, value):
+    """``region="JP"`` returns objects for these; typing them as ``str`` raised."""
+    info = SubstanceV4Info.model_validate({"casID": "50-00-0", field: value})
+
+    assert getattr(info, field) == value


### PR DESCRIPTION
## What

The SDK now hands back three pieces of data the Albert API was already sending but the models were throwing away: the Regulatory DB substance id on unpacked formulation constituents, the German water hazard class (`wgk`) on full substance records, and the Japanese `pdscl`/`prtr` objects.

## Why

`BaseAlbertModel` sets no `extra` policy, so Pydantic defaults to `extra="ignore"` and undeclared fields are dropped at validation with no `model_extra` fallback. Consumers could not reach them without bypassing the typed client. Closes SDK-88.

## How

- `CasLevelSubstance` declared 3 of the 8 keys the unpack endpoint returns. Adds `substance_id`, `albert_id`, `min`, `target`. A CAS number is not 1:1 with a Regulatory DB record, so losing `substanceId` forced consumers onto a less precise key.
- `SubstanceV4Info` lacked the `wgk` that `SubstanceV4SearchItem` already declares, so `search()` exposed `.wgk` while `get_by_ids()` did not. Adds it, aliased `WGK`.
- `pdscl`/`prtr` were typed `str` but the API returns objects, so `region="JP"` raised `ValidationError`. Retyped as `dict`.
- Deliberately did **not** set `extra="allow"` as a blanket net. `SubstanceV4Info` already has it and the `wgk` bug still happened: the value arrived under a raw camelCase key that no snake_case lookup matched, which was harder to diagnose than a clean absence. Loosening validation on a public SDK deserves its own decision rather than arriving as a side effect of a bug fix.
- `aggregatedFunc` left undeclared: every sample was an empty array, so its element type could not be determined and guessing would be worse than omitting it.

## Testing

`uv run pytest tests/unit -q` (30 passed). New `tests/unit/test_api_response_field_coverage.py` pins each field against payload fragments recorded from the live API, so a future model edit that drops one fails a test.

Verified live against `app.albertinvent.com`:

- `substances_v4.get_by_id(cas_id="64-18-6", region="DE").wgk == "WGK 1"`, formaldehyde `"WGK 3"`, and `None` at `region="global"` (no fabrication)
- `substances_v4.get_by_ids(cas_ids=["50-00-0"], region="JP")` no longer raises; all of global/US/EU/DE/GB/CN/CA/AU still validate
- unpack of `P603-004` yields substance UUIDs matching `substances_v4.search(cas=...)` exactly

## Downstream

Unblocks AI-1573 in `albert-ai`, which consumes `substance_id` for Regulatory DB lookups.