### PR TITLE
feat(sheets): add reorder_columns for worksheet column order

### DIFF
--- a/src/albert/resources/sheets.py
+++ b/src/albert/resources/sheets.py
@@ -732,6 +732,8 @@ class Sheet(BaseSessionResource):  # noqa:F811
         Show a hidden column.
     set_columns_width(col_ids, width) -> None
         Set the display width of columns.
+    reorder_columns(column_ids) -> None
+        Reorder all columns left to right by column ID.
     delete_column(column_id) -> None
         Delete a column.
     delete_row(row_id, design_id) -> None
@@ -2225,6 +2227,97 @@ class Sheet(BaseSessionResource):  # noqa:F811
                 "datacolumnName": data_column_name,
             },
         )
+
+    def _move_column(
+        self,
+        *,
+        source_id: str,
+        reference_id: str,
+        position: ColumnPosition,
+    ) -> None:
+        payload = {
+            "data": [
+                {
+                    "operation": "update",
+                    "attribute": "sequence",
+                    "sourceId": source_id,
+                    "referenceId": reference_id,
+                    "position": (
+                        position.value if isinstance(position, ColumnPosition) else position
+                    ),
+                }
+            ]
+        }
+        self.session.patch(f"/api/v3/worksheet/sheet/{self.id}/columns", json=payload)
+
+    @validate_call
+    def reorder_columns(self, *, column_ids: list[str]) -> None:
+        """Reorder all columns on this sheet from left to right.
+
+        Provide every column ID on the sheet exactly once, in the desired display
+        order. The first ID is placed at the left edge; the last at the right.
+
+        !!! example
+            ```python
+            column_ids = [col.column_id for col in sheet.columns]
+            column_ids = [column_ids[2], column_ids[0], column_ids[1], *column_ids[3:]]
+            sheet.reorder_columns(column_ids=column_ids)
+            ```
+
+        Parameters
+        ----------
+        column_ids : list[str]
+            Column IDs in the desired left-to-right order. Must include every column
+            on the sheet exactly once.
+
+        Returns
+        -------
+        None
+
+        Raises
+        ------
+        AlbertException
+            If ``column_ids`` is empty, contains duplicates or unknown IDs, or omits
+            any column on the sheet.
+        """
+        if not column_ids:
+            raise AlbertException("column_ids must include at least one column ID.")
+
+        current_ids = [col.column_id for col in self.columns]
+        current_set = set(current_ids)
+        if len(column_ids) != len(set(column_ids)):
+            raise AlbertException("column_ids must not contain duplicates.")
+
+        unknown = set(column_ids) - current_set
+        if unknown:
+            raise AlbertException(f"Unknown column ID(s): {', '.join(sorted(unknown))}")
+
+        missing = current_set - set(column_ids)
+        if missing:
+            raise AlbertException(
+                "column_ids must include every column on the sheet; "
+                f"missing: {', '.join(sorted(missing))}"
+            )
+
+        if column_ids == current_ids:
+            return
+
+        order = list(current_ids)
+        for i, target_id in enumerate(column_ids):
+            j = order.index(target_id)
+            if j == i:
+                continue
+            reference_id = order[i]
+            position = ColumnPosition.LEFT_OF if j > i else ColumnPosition.RIGHT_OF
+            self._move_column(
+                source_id=target_id,
+                reference_id=reference_id,
+                position=position,
+            )
+            order.pop(j)
+            order.insert(i, target_id)
+
+        self.grid = None
 
     @validate_call
     def pin_columns(

--- a/tests/resources/test_sheets.py
+++ b/tests/resources/test_sheets.py
@@ -527,6 +527,87 @@ def test_add_task_row(
             client.projects.delete(id=project.id)
 
 
+def _column_ids(sheet: Sheet) -> list[str]:
+    return [col.column_id for col in sheet.columns]
+
+
+def test_reorder_columns_basic(seeded_sheet: Sheet):
+    """Test reordering newly added blank columns and restoring the original order."""
+    seeded_sheet.grid = None
+    col_a = seeded_sheet.add_blank_column(name="reorder test A")
+    col_b = seeded_sheet.add_blank_column(name="reorder test B")
+    col_c = seeded_sheet.add_blank_column(name="reorder test C")
+    original_order = _column_ids(seeded_sheet)
+    try:
+        assert original_order[-3:] == [col_a.column_id, col_b.column_id, col_c.column_id]
+        desired = original_order[:-3] + [
+            col_c.column_id,
+            col_b.column_id,
+            col_a.column_id,
+        ]
+        seeded_sheet.reorder_columns(column_ids=desired)
+        assert _column_ids(seeded_sheet) == desired
+
+        seeded_sheet.reorder_columns(column_ids=original_order)
+        assert _column_ids(seeded_sheet) == original_order
+    finally:
+        for col in (col_a, col_b, col_c):
+            seeded_sheet.delete_column(column_id=col.column_id)
+        seeded_sheet.grid = None
+
+
+def test_reorder_columns_noop(seeded_sheet: Sheet):
+    """Test that passing the current order is a no-op."""
+    seeded_sheet.grid = None
+    current = _column_ids(seeded_sheet)
+    seeded_sheet.reorder_columns(column_ids=current)
+    assert _column_ids(seeded_sheet) == current
+
+
+def test_reorder_columns_validation(seeded_sheet: Sheet):
+    """Test reorder_columns rejects invalid column ID lists."""
+    seeded_sheet.grid = None
+    current = _column_ids(seeded_sheet)
+
+    with pytest.raises(AlbertException, match="must not contain duplicates"):
+        seeded_sheet.reorder_columns(column_ids=[current[0], current[0]])
+
+    with pytest.raises(AlbertException, match="Unknown column ID"):
+        seeded_sheet.reorder_columns(column_ids=[*current, "COL999999999"])
+
+    with pytest.raises(AlbertException, match="must include every column"):
+        seeded_sheet.reorder_columns(column_ids=current[:-1])
+
+    with pytest.raises(AlbertException, match="must include at least one"):
+        seeded_sheet.reorder_columns(column_ids=[])
+
+
+def test_reorder_columns_with_pinned_column(seeded_sheet: Sheet):
+    """Test reordering column sequence when a left-pinned column is present."""
+    seeded_sheet.grid = None
+    col_a = seeded_sheet.add_blank_column(name="reorder pin A")
+    col_b = seeded_sheet.add_blank_column(name="reorder pin B")
+    col_c = seeded_sheet.add_blank_column(name="reorder pin C")
+    original_order = _column_ids(seeded_sheet)
+    try:
+        seeded_sheet.pin_columns(col_ids=[col_a.column_id], side="left")
+        seeded_sheet.grid = None
+
+        desired = original_order[:-3] + [
+            col_a.column_id,
+            col_c.column_id,
+            col_b.column_id,
+        ]
+        seeded_sheet.reorder_columns(column_ids=desired)
+        assert _column_ids(seeded_sheet) == desired
+    finally:
+        seeded_sheet.reorder_columns(column_ids=original_order)
+        seeded_sheet.unpin_columns(col_ids=[col_a.column_id])
+        for col in (col_a, col_b, col_c):
+            seeded_sheet.delete_column(column_id=col.column_id)
+        seeded_sheet.grid = None
+
+
 ########################## CELLS ##########################
 
 


### PR DESCRIPTION
## What

Callers can reorder all columns on a sheet in one call by passing the full left-to-right column ID list to `Sheet.reorder_columns`.

## Why

The SDK had no way to rearrange existing columns; callers could only pin/unpin or set placement when adding new columns. Worksheets often need bulk column reordering during automation.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/resources/test_sheets.py -k reorder_columns -v`

## SDK Changes

Added `Sheet.reorder_columns(column_ids=[...])`. Pass every column ID on the sheet exactly once in the desired display order.