### PR TITLE
chore(ci): quiet pytest CI output and stop leaking locals on failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            uv run pytest -n 4 --tb=short -r fEsxX --durations=15
+            uv run pytest -n 4 -v --tb=short -r fEsxX --durations=15
 
   validate_version_bump:
     executor:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,7 +37,7 @@ jobs:
       - run:
           name: Run pytest
           command: |
-            uv run pytest -n 4 -v --tb=long -r fEsxX --showlocals --durations=15
+            uv run pytest -n 4 --tb=short -r fEsxX --durations=15
 
   validate_version_bump:
     executor:


### PR DESCRIPTION
## What

CI pytest runs produce compact logs again: no per-test verbose lines, no frame-local dumps on failure.

## Why

PR #633 added `-v --tb=long --showlocals` alongside pytest-xdist. That made every CI run print duplicate test names from xdist workers, and failures dumped stack-frame locals including `Authorization` Bearer tokens into CircleCI logs.

## Testing

- [ ] `uv run ruff format .`
- [ ] `uv run ruff check . --fix`
- [ ] CI Test job (config-only change; no pytest file edits)