### PR TITLE
fix(property_data): recalculate columns on task property upsert

### DIFF
--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -1056,6 +1056,44 @@ class PropertyDataCollection(BaseCollection):
             get_task_block_properties=self.get_task_block_properties,
         )
 
+    def _apply_calculated_task_property_patches(
+        self,
+        *,
+        inventory_id: InventoryId,
+        task_id: TaskId,
+        block_id: BlockId,
+        lot_id: LotId | None,
+        properties: list[TaskPropertyCreate],
+        return_scope: ReturnScope,
+    ) -> list[TaskPropertyData]:
+        """Re-fetch block data and patch calculated columns from current input values."""
+        existing_data_rows = self.get_task_block_properties(
+            inventory_id=inventory_id, task_id=task_id, block_id=block_id, lot_id=lot_id
+        )
+        patches = property_data_utils.form_calculated_task_property_patches(
+            existing_data_rows=existing_data_rows,
+            properties=properties,
+        )
+        if patches:
+            return self.update_property_on_task(
+                task_id=task_id,
+                patch_payload=patches,
+                return_scope=return_scope,
+                inventory_id=inventory_id,
+                block_id=block_id,
+                lot_id=lot_id,
+            )
+        return property_data_utils.resolve_return_scope(
+            task_id=task_id,
+            return_scope=return_scope,
+            inventory_id=inventory_id,
+            block_id=block_id,
+            lot_id=lot_id,
+            prefetched_block=existing_data_rows,
+            get_all_task_properties=self.get_all_task_properties,
+            get_task_block_properties=self.get_task_block_properties,
+        )
+
     @validate_call
     def update_or_create_task_properties(
         self,
@@ -1138,73 +1176,19 @@ class PropertyDataCollection(BaseCollection):
             properties=properties,
         )
 
-        calculated_patches = property_data_utils.form_calculated_task_property_patches(
-            existing_data_rows=existing_data_rows,
-            properties=properties,
-        )
-        all_patches = update_patches + calculated_patches
-        if len(new_values) > 0:
-            if len(all_patches) > 0:
-                self.update_property_on_task(
-                    task_id=task_id,
-                    patch_payload=all_patches,
-                    return_scope="none",
-                    inventory_id=inventory_id,
-                    block_id=block_id,
-                    lot_id=lot_id,
-                )
-            if any(
-                isinstance(prop.value, ImagePropertyValue | CurvePropertyValue)
-                for prop in new_values
-            ):
-                params = {
-                    "blockId": block_id,
-                    "inventoryId": inventory_id,
-                }
-                params = {k: v for k, v in params.items() if v is not None}
-                payload = property_data_utils.resolve_task_property_payload(
-                    session=self.session,
-                    task_id=task_id,
-                    block_id=block_id,
-                    properties=new_values,
-                )
-                response = self.session.post(
-                    url=f"{self.base_path}/{task_id}",
-                    json=payload,
-                    params=params,
-                )
-                registered_properties = [
-                    TaskPropertyCreate(**x) for x in response.json() if "DataTemplate" in x
-                ]
-                existing_data_rows = self.get_task_block_properties(
-                    inventory_id=inventory_id,
-                    task_id=task_id,
-                    block_id=block_id,
-                    lot_id=lot_id,
-                )
-                patches = property_data_utils.form_calculated_task_property_patches(
-                    existing_data_rows=existing_data_rows,
-                    properties=registered_properties,
-                )
-                if len(patches) > 0:
-                    return self.update_property_on_task(
-                        task_id=task_id,
-                        patch_payload=patches,
-                        return_scope=return_scope,
-                        inventory_id=inventory_id,
-                        block_id=block_id,
-                        lot_id=lot_id,
-                    )
-                return property_data_utils.resolve_return_scope(
-                    task_id=task_id,
-                    return_scope=return_scope,
-                    inventory_id=inventory_id,
-                    block_id=block_id,
-                    lot_id=lot_id,
-                    prefetched_block=existing_data_rows,
-                    get_all_task_properties=self.get_all_task_properties,
-                    get_task_block_properties=self.get_task_block_properties,
-                )
+        if not update_patches and not new_values:
+            return property_data_utils.resolve_return_scope(
+                task_id=task_id,
+                return_scope=return_scope,
+                inventory_id=inventory_id,
+                block_id=block_id,
+                lot_id=lot_id,
+                prefetched_block=existing_data_rows,
+                get_all_task_properties=self.get_all_task_properties,
+                get_task_block_properties=self.get_task_block_properties,
+            )
+
+        if not update_patches:
             return self.add_properties_to_task(
                 inventory_id=inventory_id,
                 task_id=task_id,
@@ -1213,15 +1197,32 @@ class PropertyDataCollection(BaseCollection):
                 properties=new_values,
                 return_scope=return_scope,
             )
-        else:
-            return self.update_property_on_task(
-                task_id=task_id,
-                patch_payload=all_patches,
-                return_scope=return_scope,
+
+        self.update_property_on_task(
+            task_id=task_id,
+            patch_payload=update_patches,
+            return_scope="none",
+            inventory_id=inventory_id,
+            block_id=block_id,
+            lot_id=lot_id,
+        )
+        if new_values:
+            self.add_properties_to_task(
                 inventory_id=inventory_id,
+                task_id=task_id,
                 block_id=block_id,
                 lot_id=lot_id,
+                properties=new_values,
+                return_scope="none",
             )
+        return self._apply_calculated_task_property_patches(
+            inventory_id=inventory_id,
+            task_id=task_id,
+            block_id=block_id,
+            lot_id=lot_id,
+            properties=properties,
+            return_scope=return_scope,
+        )
 
     def bulk_load_task_properties(
         self,

--- a/src/albert/utils/property_data.py
+++ b/src/albert/utils/property_data.py
@@ -390,9 +390,60 @@ def form_existing_row_value_patches(
             if prop_patches:
                 patches.extend(prop_patches)
             continue
-        new_properties.append(prop)
+        new_properties.append(
+            prepare_new_task_property(
+                prop=prop,
+                existing_data_rows=existing_data_rows,
+                trial_number=resolved_trial_number,
+            )
+        )
 
     return patches, new_properties
+
+
+def trial_has_recorded_data(
+    *,
+    existing_data_rows: TaskPropertyData,
+    interval_combination: str,
+    trial_number: int,
+) -> bool:
+    """Return True if the trial already has at least one stored property-data value."""
+    trial = get_on_platform_row(
+        existing_data_rows=existing_data_rows,
+        interval_combination=interval_combination,
+        trial_number=trial_number,
+    )
+    if trial is None:
+        return False
+    return any(col.property_data is not None for col in trial.data_columns)
+
+
+def prepare_new_task_property(
+    *,
+    prop: TaskPropertyCreate,
+    existing_data_rows: TaskPropertyData,
+    trial_number: int | None,
+) -> TaskPropertyCreate:
+    """Keep trial_number only when it refers to a trial that already has stored data.
+
+    A block listing can include an empty placeholder trial. That placeholder is
+    not a stored trial, so trial_number is omitted and a new trial is created.
+    If the trial already has data, trial_number is kept so a missing column is
+    added to that trial.
+    """
+    if trial_number is None:
+        return prop
+    if trial_has_recorded_data(
+        existing_data_rows=existing_data_rows,
+        interval_combination=prop.interval_combination,
+        trial_number=trial_number,
+    ):
+        if prop.trial_number == trial_number:
+            return prop
+        return prop.model_copy(update={"trial_number": trial_number})
+    if prop.trial_number is None:
+        return prop
+    return prop.model_copy(update={"trial_number": None})
 
 
 def process_property(
@@ -528,7 +579,15 @@ def form_calculated_task_property_patches(
         first_row_data_column=first_row_data_column
     )
     for posted_prop in properties:
-        this_interval_trial = f"{posted_prop.interval_combination}-{posted_prop.trial_number}"
+        trial_number = posted_prop.trial_number
+        if trial_number is None:
+            trial_number = resolve_trial_number(
+                prop=posted_prop,
+                existing_data_rows=existing_data_rows,
+            )
+        if trial_number is None:
+            continue
+        this_interval_trial = f"{posted_prop.interval_combination}-{trial_number}"
         if (
             this_interval_trial in covered_interval_trials
             or posted_prop.data_column.column_sequence not in columns_used_in_calculations
@@ -536,7 +595,7 @@ def form_calculated_task_property_patches(
             continue
         on_platform_row = get_on_platform_row(
             existing_data_rows=existing_data_rows,
-            trial_number=posted_prop.trial_number,
+            trial_number=trial_number,
             interval_combination=posted_prop.interval_combination,
         )
         if on_platform_row is not None:
@@ -669,7 +728,7 @@ def generate_data_patch_payload(*, trial: Trial) -> list[PropertyDataPatchDatum]
 
     patch_data = []
     for column in trial.data_columns:
-        if column.calculation:
+        if column.calculation and column.property_data is not None:
             recalculated_value = evaluate_calculation(
                 calculation=column.calculation, column_values=column_values
             )

--- a/tests/collections/test_property_data.py
+++ b/tests/collections/test_property_data.py
@@ -374,3 +374,186 @@ def test_task_property_calculation_evaluation(
         for dc_id in calc_dc_ids:
             with suppress(NotFoundError):
                 client.data_columns.delete(id=dc_id)
+
+
+def test_update_or_create_task_property_calculation_evaluation(
+    client: Albert,
+    seed_prefix: str,
+    seeded_inventory,
+    seeded_lots,
+    seeded_locations,
+    seeded_projects,
+    seeded_workflows,
+):
+    """Test update_or_create_task_properties on an empty trial, then recalculates."""
+    calc_task_id = None
+    calc_dt_id = None
+    calc_dc_ids = []
+
+    try:
+        dc_one = client.data_columns.create(
+            data_column=DataColumn(name=f"{seed_prefix} - upsert calc col one")
+        )
+        dc_two = client.data_columns.create(
+            data_column=DataColumn(name=f"{seed_prefix} - upsert calc col two")
+        )
+        dc_calc = client.data_columns.create(
+            data_column=DataColumn(name=f"{seed_prefix} - upsert calc col result")
+        )
+        calc_dc_ids = [dc_one.id, dc_two.id, dc_calc.id]
+
+        calc_dt = client.data_templates.create(
+            data_template=DataTemplate(
+                name=f"{seed_prefix} - upsert calc dt",
+                description="Integration test template for calculated columns via upsert.",
+                data_column_values=[
+                    DataColumnValue(
+                        data_column=dc_one,
+                    ),
+                    DataColumnValue(
+                        data_column=dc_two,
+                    ),
+                ],
+            )
+        )
+        calc_dt_id = calc_dt.id
+        sequence_by_id = {col.data_column_id: col.sequence for col in calc_dt.data_column_values}
+        seq_one = sequence_by_id[dc_one.id]
+        seq_two = sequence_by_id[dc_two.id]
+        calc_dt = client.data_templates.add_data_columns(
+            data_template_id=calc_dt.id,
+            data_columns=[
+                DataColumnValue(
+                    data_column=dc_calc,
+                    calculation=f"={seq_one}+sqrt({seq_two})",
+                )
+            ],
+        )
+        sequence_by_id = {col.data_column_id: col.sequence for col in calc_dt.data_column_values}
+        seq_calc = sequence_by_id[dc_calc.id]
+
+        lot = next(
+            (l for l in seeded_lots if l.inventory_id == seeded_inventory[0].id),
+            None,
+        )
+        workflow = seeded_workflows[0]
+
+        calc_task = client.tasks.create(
+            task=PropertyTask(
+                name=f"{seed_prefix} - upsert calc task",
+                category=TaskCategory.PROPERTY,
+                inventory_information=[
+                    TaskInventoryInformation(
+                        inventory_id=seeded_inventory[0].id,
+                        lot_id=lot.id if lot else None,
+                    )
+                ],
+                parent_id=seeded_inventory[0].id,
+                location=seeded_locations[0],
+                project=seeded_projects[0],
+                blocks=[
+                    Block(
+                        workflow=[workflow],
+                        data_template=[calc_dt],
+                    )
+                ],
+            )
+        )
+        calc_task_id = calc_task.id
+        calc_task = client.tasks.get_by_id(id=calc_task_id)
+        block_id = calc_task.blocks[0].id
+        block = client.property_data.get_task_block_properties(
+            inventory_id=seeded_inventory[0].id,
+            task_id=calc_task_id,
+            block_id=block_id,
+            lot_id=lot.id if lot else None,
+        )
+        interval_id = block.data[0].interval_combination
+        trial_number = block.data[0].trials[0].trial_number
+
+        seed_result = client.property_data.update_or_create_task_properties(
+            task_id=calc_task_id,
+            inventory_id=seeded_inventory[0].id,
+            block_id=block_id,
+            lot_id=lot.id if lot else None,
+            properties=[
+                TaskPropertyCreate(
+                    interval_combination=interval_id,
+                    data_template=calc_dt,
+                    data_column=TaskDataColumn(
+                        data_column_id=dc_one.id,
+                        column_sequence=seq_one,
+                    ),
+                    value="5",
+                    trial_number=trial_number,
+                ),
+                TaskPropertyCreate(
+                    interval_combination=interval_id,
+                    data_template=calc_dt,
+                    data_column=TaskDataColumn(
+                        data_column_id=dc_two.id,
+                        column_sequence=seq_two,
+                    ),
+                    value="16",
+                    trial_number=trial_number,
+                ),
+            ],
+            return_scope="block",
+        )
+        seeded_trial = max(
+            (
+                t
+                for t in seed_result[0].data[0].trials
+                if t.data_columns[0].property_data is not None
+            ),
+            key=lambda t: t.trial_number,
+        )
+        trial_number = seeded_trial.trial_number
+        calc_column = next(c for c in seeded_trial.data_columns if c.sequence == seq_calc)
+        assert calc_column.property_data is not None
+        assert float(calc_column.property_data.value) == pytest.approx(9.0)
+
+        result = client.property_data.update_or_create_task_properties(
+            task_id=calc_task_id,
+            inventory_id=seeded_inventory[0].id,
+            block_id=block_id,
+            lot_id=lot.id if lot else None,
+            properties=[
+                TaskPropertyCreate(
+                    interval_combination=interval_id,
+                    data_template=calc_dt,
+                    data_column=TaskDataColumn(
+                        data_column_id=dc_one.id,
+                        column_sequence=seq_one,
+                    ),
+                    value="10",
+                    trial_number=trial_number,
+                ),
+                TaskPropertyCreate(
+                    interval_combination=interval_id,
+                    data_template=calc_dt,
+                    data_column=TaskDataColumn(
+                        data_column_id=dc_two.id,
+                        column_sequence=seq_two,
+                    ),
+                    value="16",
+                    trial_number=trial_number,
+                ),
+            ],
+            return_scope="block",
+        )
+
+        trial = next(t for t in result[0].data[0].trials if t.trial_number == trial_number)
+        calc_column = next(c for c in trial.data_columns if c.sequence == seq_calc)
+        assert calc_column.property_data is not None
+        assert float(calc_column.property_data.value) == pytest.approx(14.0)
+    finally:
+        if calc_task_id:
+            with suppress(NotFoundError):
+                client.tasks.delete(id=calc_task_id)
+        if calc_dt_id:
+            with suppress(NotFoundError):
+                client.data_templates.delete(id=calc_dt_id)
+        for dc_id in calc_dc_ids:
+            with suppress(NotFoundError):
+                client.data_columns.delete(id=dc_id)


### PR DESCRIPTION
## What

`update_or_create_task_properties` now fills calculated columns after writing values, including when updating an existing trial. Passing `trial_number` on an empty placeholder row creates a real trial instead of failing.

## Why

Callers writing results into a data template with formulas saw calculated cells stay blank or stale (`#664`). `add_properties_to_task` already filled those columns; upsert did not.

## How

Write input values first, re-read the trial, then patch formula columns from the fresh values. New rows go through `add_properties_to_task` so image and curve creates get the same calculation path. Placeholder `trial_number` values (no stored data yet) are omitted so the first row can be created.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_property_data.py -v`
- Live repro on `dev.albertinventdev.com`: first write `5,16` → calc `9`; update existing trial to `10,16` → calc `14`; skeleton `trial_number=1` no longer 400s.
- Added `test_update_or_create_task_property_calculation_evaluation`. Full-file pytest setup failed on an unrelated `POST /parametergroups` seeding error (`One or more Units do not exist!`).

## SDK Changes

`update_or_create_task_properties` now recalculates formula columns after upserts, matching `add_properties_to_task`.