### PR TITLE
fix(sheets): default new formula columns to rightOf last column

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -1274,7 +1274,9 @@ class Sheet(BaseSessionResource):  # noqa:F811
         starting_position : dict, optional
             Where to insert the new columns, as a dict with ``reference_id`` (a
             column ID) and ``position`` (``"leftOf"`` or ``"rightOf"``). When
-            omitted, the platform chooses the default placement.
+            omitted, inserts ``RIGHT_OF`` the last product-design column, matching
+            [`add_blank_column`][albert.resources.sheets.Sheet.add_blank_column] and
+            other ``add_*_column`` helpers.
 
         Returns
         -------
@@ -1288,15 +1290,22 @@ class Sheet(BaseSessionResource):  # noqa:F811
             formulation_names if isinstance(formulation_names, list) else [formulation_names]
         )
 
+        if starting_position is None:
+            starting_position = {
+                "reference_id": (
+                    self.columns[-1].column_id if self.columns else self.leftmost_pinned_column
+                ),
+                "position": ColumnPosition.RIGHT_OF.value,
+            }
+
         payload = []
         for formulation_name in formulation_names:
-            entry = {"type": "INV", "name": formulation_name}
-            # When no position is given, omit referenceId/position so the platform
-            # applies its default placement. Sending a null (or stale) referenceId
-            # leaves the new column out of the sheet sequence, hiding it on refresh.
-            if starting_position is not None:
-                entry["referenceId"] = starting_position["reference_id"]
-                entry["position"] = starting_position["position"]
+            entry = {
+                "type": "INV",
+                "name": formulation_name,
+                "referenceId": starting_position["reference_id"],
+                "position": starting_position["position"],
+            }
             payload.append(entry)
         response = self.session.post(endpoint, json=payload)
 

--- a/tests/collections/test_custom_templates.py
+++ b/tests/collections/test_custom_templates.py
@@ -93,9 +93,20 @@ def test_custom_template_update_acl(
     assert any(entry.id == static_user.id for entry in updated.acl.fgclist)
 
 
-def test_hydrate_custom_template(client: Albert, seeded_custom_templates: list[CustomTemplate]):
-    seeded_template = seeded_custom_templates[0]
-    custom_templates = list(client.custom_templates.search(text=seeded_template.name, max_items=5))
+def test_hydrate_custom_template(
+    client: Albert,
+    seed_prefix: str,
+    seeded_custom_templates: list[CustomTemplate],
+):
+    """Test hydrate on search hits scoped to the seeded custom template ids."""
+    seeded_ids = {t.id for t in seeded_custom_templates}
+    custom_templates = poll_until(
+        lambda: [
+            t
+            for t in client.custom_templates.search(text=seed_prefix, max_items=100)
+            if t.id in seeded_ids
+        ]
+    )
     assert custom_templates, "Expected at least one custom_template in search results"
 
     for custom_template in custom_templates:


### PR DESCRIPTION
## What

Callers using `add_formulation()` (and `add_formulation_columns()` without `starting_position`) now get unpinned formula columns appended after the last product-design column, consistent with `add_blank_column` and other `add_*_column` helpers.

## Why

After #630 omitted `referenceId`/`position` to avoid columns dropping from the sheet sequence, the API default (`leftOf` COL4) inherited the pinned state of the reference column. Every new formula column was pinned left, which breaks worksheets when dozens of formulas are added.

## How

When `starting_position` is omitted, the SDK resolves placement the same way as `_add_column`: `rightOf` the last column in the product design grid (falling back to `leftmost_pinned_column` on an empty sheet). Callers can still override via `starting_position` on `add_formulation_columns`.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/resources/test_sheets.py -v -n 4 -k formulation`
- [x] Manual dev verification on `WKS103571` (`add_formulation` unpinned; explicit `leftOf` still inherits pin as expected)

## SDK Changes

`add_formulation()` no longer produces pinned-left formula columns by default. Formula columns are inserted to the right of the last product-design column unless `starting_position` is provided to `add_formulation_columns`.