### PR TITLE
test(cas): skip CAS collection tests pending deprecation

### DIFF
--- a/tests/collections/test_cas.py
+++ b/tests/collections/test_cas.py
@@ -11,7 +11,13 @@ from albert.resources.cas import Cas
 from albert.resources.custom_fields import CustomField, FieldType, ServiceType
 from albert.resources.lists import ListItem
 
-pytestmark = pytest.mark.xdist_group("projects")
+pytestmark = [
+    pytest.mark.xdist_group("projects"),
+    pytest.mark.skip(
+        reason="CAS collection is deprecated in favor of Substance v4; "
+        "the testing tenant has migrated to substance_v4."
+    ),
+]
 
 
 def _cas_list_metadata_items(


### PR DESCRIPTION
## What

All tests in `tests/collections/test_cas.py` are now unconditionally skipped. The CAS collection test suite no longer runs against the testing tenant.

## Why

The CAS collection will be deprecated in favor of Substance v4, and the testing tenant has already migrated to `substance_v4`, so these tests can no longer run against it (Linear: SDK-111).

## How

- Extended the module-level `pytestmark` to a list, keeping the existing `xdist_group("projects")` mark and adding a `pytest.mark.skip` with a reason, matching the established pattern for unavailable APIs (e.g. `test_chats.py`).
- Note on wording: the ticket says "mark as `xskip`", but pytest has no `xskip` marker and this repo has no custom one. The established repo convention for this exact situation is a module-level `pytest.mark.skip(reason=...)`, which is what is applied here.

## Testing

Ran `uv run pytest tests/collections/test_cas.py -v`: all 10 tests collect and report SKIPPED. Ruff format and check pass.

Cake session: https://agents.ai.albertinventdev.com/sessions/a650cf84-1240-4cab-99b0-c24d66881891