### PR TITLE
feat(sds): model the remaining optional SDSRequest fields

### DIFF
--- a/src/albert/resources/sds.py
+++ b/src/albert/resources/sds.py
@@ -194,6 +194,79 @@ class SDSRequest(BaseAlbertModel):
     kinematic_viscosity_40: float | None = Field(default=None, alias="kinematicViscosity40")
     """Kinematic viscosity at 40°C in mm²/s, optional."""
 
+    intended_use: str | None = Field(default=None, alias="intendedUse")
+    """Intended-use option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``intendedUse``, optional. Required by some tenants."""
+
+    use: str | None = Field(default=None)
+    """Use option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``use``, optional."""
+
+    physical_form: str | None = Field(default=None, alias="physicalForm")
+    """Physical-form option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``physicalForm``, optional."""
+
+    waste_code: str | None = Field(default=None, alias="wasteCode")
+    """Union waste-code option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``wasteCode``, optional."""
+
+    flammability: str | None = Field(default=None)
+    """Flammability option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``flammability``, optional."""
+
+    burning_test_result: str | None = Field(default=None, alias="burningTestResult")
+    """Burning-test option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``burningTestResult``, optional. Filtered by ``flammability``."""
+
+    plm_number: str | None = Field(default=None, alias="plmNumber", max_length=100)
+    """PLM number, optional. Tenant-gated via field options (``plmNumber``)."""
+
+    ufi_identifier: str | None = Field(default=None, alias="ufiIdentifier", max_length=100)
+    """UFI identifier, optional. Tenant-gated via field options (``ufiIdentifier``)."""
+
+    viscosity_input: str | None = Field(default=None, alias="viscosityInput", max_length=100)
+    """Viscosity SDS-output option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``viscosityInput``, optional."""
+
+    particle_characteristics: str | None = Field(default=None, alias="particleCharacteristics")
+    """Particle-characteristics option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``particleCharacteristics``, optional."""
+
+    ph_input: str | None = Field(default=None, alias="pHInput", max_length=100)
+    """pH SDS-output option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``pHInput``, optional."""
+
+    melting_point_range: str | None = Field(
+        default=None, alias="meltingPointRange", max_length=100
+    )
+    """Melting point / freezing point option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``meltingPointRange``, optional."""
+
+    boiling_point_range: str | None = Field(
+        default=None, alias="boilingPointRange", max_length=100
+    )
+    """Boiling point option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``boilingPointRange``, optional."""
+
+    vapor_pressure: str | None = Field(default=None, alias="vaporPressure", max_length=100)
+    """Vapor-pressure option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``vaporPressure``, optional."""
+
+    vapor_density: str | None = Field(default=None, alias="vaporDensity", max_length=100)
+    """Vapor-density option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``vaporDensity``, optional."""
+
+    water_solubility: str | None = Field(default=None, alias="waterSolubility", max_length=100)
+    """Water-solubility option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``waterSolubility``, optional."""
+
+    auto_ignition_temp: str | None = Field(default=None, alias="autoIgnitionTemp", max_length=100)
+    """Auto-ignition temperature option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``autoIgnitionTemp``, optional."""
+
+    decomposition_temp: str | None = Field(default=None, alias="decompositionTemp", max_length=100)
+    """Decomposition temperature option value from [`get_field_options`][albert.collections.sds.SDSCollection.get_field_options] with ``decompositionTemp``, optional."""
+
+    evaporation_rate: str | None = Field(default=None, alias="evaporationRate")
+    """Evaporation rate, optional. Not gated by tenant field options."""
+
+    explosive_limits_lower: str | None = Field(default=None, alias="explosiveLimitsLower")
+    """Lower explosive limit, optional. Not gated by tenant field options."""
+
+    explosive_limits_upper: str | None = Field(default=None, alias="explosiveLimitsUpper")
+    """Upper explosive limit, optional. Not gated by tenant field options."""
+
+    odor_threshold: str | None = Field(default=None, alias="odorThreshold")
+    """Odor threshold, optional. Not gated by tenant field options."""
+
+    partition_coefficient: str | None = Field(default=None, alias="partitionCoefficient")
+    """Partition coefficient (n-octanol/water), optional. Not gated by tenant field options."""
+
     @field_serializer("albert_id")
     def _serialize_albert_id(self, value: str) -> str:
         return remove_id_prefix(value, "InventoryId")

--- a/tests/collections/test_sds.py
+++ b/tests/collections/test_sds.py
@@ -74,6 +74,22 @@ def test_generate_sds_unpacks_formula(client: Albert, seeded_products: list[Inve
         pytest.skip("Tenant SDS lookups are missing language, state, product, or legal entity")
 
     formula = seeded_products[0]
+    intended_use = None
+    try:
+        intended_use_options = client.sds.get_field_options(
+            entity=SDSDataEntity.INTENDED_USE, region=region
+        )
+    except AlbertClientError:
+        intended_use_options = SDSFieldOptions(display=False)
+    if intended_use_options.display and isinstance(intended_use_options.data, list):
+        intended_use = next(
+            (
+                item["value"]
+                for item in intended_use_options.data
+                if isinstance(item, dict) and item.get("value") is not None
+            ),
+            None,
+        )
     sds = SDSRequest(
         albert_id=formula.id,
         region=region,
@@ -81,6 +97,7 @@ def test_generate_sds_unpacks_formula(client: Albert, seeded_products: list[Inve
         product_type=_first_code(products),
         physical_state=_first_code(states),
         legal_entity=entities[0].value,
+        intended_use=intended_use,
     )
     try:
         result = client.sds.generate_sds(sds=sds)

--- a/tests/resources/test_sds.py
+++ b/tests/resources/test_sds.py
@@ -61,6 +61,98 @@ def test_sds_request_dump_strips_inv_prefix():
     assert "name" not in payload
 
 
+def test_sds_request_optional_fields_serialize_to_aliases():
+    """Test the optional generate fields dump to their exact wire aliases."""
+    sds = SDSRequest(
+        **_identity_kwargs(),
+        intended_use="coatings",
+        use="industrial",
+        physical_form="liquid",
+        waste_code="080410",
+        flammability="flammable",
+        burning_test_result="positive",
+        plm_number="PLM-1",
+        ufi_identifier="UFI-1",
+        viscosity_input="thin",
+        particle_characteristics="fine",
+        ph_input="neutral",
+        melting_point_range="0-10",
+        boiling_point_range="90-110",
+        vapor_pressure="low",
+        vapor_density="high",
+        water_solubility="miscible",
+        auto_ignition_temp="300",
+        decomposition_temp="250",
+        evaporation_rate="slow",
+        explosive_limits_lower="1",
+        explosive_limits_upper="10",
+        odor_threshold="low",
+        partition_coefficient="2.5",
+    )
+    payload = sds.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert payload["intendedUse"] == "coatings"
+    assert payload["use"] == "industrial"
+    assert payload["physicalForm"] == "liquid"
+    assert payload["wasteCode"] == "080410"
+    assert payload["flammability"] == "flammable"
+    assert payload["burningTestResult"] == "positive"
+    assert payload["plmNumber"] == "PLM-1"
+    assert payload["ufiIdentifier"] == "UFI-1"
+    assert payload["viscosityInput"] == "thin"
+    assert payload["particleCharacteristics"] == "fine"
+    assert payload["pHInput"] == "neutral"
+    assert payload["meltingPointRange"] == "0-10"
+    assert payload["boilingPointRange"] == "90-110"
+    assert payload["vaporPressure"] == "low"
+    assert payload["vaporDensity"] == "high"
+    assert payload["waterSolubility"] == "miscible"
+    assert payload["autoIgnitionTemp"] == "300"
+    assert payload["decompositionTemp"] == "250"
+    assert payload["evaporationRate"] == "slow"
+    assert payload["explosiveLimitsLower"] == "1"
+    assert payload["explosiveLimitsUpper"] == "10"
+    assert payload["odorThreshold"] == "low"
+    assert payload["partitionCoefficient"] == "2.5"
+
+
+def test_sds_request_omits_unset_optional_fields():
+    """Test unset optional generate fields are excluded from the dump."""
+    sds = SDSRequest(**_identity_kwargs())
+    payload = sds.model_dump(by_alias=True, mode="json", exclude_none=True)
+    for alias in (
+        "intendedUse",
+        "use",
+        "physicalForm",
+        "wasteCode",
+        "flammability",
+        "burningTestResult",
+        "plmNumber",
+        "ufiIdentifier",
+        "viscosityInput",
+        "particleCharacteristics",
+        "pHInput",
+        "meltingPointRange",
+        "boilingPointRange",
+        "vaporPressure",
+        "vaporDensity",
+        "waterSolubility",
+        "autoIgnitionTemp",
+        "decompositionTemp",
+        "evaporationRate",
+        "explosiveLimitsLower",
+        "explosiveLimitsUpper",
+        "odorThreshold",
+        "partitionCoefficient",
+    ):
+        assert alias not in payload
+
+
+def test_sds_request_enforces_backend_max_length():
+    """Test fields with a backend maxLength of 100 fail fast client-side."""
+    with pytest.raises(ValidationError):
+        SDSRequest(**_identity_kwargs(), plm_number="x" * 101)
+
+
 def test_require_formula_inventory_rejects_raw_materials():
     """Test SDS generate rejects non-formula inventory items."""
     item = InventoryItem(name="ethanol", category=InventoryCategory.RAW_MATERIALS)


### PR DESCRIPTION
## What

`SDSRequest` now models all 23 remaining optional fields the SDS generate API (`POST /api/v2/documentgenerator/sds`) already accepts. `intended_use`, `use`, `physical_form`, `waste_code`, `flammability`, `burning_test_result`, `plm_number`, `ufi_identifier`, `viscosity_input`, `particle_characteristics`, `ph_input`, `melting_point_range`, `boiling_point_range`, `vapor_pressure`, `vapor_density`, `water_solubility`, `auto_ignition_temp`, `decomposition_temp`, plus 5 no-entity Section 9 fields (`evaporation_rate`, `explosive_limits_lower/upper`, `odor_threshold`, `partition_coefficient`).

## Why

The generate backend accepts ~40 request fields; the SDK modeled 24 and rejected the rest (`extra="forbid"`). Most urgently, `intendedUse` is **required** for tenants TEN4 and TEN7, and could not be sent through the SDK at all. Unblocks [AI-1663](https://linear.app/albert-invent/issue/AI-1663/wire-the-full-sds-field-set-into-the-generation-questionnaire-prose), which wires these into the Ask Albert SDS questionnaire. Implements [SDK-93](https://linear.app/albert-invent/issue/SDK-93/model-the-23-missing-optional-sdsrequest-fields-the-generate-api) per `plans/sds-field-coverage.md`. Zero backend changes; every field already exists on the contract.

## How

- All 23 fields verified against the backend OpenAPI schema (`api-documentgenerator/rest/documentgenerator.yaml`): every one is `type: string`, none required, so all are `str | None = Field(default=None, alias=...)`.
- The 11 fields carrying backend `maxLength: 100` get `max_length=100` so the SDK fails fast client-side instead of round-tripping a 400.
- 18 entity-backed fields reuse existing `SDSDataEntity` members; no enum changes. The 5 no-entity fields are modeled for contract completeness only (PM sign-off: not collected anywhere yet).
- No collection-layer change: `generate_sds` dumps with `by_alias=True, exclude_none=True`, so the new fields flow through and are omitted when unset.
- Out of scope per plan: `location`, `peroxide_check`, `project_color_formula_id` left as-is (dead as inputs); no `SDSDataEntity` additions.

## Testing

- `uv run pytest tests/resources/test_sds.py -v` — 10 passed, including new tests: each new field serializes to its exact wire alias, unset fields are excluded from the dump, and `max_length=100` is enforced client-side.
- `uv run ruff format . && uv run ruff check . --fix` — clean.
- `tests/collections/test_sds.py` extended so the live `generate_sds` test sets `intended_use` from tenant field options when the tenant displays it. Not run here: integration tests need `ALBERT_CLIENT_ID_SDK` / `ALBERT_CLIENT_SECRET_SDK` / `ALBERT_BASE_URL` against a live tenant (no test CI in this repo). Please run `uv run pytest tests/collections/test_sds.py -v -n 4` before merge.

Cake session: https://agents.ai.albertinventdev.com/sessions/416fbbd4-beca-4e22-92c0-9f0a78feeadd