### PR TITLE
test(activities): replace admin-only date range filter in get_all test

### DIFF
--- a/tests/collections/test_activities.py
+++ b/tests/collections/test_activities.py
@@ -1,12 +1,7 @@
-import uuid
-from contextlib import suppress
 from datetime import date, timedelta
 
 from albert import Albert
-from albert.exceptions import NotFoundError
 from albert.resources.activities import Activity, ActivitySearchItem, ActivityType
-from albert.resources.tags import Tag
-from tests.utils.wait import poll_until
 
 
 def assert_valid_activity_items(returned_list):
@@ -18,21 +13,15 @@ def assert_valid_activity_items(returned_list):
 
 def test_activity_get_all(client: Albert):
     """Test activity get_all returns the feed for a single entity."""
-    tag = client.tags.create(tag=Tag(tag=f"TEST - activity scope {uuid.uuid4()}"))
-    try:
-        results = poll_until(
-            lambda: list(
-                client.activities.get_all(
-                    type=ActivityType.ENTITY_ID,
-                    id=tag.id,
-                    max_items=10,
-                )
-            )
+    tag = next(iter(client.tags.get_all(max_items=1)))
+    results = list(
+        client.activities.get_all(
+            type=ActivityType.ENTITY_ID,
+            id=tag.id,
+            max_items=10,
         )
-        assert_valid_activity_items(results)
-    finally:
-        with suppress(NotFoundError):
-            client.tags.delete(id=tag.id)
+    )
+    assert_valid_activity_items(results)
 
 
 def test_activity_search(client: Albert):

--- a/tests/collections/test_activities.py
+++ b/tests/collections/test_activities.py
@@ -1,7 +1,12 @@
+import uuid
+from contextlib import suppress
 from datetime import date, timedelta
 
 from albert import Albert
+from albert.exceptions import NotFoundError
 from albert.resources.activities import Activity, ActivitySearchItem, ActivityType
+from albert.resources.tags import Tag
+from tests.utils.wait import poll_until
 
 
 def assert_valid_activity_items(returned_list):
@@ -12,15 +17,22 @@ def assert_valid_activity_items(returned_list):
 
 
 def test_activity_get_all(client: Albert):
-    end_date = date.today()
-    start_date = end_date - timedelta(days=1)
-    simple_list = client.activities.get_all(
-        type=ActivityType.DATE_RANGE,
-        start_date=start_date,
-        end_date=end_date,
-        max_items=10,
-    )
-    assert_valid_activity_items(simple_list)
+    """Test activity get_all returns the feed for a single entity."""
+    tag = client.tags.create(tag=Tag(tag=f"TEST - activity scope {uuid.uuid4()}"))
+    try:
+        results = poll_until(
+            lambda: list(
+                client.activities.get_all(
+                    type=ActivityType.ENTITY_ID,
+                    id=tag.id,
+                    max_items=10,
+                )
+            )
+        )
+        assert_valid_activity_items(results)
+    finally:
+        with suppress(NotFoundError):
+            client.tags.delete(id=tag.id)
 
 
 def test_activity_search(client: Albert):


### PR DESCRIPTION
## What

`test_activity_get_all` now queries the activity feed for a single existing tag (`ActivityType.ENTITY_ID`) instead of using a date range. The test asserts the same thing as before — `get_all` returns at least one valid `Activity` — without requiring admin privileges.

## Why

The test used `ActivityType.DATE_RANGE`, which the Activities API reserves for admin users. The SDK integration client gets `403 Forbidden: Access denied to view activities with date range filter`, failing the suite. Tracked in SDK-92.

## How

- Look up an existing tag via `client.tags.get_all(max_items=1)` and pass its ID as the `ENTITY_ID` scope — nothing is created, seeded, or polled; ambient activity from seeding and other tests populates the feed.
- Wrap the paginator in `list()` so the non-empty assertion actually evaluates (a bare iterator is always truthy).

## Testing

- `uv run ruff format --check .` and `uv run ruff check .` pass.
- `uv run pytest tests/collections/test_activities.py --collect-only` collects both tests.
- Live integration run not executed here (no `ALBERT_CLIENT_ID_SDK`/`ALBERT_CLIENT_SECRET_SDK`/`ALBERT_BASE_URL` credentials in the agent environment); verify with `uv run pytest tests/collections/test_activities.py -v`.

Linear: https://linear.app/albert-invent/issue/SDK-92/albert-python-test-activity-get-all-fails-with-403-uses-admin-only