### PR TITLE
fix(substances_v4): align search docs with search_key precedence

### DIFF
--- a/src/albert/collections/substance_v4.py
+++ b/src/albert/collections/substance_v4.py
@@ -273,21 +273,23 @@ class SubstanceV4Collection(BaseCollection):
         """Search for substances by keyword or advanced filters.
 
         At least one of ``search_key``, ``cas``, ``ec``, ``name``, ``inciname``, or
-        ``cas_ids`` must be provided. If both ``search_key`` and advanced filters are
-        provided, the advanced filters take precedence.
+        ``cas_ids`` must be provided. When ``search_key`` is provided, advanced filters
+        (``cas``, ``ec``, ``name``, ``inciname``) are ignored. Use ``cas_ids`` for
+        multi-value identifier lookups instead of combining it with ``search_key``.
 
         Parameters
         ----------
         search_key : str | None
-            Free-text search term.
+            Free-text search term. Takes precedence over ``cas``, ``ec``, ``name``, and
+            ``inciname`` when more than one is provided.
         cas : str | None
-            Filter by CAS identifier.
+            Filter by CAS identifier. Ignored when ``search_key`` is also provided.
         ec : str | None
-            Filter by EC identifier.
+            Filter by EC identifier. Ignored when ``search_key`` is also provided.
         name : str | None
-            Filter by substance name.
+            Filter by substance name. Ignored when ``search_key`` is also provided.
         inciname : str | None
-            Filter by INCI name identifier.
+            Filter by INCI name identifier. Ignored when ``search_key`` is also provided.
         cas_ids : str | None
             Comma-separated CAS IDs to filter by (for example ``"7732-18-5,50-00-0"``).
         region : str, optional
@@ -328,16 +330,17 @@ class SubstanceV4Collection(BaseCollection):
         params: dict = {"region": region, "startKey": start_key}
         if search_key:
             params["searchKey"] = search_key
-        if cas:
-            params["cas"] = cas
-        if ec:
-            params["ec"] = ec
-        if name:
-            params["name"] = name
-        if inciname:
-            params["inciname"] = inciname
         if cas_ids:
             params["casIDs"] = cas_ids
+        if not search_key:
+            if cas:
+                params["cas"] = cas
+            if ec:
+                params["ec"] = ec
+            if name:
+                params["name"] = name
+            if inciname:
+                params["inciname"] = inciname
         if classification_type:
             params["classificationType"] = classification_type
         if catch_errors is not None:

--- a/src/albert/collections/substance_v4.py
+++ b/src/albert/collections/substance_v4.py
@@ -273,23 +273,21 @@ class SubstanceV4Collection(BaseCollection):
         """Search for substances by keyword or advanced filters.
 
         At least one of ``search_key``, ``cas``, ``ec``, ``name``, ``inciname``, or
-        ``cas_ids`` must be provided. When ``search_key`` is provided, advanced filters
-        (``cas``, ``ec``, ``name``, ``inciname``) are ignored. Use ``cas_ids`` for
-        multi-value identifier lookups instead of combining it with ``search_key``.
+        ``cas_ids`` must be provided.
 
         Parameters
         ----------
         search_key : str | None
-            Free-text search term. Takes precedence over ``cas``, ``ec``, ``name``, and
-            ``inciname`` when more than one is provided.
+            Free-text search term. When provided, takes precedence over ``cas``, ``ec``,
+            ``name``, and ``inciname``.
         cas : str | None
-            Filter by CAS identifier. Ignored when ``search_key`` is also provided.
+            Filter by CAS identifier.
         ec : str | None
-            Filter by EC identifier. Ignored when ``search_key`` is also provided.
+            Filter by EC identifier.
         name : str | None
-            Filter by substance name. Ignored when ``search_key`` is also provided.
+            Filter by substance name.
         inciname : str | None
-            Filter by INCI name identifier. Ignored when ``search_key`` is also provided.
+            Filter by INCI name identifier.
         cas_ids : str | None
             Comma-separated CAS IDs to filter by (for example ``"7732-18-5,50-00-0"``).
         region : str, optional


### PR DESCRIPTION
## What

`SubstanceV4Collection.search()` now documents and enforces that `search_key` takes precedence over advanced filters (`cas`, `ec`, `name`, `inciname`).

## Why

The SDK docstring previously claimed advanced filters win when both are provided, but the API intentionally uses `search_key` only in that case (AI-1034). Callers and agents could get silently misleading results.

## How

When `search_key` is set, advanced filter params are no longer sent on the wire. Parameter docstrings state which filters are ignored.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_substance_v4.py -v`

## SDK Changes

`substances_v4.search()`: corrected precedence documentation; advanced filters (`cas`, `ec`, `name`, `inciname`) are ignored when `search_key` is also provided.