### PR TITLE
feat(data_columns): add search support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,6 +56,22 @@ pagination, resource naming, deprecations, releases, and testing edge cases.
 - Search result model naming: see `OPINIONS.md`.
 - Keep API payloads in wire format (camelCase) via `Field(alias=...)` and `model_dump(by_alias=True, mode="json", exclude_none=True)`.
 
+### Reuse shared enums and types
+
+Before typing a field as a bare `str` (or declaring a new local enum/model), check
+`src/albert/core/shared/` for an existing definition. Common cross-resource concepts
+already live there:
+
+- `enums.py` — `Status` (active/inactive), `OrderBy` (asc/desc), `SecurityClass`.
+- `models/base.py` — `EntityLink`, `EntityLinkWithName`, `AuditFields`, `LocalizedNames`.
+- `types.py` — `MetadataItem`, `SerializeAsEntityLink`.
+
+This applies to search items too (e.g. `status` on a `{Entity}SearchItem` is
+`Status | None`, not `str | None`), so wire values stay consistent and invalid values
+fail validation instead of passing through silently. If the API returns a value the
+shared enum lacks, add the member to the shared enum rather than widening the field to
+`str`. Only use a plain `str` when the field's values are genuinely open-ended.
+
 ### Pydantic `extra` on resource models
 
 `BaseAlbertModel` does not set `extra`. Pydantic's default is `extra="ignore"`: undeclared

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,9 +68,14 @@ already live there:
 
 This applies to search items too (e.g. `status` on a `{Entity}SearchItem` is
 `Status | None`, not `str | None`), so wire values stay consistent and invalid values
-fail validation instead of passing through silently. If the API returns a value the
-shared enum lacks, add the member to the shared enum rather than widening the field to
-`str`. Only use a plain `str` when the field's values are genuinely open-ended.
+fail validation instead of passing through silently.
+
+**Reuse only on an exact match.** Use a shared enum/type only when it covers exactly
+what the field requires: the same value set and the same semantics. Do not force-fit
+`Status` onto a field whose lifecycle has more or different states, and do not add
+members to a shared enum just to make one field fit. When the match is not exact, use
+`str` (for open-ended values) or a resource-specific enum (for a fixed but different
+value set).
 
 ### Pydantic `extra` on resource models
 

--- a/src/albert/collections/data_columns.py
+++ b/src/albert/collections/data_columns.py
@@ -1,5 +1,6 @@
 import logging
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import validate_call
 
@@ -9,7 +10,7 @@ from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import DataColumnId
 from albert.core.utils import ensure_list
-from albert.resources.data_columns import DataColumn
+from albert.resources.data_columns import DataColumn, DataColumnSearchItem
 
 
 class DataColumnCollection(BaseCollection):
@@ -45,6 +46,8 @@ class DataColumnCollection(BaseCollection):
 
     Methods
     -------
+    search(...) -> Iterator[DataColumnSearchItem]
+        Search data columns with free text and filters, returning partial items.
     get_all(...) -> Iterator[DataColumn]
         Get data columns matching optional filters.
     get_by_id(id) -> DataColumn
@@ -80,7 +83,8 @@ class DataColumnCollection(BaseCollection):
         """Get a single data column by its exact name.
 
         Matching is case-insensitive. To retrieve multiple columns or use partial
-        matching, use [`get_all`][albert.collections.data_columns.DataColumnCollection.get_all] instead.
+        matching, use [`get_all`][albert.collections.data_columns.DataColumnCollection.get_all]; for
+        free-text search, use [`search`][albert.collections.data_columns.DataColumnCollection.search].
 
         !!! example
             ```python
@@ -133,6 +137,115 @@ class DataColumnCollection(BaseCollection):
         return dc
 
     @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        created_by: str | list[str] | None = None,
+        data_template: str | list[str] | None = None,
+        albert_id: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        additional_field: str | list[str] | None = None,
+        translation: str | list[str] | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        metadata_filters: dict[str, Any] | None = None,
+        custom_fields: dict[str, Any] | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[DataColumnSearchItem]:
+        """Search for data columns matching the given filters.
+
+        Returns partial (unhydrated)
+        [`DataColumnSearchItem`][albert.resources.data_columns.DataColumnSearchItem] entities, best for
+        free-text lookups, counts, and pulling IDs. Results are returned lazily as an
+        iterator that pages through matches on demand. Call ``hydrate()`` on an item
+        to fetch its full [`DataColumn`][albert.resources.data_columns.DataColumn].
+
+        !!! example
+            ```python
+            for item in client.data_columns.search(text="Viscosity", max_items=10):
+                print(item.id, item.name)
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query matched against data column fields.
+        created_by : str or list[str], optional
+            Filter by creator user ID(s).
+        data_template : str or list[str], optional
+            Filter by data template name(s) the columns belong to.
+        albert_id : str or list[str], optional
+            Filter by Data Column ID(s) (format ``DAC...``).
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        source_field : str or list[str], optional
+            Restrict which fields are returned on each search hit.
+        additional_field : str or list[str], optional
+            Additional fields to include on each search hit.
+        translation : str or list[str], optional
+            Filter by translation(s).
+        sort_by : str, optional
+            Attribute to sort results by.
+        order : OrderBy, optional
+            The order in which to sort results (``asc`` or ``desc``).
+        metadata_filters : dict[str, Any], optional
+            Filter by metadata field values.
+        custom_fields : dict[str, Any], optional
+            Filter by custom field values.
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matching items.
+
+        Returns
+        -------
+        Iterator[DataColumnSearchItem]
+            A lazy iterator of matching partial data columns. Call ``hydrate()`` on an
+            item to fetch its full [`DataColumn`][albert.resources.data_columns.DataColumn].
+        """
+        payload: dict[str, Any] = {
+            "text": text,
+            "createdBy": ensure_list(created_by),
+            "dataTemplate": ensure_list(data_template),
+            "albertId": ensure_list(albert_id),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "sourceField": ensure_list(source_field),
+            "additionalField": ensure_list(additional_field),
+            "translation": ensure_list(translation),
+            "sortBy": sort_by,
+            "order": order,
+        }
+        if metadata_filters is not None:
+            payload["metadataFilters"] = {"metadata": metadata_filters}
+        if custom_fields is not None:
+            payload["customFields"] = {"metadata": custom_fields}
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            method="POST",
+            json=payload,
+            max_items=max_items,
+            deserialize=lambda items: [
+                DataColumnSearchItem.model_validate(x)._bind_collection(self) for x in items
+            ],
+        )
+
+    @validate_call
     def get_all(
         self,
         *,
@@ -148,7 +261,8 @@ class DataColumnCollection(BaseCollection):
 
         Results are returned as a lazily paginated iterator, so iterating fetches
         additional pages on demand. To retrieve a single column by its exact name,
-        use [`get_by_name`][albert.collections.data_columns.DataColumnCollection.get_by_name]; by its ID, use [`get_by_id`][albert.collections.data_columns.DataColumnCollection.get_by_id].
+        use [`get_by_name`][albert.collections.data_columns.DataColumnCollection.get_by_name]; by its ID, use [`get_by_id`][albert.collections.data_columns.DataColumnCollection.get_by_id]. For
+        free-text search, use [`search`][albert.collections.data_columns.DataColumnCollection.search].
 
         !!! example
             ```python

--- a/src/albert/resources/data_columns.py
+++ b/src/albert/resources/data_columns.py
@@ -1,7 +1,12 @@
+from typing import Any
+
 from pydantic import Field
 
+from albert.core.base import BaseAlbertModel
+from albert.core.shared.identifiers import DataColumnId
 from albert.core.shared.models.base import BaseResource
 from albert.core.shared.types import MetadataItem
+from albert.resources._mixins import HydrationMixin
 
 
 class DataColumn(BaseResource):
@@ -39,3 +44,70 @@ class DataColumn(BaseResource):
 
     id: str = Field(default=None, alias="albertId")
     """The Data Column ID assigned by Albert (format ``DAC...``). Populated by the server on creation; leave unset when building a column to create."""
+
+
+class DataColumnSearchItemDataTemplate(BaseAlbertModel):
+    """A lightweight data template reference within a data column search result."""
+
+    id: str | None = Field(default=None, alias="albertId")
+    """The Albert ID of the data template (format ``DAT...``)."""
+
+    name: str | None = None
+    """The name of the data template."""
+
+    status: str | None = None
+    """The status of the data template."""
+
+
+class DataColumnSearchItem(BaseAlbertModel, HydrationMixin[DataColumn]):
+    """Lightweight representation of a DataColumn returned from search.
+
+    Returned by
+    [`search`][albert.collections.data_columns.DataColumnCollection.search],
+    this carries only summary fields for fast listing. Call ``hydrate()`` (or fetch
+    by ``id`` via
+    [`get_by_id`][albert.collections.data_columns.DataColumnCollection.get_by_id])
+    to obtain the fully populated
+    [`DataColumn`][albert.resources.data_columns.DataColumn]."""
+
+    id: DataColumnId = Field(alias="albertId")
+    """The Data Column ID (format ``DAC...``)."""
+
+    name: str | None = None
+    """The name of the data column."""
+
+    status: str | None = None
+    """The status of the data column."""
+
+    created_by_name: str | None = Field(default=None, alias="createdByName")
+    """The name of the user who created the data column."""
+
+    created_by: str | None = Field(default=None, alias="createdBy")
+    """The ID of the user who created the data column."""
+
+    created_at: str | None = Field(default=None, alias="createdAt")
+    """ISO 8601 timestamp of when the data column was created."""
+
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+    """ISO 8601 timestamp of when the data column was last updated."""
+
+    metadata: dict[str, Any] | None = Field(default=None, alias="Metadata")
+    """Custom metadata attached to the data column."""
+
+    data_templates: list[DataColumnSearchItemDataTemplate] | None = Field(
+        default=None, alias="DataTemplates"
+    )
+    """The data templates that reference this data column."""
+
+    type: str | None = None
+    """The composite type of the data column (e.g. ``composite``, ``sub``), when applicable."""
+
+    parent_data_column: "DataColumnSearchItem | None" = Field(
+        default=None, alias="parentDataColumn"
+    )
+    """The parent data column, present on composite sub-column rows."""
+
+    sub_data_columns: "list[DataColumnSearchItem] | None" = Field(
+        default=None, alias="subDataColumns"
+    )
+    """The sub data columns, present on composite parent rows."""

--- a/src/albert/resources/data_columns.py
+++ b/src/albert/resources/data_columns.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import Field
 
 from albert.core.base import BaseAlbertModel
+from albert.core.shared.enums import Status
 from albert.core.shared.identifiers import DataColumnId
 from albert.core.shared.models.base import BaseResource
 from albert.core.shared.types import MetadataItem
@@ -55,7 +56,7 @@ class DataColumnSearchItemDataTemplate(BaseAlbertModel):
     name: str | None = None
     """The name of the data template."""
 
-    status: str | None = None
+    status: Status | None = None
     """The status of the data template."""
 
 
@@ -76,7 +77,7 @@ class DataColumnSearchItem(BaseAlbertModel, HydrationMixin[DataColumn]):
     name: str | None = None
     """The name of the data column."""
 
-    status: str | None = None
+    status: Status | None = None
     """The status of the data column."""
 
     created_by_name: str | None = Field(default=None, alias="createdByName")

--- a/tests/collections/test_data_columns.py
+++ b/tests/collections/test_data_columns.py
@@ -68,6 +68,27 @@ def test_data_column_get_all_by_ids(client: Albert, seeded_data_columns: list[Da
     assert_valid_data_column_items(results)
 
 
+def test_data_column_search(
+    client: Albert, seed_prefix: str, seeded_data_columns: list[DataColumn]
+):
+    """Test search finds seeded data columns and hits hydrate to full DataColumn."""
+    seeded_ids = {dc.id for dc in seeded_data_columns}
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.data_columns.search(text=seed_prefix, max_items=50)
+            if item.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected seeded data columns in search results"
+    hit = hits[0]
+    assert hit.id in seeded_ids
+
+    hydrated = hit.hydrate()
+    assert isinstance(hydrated, DataColumn)
+    assert hydrated.id == hit.id
+
+
 def test_get_by_name(client: Albert, seeded_data_columns: list[DataColumn]):
     name = seeded_data_columns[0].name
     dc = client.data_columns.get_by_name(name=name)


### PR DESCRIPTION
## What

Callers can now search data columns via `client.data_columns.search(...)` with free text, facet, metadata, and custom-field filters, getting back lazily paginated `DataColumnSearchItem` partial results that hydrate into full `DataColumn` objects.

## Why

Resolves SDK-104. Ask Albert and scripts previously had to use raw `session.post` or slow KEY-mode `get_all(name=...)` scans to resolve data columns; the search endpoint provides fast OpenSearch-backed lookup and filtered discovery of DACs across templates.

## How

- Follows the established `DataTemplateCollection.search` pattern: POST + OFFSET `AlbertPaginator`, `ensure_list()` for array params, `metadata_filters` / `custom_fields` wrapped as `{"metadata": ...}`, and `max_items` as the only caller-facing pagination control.
- New `DataColumnSearchItem` model with `HydrationMixin[DataColumn]`; composite-DAC fields (`type`, `parentDataColumn`, `subDataColumns`) are declared as optional self-references, and unknown keys are ignored per `BaseAlbertModel` defaults.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_data_columns.py -v -n 4` (requires Albert credentials, not available in the authoring environment; test collects cleanly and the model/collection were validated locally)

New integration test `test_data_column_search` scopes to `seed_prefix`, filters to seeded DAC ids, polls with `poll_until`, and asserts `hydrate()` returns a full `DataColumn` with the same id.

## SDK Changes

`DataColumnCollection.search(...)`: free-text and filtered search over data columns, returning lightweight `DataColumnSearchItem` hits with `.hydrate()` support.