### PR TITLE
ci: enforce conventional commit PR titles; xfail flaky substance v4 search test

### DIFF
--- a/.cursor/rules/project.mdc
+++ b/.cursor/rules/project.mdc
@@ -52,6 +52,11 @@ Fill every section from the diff and commit history. Delete optional sections
 <!-- User-facing release-notes blurb. Delete if not applicable. -->
 ```
 
-Create PRs with `gh pr create`, targeting `main` unless told otherwise. PR title:
-Conventional Commit (`type(scope): summary`). Never include an "AI-assisted code"
-disclaimer in the body.
+Create PRs with `gh pr create`, targeting `main` unless told otherwise.
+
+**PR title (required):** Conventional Commit (`type(scope): summary`), enforced by the
+`PR Title` GitHub Action. Derive the title from the overall change, not from individual
+commit messages (commits may be messy; the PR title must still be conventional).
+Examples: `feat(cas): add search by name support`, `fix(pagination): preserve has_more`.
+
+Never include an "AI-assisted code" disclaimer in the body.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,9 @@
+<!--
+PR title (required, enforced by CI): type(scope): summary
+Examples: feat(cas): add search by name support, fix(pagination): preserve has_more
+The title must follow Conventional Commits even when individual commit messages do not.
+-->
+
 ## What
 
 <!-- What can callers do now that they couldn't before? 1–2 sentences. Not a file list. -->

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,31 @@
+name: PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Match conventional-pre-commit (.pre-commit-config.yaml) types.
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test

--- a/tests/collections/test_substance_v4.py
+++ b/tests/collections/test_substance_v4.py
@@ -129,6 +129,14 @@ def test_search_filters(client: Albert):
     assert any(r.cas_id == WATER_CAS for r in by_name)
 
 
+# Remove xfail when https://github.com/MoleculeEngineering/api-substance-v4/issues/57 is fixed.
+@pytest.mark.xfail(
+    strict=False,
+    reason=(
+        "api-substance-v4 search pagination intermittently returns duplicate items across "
+        "pages (MoleculeEngineering/api-substance-v4#57)."
+    ),
+)
 def test_search_pagination(client: Albert):
     """Test max_items cap, start_key resume, multi-page uniqueness, and has_more."""
     capped_pag = client.substances_v4.search(search_key="water", max_items=5)


### PR DESCRIPTION
## What

- Pull requests now require a Conventional Commit title (`type(scope): summary`), validated in CI even when individual commit messages do not follow the format.
- `test_search_pagination` is marked `xfail` until backend search pagination stops returning duplicate items across pages.

## Why

- Commit messages are already validated locally via pre-commit, but PR titles were unconstrained. A non-conventional PR title breaks release-please changelog grouping and makes the PR history harder to scan.
- `GET /api/v4/substances/search` intermittently returns duplicate `(substanceId, casID, classificationType)` tuples across consecutive pages (~30% flake rate in prod repro for `searchKey=water`). Tracking fix in [MoleculeEngineering/api-substance-v4#57](https://github.com/MoleculeEngineering/api-substance-v4/issues/57). Remove the `xfail` decorator once that issue is resolved.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_substance_v4.py::test_search_pagination -v`