### PR TITLE
fix: column unpinning in sheet

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -2189,7 +2189,7 @@ class Sheet(BaseSessionResource):  # noqa:F811
                     "operation": "update",
                     "attribute": "pinned",
                     "colIds": col_ids,
-                    "newValue": None,
+                    "newValue": False,
                 }
             ]
         }


### PR DESCRIPTION
## What

unpin columns in worksheet

## Why

unpinning was blocked due to an error occurring, e.g.

BadRequestError: PATCH 'https://sandbox.albertinvent.com/api/v3/worksheet/sheet/WKS666/columns' failed with status code 400 (Bad Request). Errors: [{'msg': 'newValue should be of left / right for attribute pinned'}]
Body:
b'{"data": [{"operation": "update", "attribute": "pinned", "colIds": ["COL7"], "newValue": null}]}'

## How

transition new value in patch payload from "None" to "False"

## Testing

- [ ] `uv run ruff format .`
- [ ] `uv run ruff check . --fix`
- [ ] `uv run pytest <relevant_test_file>.py -v`

## SDK Changes

<!-- User-facing release-notes blurb. Delete if not applicable. -->
