### PR TITLE
feat(sheets): Sheet.add_task_row + batch lot-assignment docstring fixes (Ask Albert SDK follow-up #2)

### DIFF
--- a/src/albert/collections/notebooks.py
+++ b/src/albert/collections/notebooks.py
@@ -271,6 +271,14 @@ class NotebookCollection(BaseCollection):
         created, and any existing block that is no longer present is deleted. This
         does not change the notebook name (use [`update`][albert.collections.notebooks.NotebookCollection.update] for that).
 
+        When writing @-mention chips (``<span data-albertid="..." data-type="...">``
+        spans) into block text, also create the backing mention links — saving the
+        HTML does not register them, and without a link the chip does not resolve
+        in the UI. Create one link per mentioned entity with
+        [`create`][albert.collections.links.LinksCollection.create]
+        (``category="mention"``, parent = the notebook, child = the mentioned
+        entity), then re-read the notebook and confirm its ``links`` list them.
+
         !!! warning
             Updating existing Ketcher blocks is not supported. To change a Ketcher
             block, delete it and create a new one instead.

--- a/src/albert/resources/batch_data.py
+++ b/src/albert/resources/batch_data.py
@@ -17,19 +17,32 @@ class BatchValuePatchDatum(BaseAlbertModel):
     a batch value. See
     [`update_used_batch_amounts`][albert.collections.batch_data.BatchDataCollection.update_used_batch_amounts].
 
+    Recording a lot's consumed amount is a two-step operation on the grid:
+    first add the lot's child row under the ingredient (parent) row, then write
+    the amount on the child row. Parent rows reject value writes
+    (``400 "Parent row cannot be updated"``).
+
     !!! example
         ```python
         from albert.resources.batch_data import BatchValuePatchDatum
 
-        datum = BatchValuePatchDatum(
+        # Step 1: add the lot child row under the ingredient row. The lot id
+        # goes in the payload's top-level `lot_id`; `new_value` is the numeric
+        # initial amount ("0" is fine). `attribute` stays "lotId".
+        add_lot = BatchValuePatchDatum(operation="add", new_value="0")
+
+        # Step 2: write the recorded amount on the child row created above
+        # (re-read the grid to discover its row id). `old_value` is required.
+        write_amount = BatchValuePatchDatum(
+            attribute="cell",
             operation="update",
-            new_value="LOT123",
-            old_value="LOT100",
+            old_value="0",
+            new_value="0.025",
         )
         ```"""
 
     attribute: str = Field(default="lotId")
-    """The field being changed. Defaults to ``"lotId"``."""
+    """The field being changed. Defaults to ``"lotId"`` (lot assignment; amounts use ``"cell"``)."""
 
     lot_id: str | None = Field(default=None, alias="lotId")
     """The lot identifier being assigned, when applicable."""
@@ -79,11 +92,21 @@ class BatchValuePatchPayload(BaseAlbertModel):
             BatchValuePatchPayload,
         )
 
+        # Step 1 of the lot flow: add the lot's child row under an ingredient
+        # row. The lot id is the payload's top-level `lot_id`; the datum's
+        # `new_value` is the numeric initial amount.
         patch = BatchValuePatchPayload(
             id=BatchValueId(row_id="ROW1", col_id="COL9999999"),
-            data=[BatchValuePatchDatum(operation="update", new_value="LOT123")],
+            lot_id="LOT123",
+            data=[BatchValuePatchDatum(operation="add", new_value="0")],
         )
-        ```"""
+        ```
+
+    Note that lot rows created through this endpoint may surface in the
+    platform without the lot's display name (the "View all lots used" report
+    can show a blank lot). Verify the child row reads back with a non-empty
+    name when the lot identity matters for reporting.
+    """
 
     id: BatchValueId = Field(alias="Id")
     """Locates the cell to change (its row and optional column)."""

--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -7,7 +7,7 @@ import pandas as pd
 from pydantic import Field, PrivateAttr, field_validator, model_validator, validate_call
 
 from albert.core.base import BaseAlbertModel
-from albert.core.shared.identifiers import DataColumnId, InventoryId, ParameterGroupId
+from albert.core.shared.identifiers import DataColumnId, InventoryId, ParameterGroupId, TaskId
 from albert.core.shared.models.base import BaseResource, BaseSessionResource
 from albert.core.shared.models.patch import PatchDatum
 from albert.exceptions import AlbertException, AlbertHTTPError
@@ -706,6 +706,8 @@ class Sheet(BaseSessionResource):  # noqa:F811
         Add an application row.
     add_parameter_group_row(parameter_group_id, ...) -> Row
         Add a parameter group (PRG) row to Process Design.
+    add_task_row(task_id, ...) -> Row
+        Link a task into the Results section as a task (TAS) row.
     add_blank_column(name, ...) -> Column
         Add a blank column.
     add_lookup_column(name, ...) -> Column
@@ -1640,6 +1642,94 @@ class Sheet(BaseSessionResource):  # noqa:F811
             design=design_obj,
             sheet=self,
             name=data.get("labelName") or data.get("name"),
+            inventory_id=data.get("id"),
+        )
+
+    @validate_call
+    def add_task_row(
+        self,
+        *,
+        task_id: TaskId,
+        name: str | None = None,
+        reference_id: str | None = None,
+        position: RowPosition = RowPosition.ABOVE,
+    ) -> Row:
+        """Link a task into this sheet's Results section as a task (TAS) row.
+
+        Creating a task does not place it in the worksheet's Results grid — the
+        platform only adds the TAS row when the task is created from the worksheet
+        UI. Call this after creating a property task programmatically so the task
+        (and its results) shows up in the sheet.
+
+        !!! example
+            ```python
+            row = sheet.add_task_row(task_id="TASPT9999999")
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The Task ID to link (format ``TAS...``).
+        name : str, optional
+            The display name of the row. Defaults to the task's current name,
+            read from the platform.
+        reference_id : str, optional
+            The row ID to insert relative to. Defaults to the first Results
+            row when one exists. Omit (or leave ``None``) when the Results
+            section has no rows.
+        position : RowPosition, optional
+            Whether to insert ``ABOVE`` or ``BELOW`` the reference row.
+            Default is ``ABOVE``. Ignored when the Results section has no rows
+            and ``reference_id`` is omitted.
+
+        Returns
+        -------
+        Row
+            The created task row.
+
+        Raises
+        ------
+        AlbertException
+            If the sheet has no Results section, or the response has no rows.
+        """
+        design_obj = self.result_design
+        if design_obj is None:
+            raise AlbertException("Sheet has no Results section; cannot add a task row")
+        if name is None:
+            task = self.session.get(f"/api/v3/tasks/{task_id}").json()
+            name = task.get("name") or task_id
+        payload_item: dict[str, str] = {
+            "type": CellType.TAS.value,
+            "id": task_id,
+            "name": name,
+        }
+        if reference_id is None:
+            existing_rows = design_obj.rows
+            if existing_rows:
+                reference_id = existing_rows[0].row_id
+        if reference_id is not None:
+            payload_item["referenceId"] = reference_id
+            payload_item["position"] = position.value
+
+        response = self.session.post(
+            f"/api/v3/worksheet/design/{design_obj.id}/rows", json=[payload_item]
+        )
+        self.grid = None
+        rows = response.json()
+        if not isinstance(rows, list):
+            rows = [rows]
+        if not rows:
+            raise AlbertException(
+                f"No rows returned when adding task '{task_id}' to Results design '{design_obj.id}'"
+            )
+        data = next((row for row in rows if row.get("type") == CellType.TAS.value), rows[0])
+        return Row(
+            rowId=data["rowId"],
+            type=data["type"],
+            session=self.session,
+            design=design_obj,
+            sheet=self,
+            name=data.get("name") or name,
             inventory_id=data.get("id"),
         )
 

--- a/tests/resources/test_sheets.py
+++ b/tests/resources/test_sheets.py
@@ -1,9 +1,11 @@
 import json
+from contextlib import suppress
 
 import pandas as pd
 import pytest
 
-from albert.exceptions import AlbertException
+from albert import Albert
+from albert.exceptions import AlbertException, BadRequestError, NotFoundError
 from albert.resources.inventory import InventoryItem
 from albert.resources.sheets import (
     Cell,
@@ -454,6 +456,75 @@ def test_add_parameter_group_row(
         f"/api/v3/designs/{seeded_sheet.process_design.id}/rows",
         json=[{"rowId": row.row_id}],
     )
+
+
+def test_add_task_row(
+    client: Albert,
+    seed_prefix: str,
+    seeded_locations,
+    seeded_inventory,
+    seeded_data_templates,
+    seeded_workflows,
+):
+    """Test linking a property task into a sheet's Results section as a TAS row."""
+    from albert.core.shared.models.base import EntityLink
+    from albert.resources.projects import Project
+    from albert.resources.tasks import (
+        Block,
+        PropertyTask,
+        TaskCategory,
+        TaskInventoryInformation,
+    )
+
+    # Isolated project: TAS rows cannot be removed from a sheet, so the shared
+    # seeded sheet must not be used.
+    project = client.projects.create(
+        project=Project(
+            description=f"{seed_prefix} - add_task_row",
+            locations=[EntityLink(id=seeded_locations[0].id)],
+        )
+    )
+    task = None
+    try:
+        worksheet = client.worksheets.setup_worksheet(project_id=project.id, add_sheet=True)
+        sheet = worksheet.sheets[0]
+
+        column = sheet.add_formulation(
+            formulation_name=f"{seed_prefix} - add_task_row formula",
+            components=[Component(inventory_id=seeded_inventory[0].id, amount=100.0)],
+        )
+
+        task = client.tasks.create(
+            task=PropertyTask(
+                name=f"{seed_prefix} - add_task_row task",
+                category=TaskCategory.PROPERTY,
+                inventory_information=[TaskInventoryInformation(inventory_id=column.inventory_id)],
+                parent_id=project.id,
+                location=seeded_locations[0],
+                blocks=[
+                    Block(
+                        workflow=[seeded_workflows[0]],
+                        data_template=[seeded_data_templates[0]],
+                    )
+                ],
+            )
+        )
+
+        row = sheet.add_task_row(task_id=task.id)
+        assert isinstance(row, Row)
+        assert row.type == CellType.TAS
+        assert row.row_id.startswith("ROW")
+        assert row.inventory_id == task.id
+
+        sheet.grid = None
+        result_row_ids = {r.row_id for r in sheet.result_design.rows}
+        assert row.row_id in result_row_ids
+    finally:
+        if task is not None:
+            with suppress(NotFoundError, BadRequestError):
+                client.tasks.delete(id=task.id)
+        with suppress(NotFoundError, BadRequestError):
+            client.projects.delete(id=project.id)
 
 
 ########################## CELLS ##########################


### PR DESCRIPTION
## What

SDK-side fixes for the second Ask Albert SDK-integration batch (AI-1563, AI-1571, AI-1588, AI-1603), root-caused against production Braintrust traces — RCA + plan in [albert-monorepo PR #38](https://github.com/Albert-Invent-AI/albert-monorepo/pull/38).

After this: callers can link a programmatically created task into a worksheet's Results grid (`Sheet.add_task_row`), and the batch-data lot-assignment docs teach the platform's real two-step contract instead of an API-invalid shape.

## Why

- **AI-1603**: property tasks created via `/tasks/multi` never appear in the project worksheet's Results grid — the platform only adds the TAS row for UI-created tasks, and the SDK blocked results-design row adds client-side. Verified live on dev: the platform accepts `POST /api/v3/worksheet/design/{results_design_id}/rows` with `type: "TAS"` (200, row persists in the design sequence).
- **AI-1563 / AI-1571**: `BatchValuePatchDatum`'s docstring example (`operation="update", new_value="LOT123"`, default `attribute="lotId"`) is rejected by the platform (`400 "Value should be a number"`; `lotId` only accepts `operation="add"` with a numeric `newValue` and the lot id at the payload's top level). Agents burned 15–20 failed calls per session discovering this.
- **AI-1588**: notebook @-mention chips saved via `update_block_content` never resolve — the platform also needs a backing `links` record, which the save path does not create (verified on dev). The docstring now says so and points at `links.create(category="mention")`.

## How

- `Sheet.add_task_row(task_id=…)` on the Sheet resource, following the existing `add_parameter_group_row` pattern (defaults the reference row to the first Results row; omits `referenceId`/`position` on an empty section; raises `AlbertException` when the sheet has no Results section or the create returns no rows).
- Corrected `BatchValuePatchDatum` / `BatchValuePatchPayload` docstrings to the two-step lot-child-row flow, with a note that PATCH-created lot rows can surface without the lot's display name (the "View all lots used" report shows blanks) so callers verify when identity matters.
- `update_block_content` docstring now documents the mention-link requirement.

## Testing

- New integration test `test_add_task_row` (`tests/resources/test_sheets.py`, xdist group `sheets`): isolated project → worksheet → formulation → property task → link → assert TAS row in the results design, with task/project cleanup. (Runs in CI with the seeded fixtures; TAS rows can't be deleted via API, so the test uses a throwaway project rather than the shared seeded sheet.)
- `Sheet.add_task_row` also verified live against dev end-to-end (created ROW14 as TAS, read back in the design's row sequence).
- `uv run ruff format` / `ruff check` clean. No version bump — release-please owns that on merge.

Companion worker PR: [albert-ai PR #725](https://github.com/Albert-Invent-AI/albert-ai/pull/725) (uses the direct endpoint until the pinned SDK ships this; then the TODO swaps to this method).

Cake session: https://agents.ai.albertinventdev.com/sessions/0199a5a2-599d-4d80-85e1-85defafe9423