### PR TITLE
docs(inventory): show security_class on inventory create

### DIFF
--- a/src/albert/collections/inventory.py
+++ b/src/albert/collections/inventory.py
@@ -289,12 +289,14 @@ class InventoryCollection(BaseCollection):
 
         !!! example
             ```python
+            from albert.core.shared.enums import SecurityClass
             from albert.resources.inventory import InventoryItem, InventoryCategory
             from albert.resources.companies import Company
             item = InventoryItem(
                 name="Titanium Dioxide",
                 category=InventoryCategory.RAW_MATERIALS,
                 company=Company(name="Acme Chemicals"),
+                security_class=SecurityClass.SHARED,
             )
             created = client.inventory.create(inventory_item=item)
             created.id
@@ -306,7 +308,8 @@ class InventoryCollection(BaseCollection):
         inventory_item : InventoryItem
             The item to create. ``name`` and ``category`` are required. For raw
             materials, set ``company`` to the manufacturing Company and ``cas`` to
-            the relevant CAS numbers.
+            the relevant CAS numbers. Set ``security_class`` to ``shared``,
+            ``restricted``, or ``confidential``.
         avoid_duplicates : bool, optional
             When True (default), if an item with the same name and company already
             exists, that existing item is returned instead of creating a duplicate.

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -281,12 +281,14 @@ class InventoryItem(BaseTaggedResource):
 
     !!! example
         ```python
+        from albert.core.shared.enums import SecurityClass
         from albert.resources.inventory import InventoryItem, InventoryCategory
 
         item = InventoryItem(
             name="Titanium Dioxide",
             category=InventoryCategory.RAW_MATERIALS,
             company="Acme Chemicals",
+            security_class=SecurityClass.SHARED,
         )
         ```"""
 
@@ -306,7 +308,7 @@ class InventoryItem(BaseTaggedResource):
     """The dimension the item is measured in (mass, volume, length, pressure, or units). If not supplied, it defaults from ``category``: mass for raw materials and formulas, units for equipment and consumables."""
 
     security_class: SecurityClass | None = Field(default=None, alias="class")
-    """The access/security class of the item (e.g. confidential, shared, restricted)."""
+    """Access-control class: ``shared``, ``restricted``, or ``confidential``. Serialized as ``class``."""
 
     company: SerializeAsEntityLink[Company] | None = Field(default=None, alias="Company")
     """The manufacturing Company associated with the item (links to the Company collection). Accepts a [`Company`][albert.resources.companies.Company] or a name string; a string is turned into a Company that is first-or-created on save."""

--- a/tests/collections/test_inventory.py
+++ b/tests/collections/test_inventory.py
@@ -1,10 +1,13 @@
+from contextlib import suppress
+
 import pytest
 
 from albert.client import Albert
 from albert.collections.inventory import InventoryCategory
+from albert.core.shared.enums import SecurityClass
 from albert.core.shared.identifiers import ensure_inventory_id
 from albert.core.shared.models.base import EntityLink
-from albert.exceptions import BadRequestError
+from albert.exceptions import BadRequestError, NotFoundError
 from albert.resources.cas import Cas
 from albert.resources.companies import Company
 from albert.resources.custom_fields import FieldType, ServiceType
@@ -237,6 +240,33 @@ def test_get_by_id_preserves_metadata_list_item_names(
         ]
     finally:
         client.inventory.delete(id=created.id)
+
+
+def test_create_inventory_item_with_security_class(
+    client: Albert,
+    seed_prefix: str,
+    seeded_companies: list[Company],
+):
+    """Test creating an inventory item with a non-default security class."""
+    item = InventoryItem(
+        name=f"{seed_prefix} - Confidential class",
+        category=InventoryCategory.RAW_MATERIALS,
+        company=seeded_companies[0],
+        security_class=SecurityClass.CONFIDENTIAL,
+    )
+    assert item.security_class == SecurityClass.CONFIDENTIAL
+    assert (
+        item.model_dump(by_alias=True, exclude_none=True, mode="json")["class"] == "confidential"
+    )
+
+    created = client.inventory.create(inventory_item=item, avoid_duplicates=False)
+    try:
+        assert created.security_class == SecurityClass.CONFIDENTIAL
+        fetched = client.inventory.get_by_id(id=created.id)
+        assert fetched.security_class == SecurityClass.CONFIDENTIAL
+    finally:
+        with suppress(NotFoundError):
+            client.inventory.delete(id=created.id)
 
 
 def test_get_by_ids(client: Albert, seeded_inventory):


### PR DESCRIPTION
## What

Callers creating inventory can see and use `security_class` (`shared`, `restricted`, or `confidential`) in the create examples. That field already mapped to the API `class` value; it is now documented and covered by a create round-trip test.

## Why

[GitHub #681](https://github.com/albert-labs/albert-python/issues/681): swagger allows `class` on POST inventory, but SDK examples did not show the matching Python field (`security_class`), so it looked unsupported.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_inventory.py -v`

## SDK Changes

`InventoryItem` create examples now set `security_class`. Use `SecurityClass.SHARED`, `RESTRICTED`, or `CONFIDENTIAL`.

Closes #681