### PR TITLE
feat(data_templates): add get_document_version_history method

### DIFF
--- a/docs/resources/documents.md
+++ b/docs/resources/documents.md
@@ -1,0 +1,1 @@
+::: albert.resources.documents

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -216,6 +216,7 @@ nav:
           - Data Columns: resources/data_columns.md
           - Data Templates: resources/data_templates.md
           - Design: resources/design.md
+          - Documents: resources/documents.md
           - Entity Types: resources/entity_types.md
           - Enums: resources/enums.md
           - Files: resources/files.md

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -26,7 +26,7 @@ from albert.resources.data_templates import (
     ImageExample,
     ParameterValue,
 )
-from albert.resources.documents import DocumentVersion
+from albert.resources.documents import DocumentState, DocumentVersion
 from albert.resources.parameter_groups import DataType, EnumValidationValue, ValueValidation
 from albert.utils._patch import (
     build_acl_patch_payload,
@@ -1025,6 +1025,8 @@ class DataTemplateCollection(BaseCollection):
         self,
         *,
         document_id: DocumentId,
+        doc_version: int | None = None,
+        state: DocumentState | None = None,
     ) -> list[DocumentVersion]:
         """Get the version history for a document attached to a data template.
 
@@ -1051,15 +1053,21 @@ class DataTemplateCollection(BaseCollection):
             The document ID (format ``DOC...``). Obtain this from
             ``DataTemplate.documents[i].id`` after calling
             [`get_by_id`][albert.collections.data_templates.DataTemplateCollection.get_by_id].
+        doc_version : int, optional
+            Return only this specific version number. Requires ``document_id``.
+        state : DocumentState, optional
+            Filter by document state (``draft``, ``published``, or ``archived``).
 
         Returns
         -------
         list[DocumentVersion]
-            All versions of the document, each representing a snapshot at a
+            Matching versions of the document, each representing a snapshot at a
             point in time. See [`DocumentVersion`][albert.resources.documents.DocumentVersion].
         """
-        response = self.session.get(
-            "/api/v3/documents",
-            params={"documentId": document_id},
-        )
+        params: dict = {"documentId": document_id}
+        if doc_version is not None:
+            params["docVersion"] = doc_version
+        if state is not None:
+            params["state"] = state
+        response = self.session.get("/api/v3/documents", params=params)
         return [DocumentVersion(**item) for item in response.json().get("Items", [])]

--- a/src/albert/collections/data_templates.py
+++ b/src/albert/collections/data_templates.py
@@ -9,7 +9,7 @@ from albert.core.logging import logger
 from albert.core.pagination import AlbertPaginator, MetadataPreservingIterator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import DataColumnId, DataTemplateId, UserId
+from albert.core.shared.identifiers import DataColumnId, DataTemplateId, DocumentId, UserId
 from albert.core.shared.models.patch import (
     GeneralPatchDatum,
     GeneralPatchPayload,
@@ -26,6 +26,7 @@ from albert.resources.data_templates import (
     ImageExample,
     ParameterValue,
 )
+from albert.resources.documents import DocumentVersion
 from albert.resources.parameter_groups import DataType, EnumValidationValue, ValueValidation
 from albert.utils._patch import (
     build_acl_patch_payload,
@@ -123,6 +124,8 @@ class DataTemplateCollection(BaseCollection):
         Set the example row for a curve data column (shown on the details page).
     set_image_example(data_template_id, example, ...) -> DataTemplate
         Set the example row for an image data column (shown on the details page).
+    get_document_version_history(document_id) -> list[DocumentVersion]
+        Get the version history for a document attached to a data template.
     """
 
     _api_version = "v3"
@@ -1016,3 +1019,47 @@ class DataTemplateCollection(BaseCollection):
             json=payload.model_dump(mode="json", by_alias=True, exclude_none=True),
         )
         return self.get_by_id(id=data_template_id)
+
+    @validate_call
+    def get_document_version_history(
+        self,
+        *,
+        document_id: DocumentId,
+    ) -> list[DocumentVersion]:
+        """Get the version history for a document attached to a data template.
+
+        Each data template may have one or more documents associated with it.
+        Retrieve the document IDs from
+        [`DataTemplate.documents`][albert.resources.data_templates.DataTemplate.documents]
+        after fetching the template with
+        [`get_by_id`][albert.collections.data_templates.DataTemplateCollection.get_by_id].
+
+        !!! example
+            ```python
+            dt = client.data_templates.get_by_id(id="DAT8967")
+            for doc in dt.documents:
+                versions = client.data_templates.get_document_version_history(
+                    document_id=doc.id
+                )
+                for v in versions:
+                    print(v.doc_version, v.state, v.created.at)
+            ```
+
+        Parameters
+        ----------
+        document_id : str
+            The document ID (format ``DOC...``). Obtain this from
+            ``DataTemplate.documents[i].id`` after calling
+            [`get_by_id`][albert.collections.data_templates.DataTemplateCollection.get_by_id].
+
+        Returns
+        -------
+        list[DocumentVersion]
+            All versions of the document, each representing a snapshot at a
+            point in time. See [`DocumentVersion`][albert.resources.documents.DocumentVersion].
+        """
+        response = self.session.get(
+            "/api/v3/documents",
+            params={"documentId": document_id},
+        )
+        return [DocumentVersion(**item) for item in response.json().get("Items", [])]

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -17,6 +17,7 @@ _ALBERT_PREFIXES = {
     "CustomTemplateId": "CTP",
     "DataColumnId": "DAC",
     "DataTemplateId": "DAT",
+    "DocumentId": "DOC",
     "EntityTypeId": "ETT",
     "InventoryId": "INV",
     "LabelTemplateId": "TMP",
@@ -238,6 +239,13 @@ def ensure_data_column_id(id: str) -> str:
 
 
 DataColumnId = Annotated[str, AfterValidator(ensure_data_column_id)]
+
+
+def ensure_document_id(id: str) -> str:
+    return _ensure_albert_id(id, "DocumentId")
+
+
+DocumentId = Annotated[str, AfterValidator(ensure_document_id)]
 
 
 def ensure_datatemplate_id(id: str) -> str:

--- a/src/albert/resources/documents.py
+++ b/src/albert/resources/documents.py
@@ -1,0 +1,84 @@
+from enum import Enum
+
+from pydantic import Field
+
+from albert.core.base import BaseAlbertModel
+from albert.core.shared.models.base import AuditFields
+
+
+class DocumentState(str, Enum):
+    """Lifecycle state of a document version."""
+
+    DRAFT = "draft"
+    PUBLISHED = "published"
+    ARCHIVED = "archived"
+
+
+class DocumentClass(str, Enum):
+    """Access class of a document."""
+
+    PRIVATE = "private"
+    PUBLIC = "public"
+    SHARED = "shared"
+    CONFIDENTIAL = "confidential"
+    RESTRICTED = "restricted"
+
+
+class DocumentVersion(BaseAlbertModel):
+    """A single version entry in a document's version history.
+
+    Each entry represents one version of a document attached to a Data Template.
+    Obtain the document ID from
+    [`DataTemplate.documents`][albert.resources.data_templates.DataTemplate.documents]
+    and pass it to
+    [`get_document_version_history`][albert.collections.data_templates.DataTemplateCollection.get_document_version_history].
+
+    !!! example
+        ```python
+        from albert import Albert
+
+        client = Albert()
+        dt = client.data_templates.get_by_id(id="DAT8967")
+        for doc in dt.documents:
+            for version in client.data_templates.get_document_version_history(
+                document_id=doc.id
+            ):
+                print(version.doc_version, version.state)
+        ```
+    """
+
+    id: str | None = Field(default=None, alias="albertId")
+    """The document ID (format ``DOC...``)."""
+
+    name: str | None = Field(default=None)
+    """The document name."""
+
+    name_space: str | None = Field(default=None, alias="nameSpace")
+    """The S3 bucket namespace."""
+
+    key: str | None = Field(default=None)
+    """The S3 storage path for this version."""
+
+    version_id: str | None = Field(default=None, alias="versionId")
+    """The S3 version key for this version."""
+
+    doc_version: int | None = Field(default=None, alias="docVersion")
+    """The sequential version number (increments with each new version)."""
+
+    document_class: DocumentClass | None = Field(default=None, alias="class")
+    """The access class of the document."""
+
+    state: DocumentState | None = Field(default=None)
+    """The lifecycle state of this document version."""
+
+    signed_url: str | None = Field(default=None, alias="signedUrl")
+    """A short-lived S3 download URL for this version's file."""
+
+    published_at: str | None = Field(default=None, alias="publishedAt")
+    """The timestamp when this version was published, if applicable."""
+
+    created: AuditFields | None = Field(default=None, alias="Created")
+    """Who created this version and when."""
+
+    updated: AuditFields | None = Field(default=None, alias="Updated")
+    """Who last updated this version and when."""


### PR DESCRIPTION
## What

Callers can now retrieve the full version history for any document attached to a data template via `client.data_templates.get_document_version_history(document_id=doc.id)`.

## Why

Ask Albert was unable to read data template document history (AI-1322). The `GET /api/v3/documents?documentId=<id>` endpoint exists in the document service but had no SDK wrapper.

## How

- Added `DocumentId` annotated type (`DOC` prefix) to `identifiers.py`, following the existing pattern for all Albert ID types.
- Added `src/albert/resources/documents.py` with `DocumentVersion`, `DocumentState`, and `DocumentClass` models mapping the full `api-document` OpenAPI contract.
- Added `get_document_version_history(*, document_id: DocumentId) -> list[DocumentVersion]` to `DataTemplateCollection`. The docstring explicitly guides callers to obtain the document ID from `DataTemplate.documents[i].id`.
- Added `docs/resources/documents.md` and the corresponding `mkdocs.yml` entry.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/test_data_templates.py -v`

## SDK Changes

**New:** `client.data_templates.get_document_version_history(document_id="DOC...")` returns a `list[DocumentVersion]` with fields `id`, `name`, `key`, `version_id`, `doc_version`, `document_class`, `state`, `signed_url`, `published_at`, `created`, and `updated`.