### PR TITLE
feat(design_runs): add per-run objective weights

### DIFF
--- a/src/albert/collections/design_runs.py
+++ b/src/albert/collections/design_runs.py
@@ -6,13 +6,13 @@ from albert.core.shared.identifiers import SmartDatasetId, TargetId
 from albert.resources.btinsight import BTInsight
 from albert.resources.chats import ChatSessionRef
 from albert.resources.design import (
+    DesignObjective,
     DesignRunValidationResponse,
     DOEDesignRunRequest,
     DOERunSettings,
     OptimizationDesignRunRequest,
     OptimizationRunSettings,
 )
-from albert.resources.targets import Criterion
 
 
 class DesignRunCollection(BaseCollection):
@@ -58,7 +58,7 @@ class DesignRunCollection(BaseCollection):
         *,
         smart_dataset_id: SmartDatasetId,
         name: str | None = None,
-        objectives: dict[TargetId, Criterion] | None = None,
+        objectives: dict[TargetId, DesignObjective] | None = None,
         settings: OptimizationRunSettings | None = None,
         chat_session: ChatSessionRef | None = None,
     ) -> BTInsight:
@@ -80,10 +80,14 @@ class DesignRunCollection(BaseCollection):
         name : str, optional
             Display name for the resulting insight. When ``None``, a name is
             generated from the smart dataset id.
-        objectives : dict[TargetId, Criterion], optional
-            Per-target objectives. Each key must be present within the dataset.
-            When ``None``, all targets in the dataset are optimized using their own
-            target values.
+        objectives : dict[TargetId, DesignObjective], optional
+            Per-target objectives, each carrying an optional ``weight`` that sets how
+            much it counts relative to the others on this run. See
+            [`DesignObjective`][albert.resources.design.DesignObjective]. Each key must
+            be present within the dataset. When ``None``, all targets in the dataset are
+            optimized using their own target values, each at the default weight. A plain
+            [`Criterion`][albert.resources.targets.Criterion] is accepted and takes the
+            default weight.
         settings : OptimizationRunSettings, optional
             Run sizing for candidate generation and selection. See
             [`OptimizationRunSettings`][albert.resources.design.OptimizationRunSettings].
@@ -177,7 +181,7 @@ class DesignRunCollection(BaseCollection):
         self,
         *,
         smart_dataset_id: SmartDatasetId,
-        objectives: dict[TargetId, Criterion] | None = None,
+        objectives: dict[TargetId, DesignObjective] | None = None,
         settings: OptimizationRunSettings | None = None,
     ) -> DesignRunValidationResponse:
         """Validate an optimization run configuration without starting a job.
@@ -198,8 +202,9 @@ class DesignRunCollection(BaseCollection):
         ----------
         smart_dataset_id : SmartDatasetId
             The smart dataset used to train the surrogate model.
-        objectives : dict[TargetId, Criterion], optional
-            Per-target objectives for the optimization run.
+        objectives : dict[TargetId, DesignObjective], optional
+            Per-target objectives for the optimization run, each carrying an optional
+            ``weight``. See [`DesignObjective`][albert.resources.design.DesignObjective].
         settings : OptimizationRunSettings, optional
             Run sizing for candidate generation and selection.
 

--- a/src/albert/resources/design.py
+++ b/src/albert/resources/design.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import sys
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator, model_validator
 
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.identifiers import SmartDatasetId, TargetId
@@ -89,6 +89,58 @@ class OptimizationRunSettings(BaseAlbertModel):
     """Top diverse candidates to return after ranking (default ``20``, range ``1``–``100``)."""
 
 
+class DesignObjective(Criterion):
+    """A per-run optimization goal: a success criterion plus how much it matters.
+
+    A [`Criterion`][albert.resources.targets.Criterion] states what good looks like.
+    ``weight`` states how much that goal counts relative to the other objectives on the
+    same run, and belongs to the run rather than to the Target. A Target carries no
+    priority of its own, so the same targets can be reweighted from one run to the next
+    to see how the trade-off moves the candidates.
+
+    A plain ``Criterion`` is accepted anywhere a ``DesignObjective`` is expected and
+    takes the default weight.
+
+    !!! example
+        ```python
+        from albert.resources.design import DesignObjective
+
+        # a hard specification that should not be traded away
+        DesignObjective(operator="gte", value=95, weight=3.0)
+
+        # the same goal at the default weight
+        DesignObjective(operator="gte", value=95)
+        ```
+    """
+
+    weight: float = Field(default=1.0, gt=0)
+    """How much this objective counts relative to the others on the same run.
+
+    Candidate scores are combined as a product of each objective's score raised to its
+    weight, so a weight above ``1.0`` makes the objective harder to trade away and a
+    weight below ``1.0`` makes it easier. Must be positive; to ignore an objective,
+    leave it out.
+
+    Always a float, never ``None``: an unweighted objective is ``1.0``, which weighs it
+    equally against the others. Omitting the field, or passing an explicit ``None``,
+    both give ``1.0``.
+    """
+
+    @model_validator(mode="before")
+    @classmethod
+    def _accept_plain_criterion(cls, value: object) -> object:
+        """Accept a plain Criterion, giving it the default weight."""
+        if isinstance(value, Criterion) and not isinstance(value, cls):
+            return value.model_dump()
+        return value
+
+    @field_validator("weight", mode="before")
+    @classmethod
+    def _null_weight_is_unweighted(cls, value: object) -> object:
+        """Treat an explicit null as unset, so the weight is always a float."""
+        return 1.0 if value is None else value
+
+
 class OptimizationDesignRunRequest(BaseAlbertModel):
     """Request body for a model-guided optimization design run."""
 
@@ -101,8 +153,8 @@ class OptimizationDesignRunRequest(BaseAlbertModel):
     name: str | None = Field(default=None, min_length=1, max_length=255)
     """Display name for the resulting insight; a name is generated when omitted."""
 
-    objectives: dict[TargetId, Criterion] | None = None
-    """Per-target objectives; omitted to optimize every scoped target."""
+    objectives: dict[TargetId, DesignObjective] | None = None
+    """Per-target objectives, each with its weight; omitted to optimize every scoped target."""
 
     settings: OptimizationRunSettings | None = None
     """Settings for a model-guided optimization design run."""

--- a/tests/collections/test_design_runs.py
+++ b/tests/collections/test_design_runs.py
@@ -2,7 +2,7 @@ import pytest
 
 from albert.client import Albert
 from albert.resources.btinsight import BTInsight, BTInsightCategory
-from albert.resources.design import DesignRunValidationResponse
+from albert.resources.design import DesignObjective, DesignRunValidationResponse
 from albert.resources.smart_datasets import SmartDataset
 from albert.resources.targets import Criterion
 
@@ -62,3 +62,57 @@ def test_validate_doe_returns_response(client: Albert, seeded_smart_dataset: Sma
     result = client.design_runs.validate_doe(smart_dataset_id=seeded_smart_dataset.id)
     assert isinstance(result, DesignRunValidationResponse)
     assert isinstance(result.valid, bool)
+
+
+@ignore_in_ten0
+def test_create_optimization_accepts_weighted_objectives(
+    client: Albert, seeded_smart_dataset: SmartDataset
+) -> None:
+    """Test create_optimization accepts an objective carrying a weight."""
+    target_id = seeded_smart_dataset.scope.target_ids[0]
+    insight = client.design_runs.create_optimization(
+        smart_dataset_id=seeded_smart_dataset.id,
+        name="SDK weighted optimization run",
+        objectives={target_id: DesignObjective(operator="gte", value=1.0, weight=2.0)},
+    )
+    assert isinstance(insight, BTInsight)
+    assert insight.category == BTInsightCategory.GENERATE
+
+
+@ignore_in_ten0
+def test_validate_optimization_accepts_weighted_objectives(
+    client: Albert, seeded_smart_dataset: SmartDataset
+) -> None:
+    """Test validate_optimization accepts an objective carrying a weight."""
+    target_id = seeded_smart_dataset.scope.target_ids[0]
+    result = client.design_runs.validate_optimization(
+        smart_dataset_id=seeded_smart_dataset.id,
+        objectives={target_id: DesignObjective(operator="gte", value=1.0, weight=2.0)},
+    )
+    assert isinstance(result, DesignRunValidationResponse)
+
+
+@ignore_in_ten0
+def test_validate_optimization_accepts_plain_criterion(
+    client: Albert, seeded_smart_dataset: SmartDataset
+) -> None:
+    """Test a plain Criterion is still accepted and takes the default weight."""
+    target_id = seeded_smart_dataset.scope.target_ids[0]
+    result = client.design_runs.validate_optimization(
+        smart_dataset_id=seeded_smart_dataset.id,
+        objectives={target_id: Criterion(operator="gte", value=1.0)},
+    )
+    assert isinstance(result, DesignRunValidationResponse)
+
+
+@ignore_in_ten0
+def test_validate_optimization_treats_a_null_weight_as_unweighted(
+    client: Albert, seeded_smart_dataset: SmartDataset
+) -> None:
+    """Test an explicit null weight resolves to the default rather than failing."""
+    target_id = seeded_smart_dataset.scope.target_ids[0]
+    result = client.design_runs.validate_optimization(
+        smart_dataset_id=seeded_smart_dataset.id,
+        objectives={target_id: {"operator": "gte", "value": 1.0, "weight": None}},
+    )
+    assert isinstance(result, DesignRunValidationResponse)


### PR DESCRIPTION
## Why

Optimization design runs weighed every objective equally. Candidate scores are combined as a product of each objective's score, which is a strict logical AND: a candidate is only good if it is good on every dimension. That is the right default for experimental chemistry, but it left a caller with no way to say "viscosity matters more than cost here" short of loosening a target they did not actually want to loosen.

## What

Adds `DesignObjective`, a `Criterion` subclass carrying a positive `weight` that defaults to `1.0`. The engine composes objectives as `Π_i score_i ** w_i`, so a weight above `1.0` makes an objective harder to trade away and below `1.0` makes it easier. At `1.0` the composed score is bit-for-bit what it is today.

```python
client.design_runs.create_optimization(
    smart_dataset_id="SDT000001",
    objectives={
        "TAR000001": DesignObjective(operator="gte", value=95, weight=3.0),
        "TAR000002": DesignObjective(operator="lte", value=10),
    },
)
```

## Design notes

**The weight belongs to the run, not to the Target.** A `Target` states what good looks like: a threshold, a range, an approved set. It says nothing about how much that goal matters relative to another, and it should not, because the answer changes with the question being asked. A formulator exploring a trade-off fires several runs against one Smart Dataset with the same targets and different weights, precisely to see how the candidate set moves. Putting the weight on the `Target` would make that a destructive edit to a shared entity, visible to every other consumer of that target and to every past run's provenance. `Target.target_value` therefore keeps using a plain `Criterion`, untouched.

**Flat field, not a nested wrapper.** The obvious modelling of "a goal plus its priority" is `{criterion: {...}, weight: n}`. Rejected on two counts: it would break every existing request body, where a flat added field with a default does not; and `create_optimization` is an agent tool whose signature becomes the LLM tool schema, where added nesting depth costs tool-calling accuracy.

**`weight` is always a float, never `None`.** An unweighted objective is `1.0`, which is what "unweighted" means arithmetically in a product. There is no separate absent state to branch on, so nothing downstream needs a `weight or 1.0` fallback. An explicit JSON `null` coerces to `1.0` rather than raising, for clients that serialize an unset field as null. Zero and negatives are rejected: `x ** 0 == 1` would silently neutralize an objective while it still appeared in the run configuration.

## Compatibility

Additive. A request that sets no weights is unchanged, and a plain `Criterion` is still accepted anywhere a `DesignObjective` is expected (via a `mode="before"` validator) and takes the default weight. Existing callers need no change.

## Testing

Four integration tests added to `tests/collections/test_design_runs.py` covering a weighted objective on create and validate, a plain `Criterion` still being accepted, and an explicit null resolving to the default. `ruff check` and `ruff format --check` clean across `src` and `tests`.

Note: these tests carry the existing `ignore_in_ten0` xfail, and I could not execute them locally (no `ALBERT_CLIENT_ID_SDK` credentials in my environment). I verified the model behavior directly instead: omitted, explicit-null, plain-`Criterion`, and explicitly-set weights all resolve to a `float`, and the serialized wire body carries `weight` on every objective.

## Follow-up

The private tier (`api_ai_zeus`, `lib_ai_schemas`) already implements the matching contract and declares its own `DesignObjective`, since it pins a published `albert>=1.47.2,<2` and cannot import this one until it ships. Once this releases, `svc_ai_react_worker` can bump the pin and type its design-run proxy against `DesignObjective` so the agent can set weights too. Until then the agent path works unchanged at the default weight.

This PR contains AI-assisted code generated with Claude Code. The author has reviewed and takes full responsibility for all changes.