### PR TITLE
feat(workflows): add search method

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,7 @@ Offset search endpoints (projects, tasks, lots, inventories, datatemplates, para
 
 Rule of thumb: if you already have an `AlbertPaginator`, return it. Reach for `MappedPaginator` / `MetadataPreservingIterator` only when a plain generator would strip `has_more` / `total`.
 
-**`offset` and `limit` are never exposed as method parameters.** They are internal pagination state managed entirely by `AlbertPaginator`. Never add `offset` or `limit` to a public method signature or docstring. Use `max_items` as the only caller-facing pagination control.
+**`offset` and `limit` are never exposed as method parameters.** They are internal pagination state managed entirely by `AlbertPaginator`. Never add `offset` or `limit` to a public method signature or docstring. Collection methods must not set `limit` or `offset` in search/list payloads (query params or POST JSON); pass filters only and let `AlbertPaginator` inject page size and continuation. Use `max_items` as the only caller-facing pagination control.
 
 ## Testing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,7 +125,9 @@ Offset search endpoints (projects, tasks, lots, inventories, datatemplates, para
 
 Rule of thumb: if you already have an `AlbertPaginator`, return it. Reach for `MappedPaginator` / `MetadataPreservingIterator` only when a plain generator would strip `has_more` / `total`.
 
-**`offset` and `limit` are never exposed as method parameters.** They are internal pagination state managed entirely by `AlbertPaginator`. Never add `offset` or `limit` to a public method signature or docstring. Collection methods must not set `limit` or `offset` in search/list payloads (query params or POST JSON); pass filters only and let `AlbertPaginator` inject page size and continuation. Use `max_items` as the only caller-facing pagination control.
+**`offset` and `limit` are never exposed as method parameters.** They are internal pagination state managed entirely by `AlbertPaginator`. Never add `offset` or `limit` to a public method signature or docstring. Use `max_items` as the only caller-facing pagination control.
+
+Exception: when a backend caps page size below `DEFAULT_LIMIT` (1000), set `limit` in the search/list payload (or paginator params) to that cap so the first request is valid (see `substance_v4`, `workflows`). Collections still must not expose `limit` as a public method parameter.
 
 ## Testing
 

--- a/OPINIONS.md
+++ b/OPINIONS.md
@@ -54,6 +54,8 @@ never public method parameters; `max_items` is the only caller-facing control.
 Why: exposing raw pagination params leaks backend details, invites misuse, and
 diverges from the SDK's iterator-style API.
 
+Some endpoints reject `limit` above a fixed cap (e.g. workflow search `<= 100`, substance v4 search `<= 20`). Set a module-level page-size constant and pass `limit` in the payload or paginator params to that cap; `AlbertPaginator` still owns `offset` and must not surface `limit` on the public collection method.
+
 ## Paginators — override _response_items for non-standard response keys
 
 `AlbertPaginator._response_items` defaults to reading `data["Items"]` or

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -472,7 +472,6 @@ class WorkflowCollection(BaseCollection):
             [`Workflow`][albert.resources.workflows.Workflow].
         """
         payload: dict[str, Any] = {
-            "limit": 100,
             "order": order_by,
             "text": text,
             "status": ensure_list(status),

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -19,6 +19,8 @@ from albert.resources.workflows import (
     WorkflowSearchItem,
 )
 
+_SEARCH_PAGE_SIZE = 100  # maximum page size accepted by the workflow search endpoint
+
 
 class WorkflowCollection(BaseCollection):
     """Manage Workflows in the Albert platform.
@@ -492,6 +494,7 @@ class WorkflowCollection(BaseCollection):
             "fromCreatedAt": from_created_at,
             "toCreatedAt": to_created_at,
             "sortBy": sort_by,
+            "limit": _SEARCH_PAGE_SIZE,
         }
         if parameter_set is not None:
             payload["parameterSet"] = [

--- a/src/albert/collections/workflows.py
+++ b/src/albert/collections/workflows.py
@@ -1,4 +1,5 @@
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import validate_call
 
@@ -7,10 +8,16 @@ from albert.collections.data_templates import DataTemplateCollection
 from albert.collections.parameter_groups import ParameterGroupCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
-from albert.core.shared.enums import PaginationMode
+from albert.core.shared.enums import OrderBy, PaginationMode, Status
 from albert.core.shared.identifiers import WorkflowId
+from albert.core.utils import ensure_list
 from albert.resources.parameter_groups import DataType, ParameterValue
-from albert.resources.workflows import ParameterSetpoint, Workflow
+from albert.resources.workflows import (
+    ParameterSetpoint,
+    Workflow,
+    WorkflowParameterSet,
+    WorkflowSearchItem,
+)
 
 
 class WorkflowCollection(BaseCollection):
@@ -89,6 +96,8 @@ class WorkflowCollection(BaseCollection):
         Get multiple workflows by their IDs in batches.
     get_all(max_items=None) -> Iterator[Workflow]
         Iterate over all workflows (rarely needed in production).
+    search(...) -> Iterator[WorkflowSearchItem]
+        Search for workflows matching the given filters.
     """
 
     _api_version = "v3"
@@ -361,4 +370,144 @@ class WorkflowCollection(BaseCollection):
             session=self.session,
             deserialize=deserialize,
             max_items=max_items,
+        )
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        status: Status | list[Status] | None = None,
+        created_by: str | list[str] | None = None,
+        ids: WorkflowId | list[WorkflowId] | None = None,
+        data_templates: str | list[str] | None = None,
+        data_template_ids: str | list[str] | None = None,
+        parameter_groups: str | list[str] | None = None,
+        parameter_group_ids: str | list[str] | None = None,
+        parameters: str | list[str] | None = None,
+        unit: str | list[str] | None = None,
+        parameter_set: list[WorkflowParameterSet] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        search_field: list[str] | None = None,
+        source_field: list[str] | None = None,
+        from_created_at: str | None = None,
+        to_created_at: str | None = None,
+        sort_by: str | None = None,
+        order_by: OrderBy = OrderBy.DESCENDING,
+        max_items: int | None = None,
+    ) -> Iterator[WorkflowSearchItem]:
+        """Search for workflows matching the given filters.
+
+        This is the fast path: it returns partial (unhydrated)
+        [`WorkflowSearchItem`][albert.resources.workflows.WorkflowSearchItem] hits and is
+        best for lookups, counts, and pulling IDs. To retrieve fully populated
+        workflows, use [`get_by_id`][albert.collections.workflows.WorkflowCollection.get_by_id]
+        or call `hydrate()` on a hit. Results are returned lazily as an iterator
+        that pages through the API on demand.
+
+        !!! example
+            ```python
+            for item in client.workflows.search(text="Tensile", max_items=10):
+                print(item.id, item.name)
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query.
+        status : Status or list[Status], optional
+            Filter by workflow status.
+        created_by : str or list[str], optional
+            Filter by creator. Accepts user display name(s) or UserId(s) (e.g.
+            ``"USR4227"`` or ``"Jane Doe"``).
+        ids : WorkflowId or list[WorkflowId], optional
+            Filter by workflow ID(s) (format ``WFL...``).
+        data_templates : str or list[str], optional
+            Filter by data template name(s).
+        data_template_ids : str or list[str], optional
+            Filter by data template ID(s) (format ``DAT...``).
+        parameter_groups : str or list[str], optional
+            Filter by parameter group name(s).
+        parameter_group_ids : str or list[str], optional
+            Filter by parameter group ID(s) (format ``PRG...``).
+        parameters : str or list[str], optional
+            Filter by parameter name(s). Supports inline range syntax such as
+            ``name(value)``, ``name(>n)``, ``name(<n)``, or ``name(min-max)``.
+        unit : str or list[str], optional
+            Filter by unit name(s).
+        parameter_set : list[WorkflowParameterSet], optional
+            Filter by parameter constraints that bind a name, value range, and unit.
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        search_field : list[str], optional
+            Restrict which fields the text query searches.
+        source_field : list[str], optional
+            Restrict which fields are returned in search results.
+        from_created_at : str, optional
+            Only include workflows created on or after this date (ISO 8601).
+        to_created_at : str, optional
+            Only include workflows created on or before this date (ISO 8601).
+        sort_by : str, optional
+            Attribute to sort results by.
+        order_by : OrderBy, optional
+            The order in which to sort results. Default is ``DESCENDING``.
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matching items.
+
+        Returns
+        -------
+        Iterator[WorkflowSearchItem]
+            A lazy iterator of matching partial workflows. Call
+            `hydrate()` on an item to fetch its full
+            [`Workflow`][albert.resources.workflows.Workflow].
+        """
+        payload: dict[str, Any] = {
+            "limit": 100,
+            "order": order_by,
+            "text": text,
+            "status": ensure_list(status),
+            "createdBy": ensure_list(created_by),
+            "albertId": ensure_list(ids),
+            "dataTemplates": ensure_list(data_templates),
+            "dataTemplateIds": ensure_list(data_template_ids),
+            "parameterGroups": ensure_list(parameter_groups),
+            "parameterGroupIds": ensure_list(parameter_group_ids),
+            "parameters": ensure_list(parameters),
+            "unit": ensure_list(unit),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "searchField": ensure_list(search_field),
+            "sourceField": ensure_list(source_field),
+            "fromCreatedAt": from_created_at,
+            "toCreatedAt": to_created_at,
+            "sortBy": sort_by,
+        }
+        if parameter_set is not None:
+            payload["parameterSet"] = [
+                item.model_dump(by_alias=True, mode="json", exclude_none=True)
+                for item in parameter_set
+            ]
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            method="POST",
+            json=payload,
+            max_items=max_items,
+            deserialize=lambda items: [
+                WorkflowSearchItem.model_validate(x)._bind_collection(self) for x in items
+            ],
         )

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -520,8 +520,8 @@ class WorkflowParameterSet(BaseAlbertModel):
     data_template_name: str | None = Field(default=None, alias="dataTemplateName")
     """The name of the data template."""
 
-    category: str | None = None
-    """The parameter category (e.g. ``Normal``)."""
+    category: ParameterCategory | None = None
+    """The category of the parameter: ``SPECIAL`` for an inventory item (Equipment, Consumable, Template), ``NORMAL`` for everything else."""
 
 
 class WorkflowSearchItemGroup(BaseAlbertModel):

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -6,6 +6,7 @@ from typing import Any
 from pydantic import AliasChoices, Field, PrivateAttr, model_validator
 
 from albert.core.base import BaseAlbertModel
+from albert.core.shared.enums import SecurityClass, Status
 from albert.core.shared.identifiers import (
     DataTemplateId,
     IntervalId,
@@ -16,6 +17,7 @@ from albert.core.shared.identifiers import (
 from albert.core.shared.models.base import BaseResource, EntityLink
 from albert.core.shared.types import SerializeAsEntityLink
 from albert.exceptions import AlbertException
+from albert.resources._mixins import HydrationMixin
 from albert.resources.parameter_groups import ParameterGroup
 from albert.resources.parameters import Parameter, ParameterCategory
 from albert.resources.units import Unit
@@ -486,3 +488,96 @@ class Workflow(BaseResource):
             )
 
         return interval_id
+
+
+class WorkflowParameterSet(BaseAlbertModel):
+    """One parameter constraint for workflow search filtering."""
+
+    parameter: str | None = None
+    """Parameter name for filtering. Optional inline range syntax: ``name``, ``name(value)``, ``name(>n)``, ``name(<n)``, or ``name(min-max)``."""
+
+    parameter_short_name: str | None = Field(default=None, alias="parameterShortName")
+    """The short name of the parameter."""
+
+    min: float | None = None
+    """Lower bound on the parameter value."""
+
+    max: float | None = None
+    """Upper bound on the parameter value."""
+
+    unit: str | None = None
+    """The unit name for the parameter value."""
+
+    unit_id: str | None = Field(default=None, alias="unitId")
+    """The unit ID (format ``UNI...``)."""
+
+    parameter_group: str | None = None
+    """The parameter group ID (format ``PRG...``)."""
+
+    parameter_group_name: str | None = Field(default=None, alias="parameterGroupName")
+    """The name of the parameter group."""
+
+    data_template_name: str | None = Field(default=None, alias="dataTemplateName")
+    """The name of the data template."""
+
+    category: str | None = None
+    """The parameter category (e.g. ``Normal``)."""
+
+
+class WorkflowSearchItemGroup(BaseAlbertModel):
+    """A lightweight data template or parameter group reference in a workflow search hit."""
+
+    id: str | None = None
+    """The Albert ID of the group. ``None`` when omitted from the search hit."""
+
+    name: str | None = None
+    """The display name of the group."""
+
+
+class WorkflowSearchItem(BaseAlbertModel, HydrationMixin[Workflow]):
+    """Lightweight workflow search hit.
+
+    Returned by [`search`][albert.collections.workflows.WorkflowCollection.search].
+    Call `hydrate()` to fetch the full
+    [`Workflow`][albert.resources.workflows.Workflow].
+    """
+
+    id: str = Field(alias="albertId", validation_alias=AliasChoices("albertId", "id"))
+    """The Albert ID of the workflow (format ``WFL...``)."""
+
+    name: str
+    """The name of the workflow."""
+
+    status: Status | None = None
+    """The lifecycle status of the workflow."""
+
+    created_by: str | None = Field(default=None, alias="createdBy")
+    """The ID of the user who created the workflow."""
+
+    created_by_name: str | None = Field(default=None, alias="createdByName")
+    """The display name of the user who created the workflow."""
+
+    created_at: str | None = Field(default=None, alias="createdAt")
+    """ISO 8601 timestamp of when the workflow was created."""
+
+    resource_class: SecurityClass | None = Field(default=None, alias="resourceClass")
+    """The security class of the workflow."""
+
+    data_template_ids: list[str] | None = Field(default=None, alias="dataTemplateIds")
+    """IDs of data templates linked to the workflow."""
+
+    parameter_group_ids: list[str] | None = Field(default=None, alias="parameterGroupIds")
+    """IDs of parameter groups linked to the workflow."""
+
+    parameter_ids: list[str] | None = Field(default=None, alias="parameterIds")
+    """IDs of parameters linked to the workflow."""
+
+    data_templates: list[WorkflowSearchItemGroup] | None = Field(
+        default=None, alias="dataTemplates"
+    )
+    """Data templates linked to the workflow."""
+
+    parameter_groups: list[WorkflowSearchItemGroup] | None = Field(
+        default=None, alias="parameterGroups"
+    )
+    """Parameter groups linked to the workflow."""

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -1,17 +1,10 @@
 import pytest
 
 from albert import Albert
-from albert.exceptions import NotFoundError
 from albert.resources.workflows import Workflow, WorkflowSearchItem
 from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("tasks")
-
-search_not_deployed = pytest.mark.xfail(
-    reason="POST /api/v3/workflows/search is not yet deployed (api-workflow#129). Remove decorator once live.",
-    raises=NotFoundError,
-    strict=False,
-)
 
 
 def test_workflow_get_all_with_pagination(client: Albert, seeded_workflows: list[Workflow]):
@@ -36,7 +29,6 @@ def test_blocks_dupes(client: Albert, seeded_workflows: list[Workflow]):
     assert r[0].id == seeded_workflows[0].id
 
 
-@search_not_deployed
 def test_workflow_search_basic(client: Albert, seeded_workflows: list[Workflow]):
     """Test search returns WorkflowSearchItem results with WFL ids."""
     results = list(client.workflows.search(max_items=10))
@@ -47,7 +39,6 @@ def test_workflow_search_basic(client: Albert, seeded_workflows: list[Workflow])
         assert item.name
 
 
-@search_not_deployed
 def test_workflow_search_by_text(
     client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
 ):
@@ -63,7 +54,6 @@ def test_workflow_search_by_text(
     assert hits, "Expected at least one seeded workflow in text search results"
 
 
-@search_not_deployed
 def test_workflow_search_by_ids(client: Albert, seeded_workflows: list[Workflow]):
     """Test search by workflow ids returns seeded workflows."""
     seeded_ids = {wf.id for wf in seeded_workflows}
@@ -78,7 +68,6 @@ def test_workflow_search_by_ids(client: Albert, seeded_workflows: list[Workflow]
     assert {item.id for item in hits}.issubset(seeded_ids)
 
 
-@search_not_deployed
 def test_workflow_search_hydrate(
     client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
 ):
@@ -99,7 +88,6 @@ def test_workflow_search_hydrate(
     assert hydrated.name == hits[0].name
 
 
-@search_not_deployed
 def test_workflow_search_by_parameter_groups(
     client: Albert,
     seed_prefix: str,

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -102,11 +102,13 @@ def test_workflow_search_by_parameter_groups(
     client: Albert,
     seed_prefix: str,
     seeded_workflows: list[Workflow],
-    seeded_parameter_groups,
 ):
     """Test search by parameter group name scoped to seeded workflow ids."""
-    seeded_ids = {wf.id for wf in seeded_workflows}
-    group_name = seeded_parameter_groups[0].name
+    wf = client.workflows.get_by_id(id=seeded_workflows[0].id)
+    assert wf.parameter_group_setpoints, "Seeded workflow should have parameter groups"
+    group_name = wf.parameter_group_setpoints[0].parameter_group_name
+
+    seeded_ids = {item.id for item in seeded_workflows}
     hits = poll_until(
         lambda: [
             item

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -1,9 +1,17 @@
 import pytest
 
 from albert import Albert
-from albert.resources.workflows import Workflow
+from albert.exceptions import NotFoundError
+from albert.resources.workflows import Workflow, WorkflowSearchItem
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("tasks")
+
+search_not_deployed = pytest.mark.xfail(
+    reason="POST /api/v3/workflows/search is not yet deployed (api-workflow#129). Remove decorator once live.",
+    raises=NotFoundError,
+    strict=False,
+)
 
 
 def test_workflow_get_all_with_pagination(client: Albert, seeded_workflows: list[Workflow]):
@@ -26,3 +34,90 @@ def test_blocks_dupes(client: Albert, seeded_workflows: list[Workflow]):
 
     r = client.workflows.create(workflows=wf)
     assert r[0].id == seeded_workflows[0].id
+
+
+@search_not_deployed
+def test_workflow_search_basic(client: Albert, seeded_workflows: list[Workflow]):
+    """Test search returns WorkflowSearchItem results with WFL ids."""
+    results = list(client.workflows.search(max_items=10))
+    assert results, "Expected at least one workflow search result"
+    for item in results:
+        assert isinstance(item, WorkflowSearchItem)
+        assert item.id.startswith("WFL")
+        assert item.name
+
+
+@search_not_deployed
+def test_workflow_search_by_text(
+    client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
+):
+    """Test text search scoped to seed_prefix finds seeded workflows."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(text=seed_prefix, max_items=100)
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in text search results"
+
+
+@search_not_deployed
+def test_workflow_search_by_ids(client: Albert, seeded_workflows: list[Workflow]):
+    """Test search by workflow ids returns seeded workflows."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(ids=[wf.id for wf in seeded_workflows])
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in id search results"
+    assert {item.id for item in hits}.issubset(seeded_ids)
+
+
+@search_not_deployed
+def test_workflow_search_hydrate(
+    client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
+):
+    """Test hydrating a search hit returns a full Workflow."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(text=seed_prefix, max_items=100)
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in search results"
+
+    hydrated = hits[0].hydrate()
+    assert isinstance(hydrated, Workflow)
+    assert hydrated.id == hits[0].id
+    assert hydrated.name == hits[0].name
+
+
+@search_not_deployed
+def test_workflow_search_by_parameter_groups(
+    client: Albert,
+    seed_prefix: str,
+    seeded_workflows: list[Workflow],
+    seeded_parameter_groups,
+):
+    """Test search by parameter group name scoped to seeded workflow ids."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    group_name = seeded_parameter_groups[0].name
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(
+                text=seed_prefix,
+                parameter_groups=group_name,
+                max_items=100,
+            )
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow matching parameter group filter"

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -1,9 +1,17 @@
 import pytest
 
 from albert import Albert
-from albert.resources.workflows import Workflow
+from albert.exceptions import NotFoundError
+from albert.resources.workflows import Workflow, WorkflowSearchItem
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("tasks")
+
+search_not_deployed = pytest.mark.xfail(
+    reason="POST /api/v3/workflows/search is not yet deployed (api-workflow#129). Remove decorator once live.",
+    raises=NotFoundError,
+    strict=False,
+)
 
 
 def test_workflow_get_all_with_pagination(client: Albert, seeded_workflows: list[Workflow]):
@@ -24,3 +32,90 @@ def test_blocks_dupes(client: Albert, seeded_workflows: list[Workflow]):
 
     r = client.workflows.create(workflows=wf)
     assert r[0].id == seeded_workflows[0].id
+
+
+@search_not_deployed
+def test_workflow_search_basic(client: Albert, seeded_workflows: list[Workflow]):
+    """Test search returns WorkflowSearchItem results with WFL ids."""
+    results = list(client.workflows.search(max_items=10))
+    assert results, "Expected at least one workflow search result"
+    for item in results:
+        assert isinstance(item, WorkflowSearchItem)
+        assert item.id.startswith("WFL")
+        assert item.name
+
+
+@search_not_deployed
+def test_workflow_search_by_text(
+    client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
+):
+    """Test text search scoped to seed_prefix finds seeded workflows."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(text=seed_prefix, max_items=100)
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in text search results"
+
+
+@search_not_deployed
+def test_workflow_search_by_ids(client: Albert, seeded_workflows: list[Workflow]):
+    """Test search by workflow ids returns seeded workflows."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(ids=[wf.id for wf in seeded_workflows])
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in id search results"
+    assert {item.id for item in hits}.issubset(seeded_ids)
+
+
+@search_not_deployed
+def test_workflow_search_hydrate(
+    client: Albert, seed_prefix: str, seeded_workflows: list[Workflow]
+):
+    """Test hydrating a search hit returns a full Workflow."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(text=seed_prefix, max_items=100)
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow in search results"
+
+    hydrated = hits[0].hydrate()
+    assert isinstance(hydrated, Workflow)
+    assert hydrated.id == hits[0].id
+    assert hydrated.name == hits[0].name
+
+
+@search_not_deployed
+def test_workflow_search_by_parameter_groups(
+    client: Albert,
+    seed_prefix: str,
+    seeded_workflows: list[Workflow],
+    seeded_parameter_groups,
+):
+    """Test search by parameter group name scoped to seeded workflow ids."""
+    seeded_ids = {wf.id for wf in seeded_workflows}
+    group_name = seeded_parameter_groups[0].name
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.workflows.search(
+                text=seed_prefix,
+                parameter_groups=group_name,
+                max_items=100,
+            )
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one seeded workflow matching parameter group filter"

--- a/tests/collections/test_workflows.py
+++ b/tests/collections/test_workflows.py
@@ -104,11 +104,13 @@ def test_workflow_search_by_parameter_groups(
     client: Albert,
     seed_prefix: str,
     seeded_workflows: list[Workflow],
-    seeded_parameter_groups,
 ):
     """Test search by parameter group name scoped to seeded workflow ids."""
-    seeded_ids = {wf.id for wf in seeded_workflows}
-    group_name = seeded_parameter_groups[0].name
+    wf = client.workflows.get_by_id(id=seeded_workflows[0].id)
+    assert wf.parameter_group_setpoints, "Seeded workflow should have parameter groups"
+    group_name = wf.parameter_group_setpoints[0].parameter_group_name
+
+    seeded_ids = {item.id for item in seeded_workflows}
     hits = poll_until(
         lambda: [
             item


### PR DESCRIPTION
## What

Callers can search workflows by text, IDs, status, data templates, parameter groups, parameters, units, and bound `parameter_set` constraints. Hits are lightweight [`WorkflowSearchItem`](https://github.com/albert-labs/albert-python) objects; call `hydrate()` (or `get_by_id`) for the full setpoint payload.

## Why

Workflows previously only supported list-all and get-by-id. Looking up a workflow by name meant paging the entire collection.

## How

- `search()` returns `WorkflowSearchItem`, not `Workflow`, because search hits omit setpoints and intervals.
- The ID filter is `ids=` (maps to wire `albertId`).
- Offset pagination uses page size 100, the API maximum. `offset`/`limit` are not public.
- `get_all` is unchanged (Dynamo KEY listing). Facets are deferred to a follow-up.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_workflows.py -v`

Search tests are marked `xfail(raises=NotFoundError, strict=False)` until `POST /api/v3/workflows/search` is deployed ([api-workflow#129](https://github.com/MoleculeEngineering/api-workflow/pull/129)). They will XPASS once the route is live; remove the decorator then. Existing get_all / get_by_id / create tests pass.

## SDK Changes

Added `client.workflows.search(...)` for full-text and filtered workflow lookup, returning `WorkflowSearchItem` with `hydrate()` to the full `Workflow`.