### PR TITLE
feat(notebooks): add search for notebook block content

### DIFF
--- a/src/albert/collections/notebooks.py
+++ b/src/albert/collections/notebooks.py
@@ -12,7 +12,13 @@ from albert.core.base import BaseAlbertModel
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import NotebookId, ProjectId, SynthesisId, TaskId
+from albert.core.shared.identifiers import (
+    NotebookId,
+    ProjectId,
+    SearchProjectId,
+    SynthesisId,
+    TaskId,
+)
 from albert.exceptions import AlbertException
 from albert.resources.files import FileNamespace
 from albert.resources.notebooks import (
@@ -172,7 +178,7 @@ class NotebookCollection(BaseCollection):
         self,
         *,
         text: str | None = None,
-        project_id: ProjectId | None = None,
+        project_id: SearchProjectId | None = None,
         sort_by: str | None = None,
         order: OrderBy | None = None,
         max_items: int | None = None,
@@ -198,8 +204,9 @@ class NotebookCollection(BaseCollection):
         ----------
         text : str, optional
             Free-text search term matched against block content.
-        project_id : ProjectId, optional
+        project_id : SearchProjectId, optional
             Scope the search to notebooks in the given project (format ``PRO...``).
+            The ``PRO`` prefix is stripped before the request is sent.
         sort_by : str, optional
             Field to sort on.
         order : OrderBy, optional

--- a/src/albert/collections/notebooks.py
+++ b/src/albert/collections/notebooks.py
@@ -1,5 +1,7 @@
 import mimetypes
+from collections.abc import Iterator
 from pathlib import Path, PurePosixPath
+from typing import Any
 
 from pydantic import TypeAdapter, validate_call
 
@@ -7,7 +9,9 @@ from albert.collections.base import BaseCollection
 from albert.collections.files import FileCollection
 from albert.collections.synthesis import SynthesisCollection
 from albert.core.base import BaseAlbertModel
+from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
+from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import NotebookId, ProjectId, SynthesisId, TaskId
 from albert.exceptions import AlbertException
 from albert.resources.files import FileNamespace
@@ -19,6 +23,7 @@ from albert.resources.notebooks import (
     NotebookBlock,
     NotebookCopyInfo,
     NotebookCopyType,
+    NotebookSearchItem,
     PutBlockDatum,
     PutBlockPayload,
     PutOperation,
@@ -72,6 +77,8 @@ class NotebookCollection(BaseCollection):
     -------
     get_by_id(id) -> Notebook
         Get a single notebook by its ID.
+    search(...) -> Iterator[NotebookSearchItem]
+        Search notebook block content across projects.
     list_by_parent_id(parent_id) -> list[Notebook]
         List the notebooks attached to a given parent (project or task).
     create(notebook) -> Notebook
@@ -140,6 +147,9 @@ class NotebookCollection(BaseCollection):
                 print(notebook.id, notebook.name)
             ```
 
+        To find notebooks by their block content instead of by parent, use
+        [`search`][albert.collections.notebooks.NotebookCollection.search].
+
         Parameters
         ----------
         parent_id : ProjectId or TaskId
@@ -156,6 +166,68 @@ class NotebookCollection(BaseCollection):
         response = self.session.get(f"{self.base_path}/{parent_id}/search")
         # return
         return [self.get_by_id(id=x["id"]) for x in response.json()["Items"]]
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        project_id: ProjectId | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[NotebookSearchItem]:
+        """Search for notebook block content matching the given filters.
+
+        Each result is a [`NotebookSearchItem`][albert.resources.notebooks.NotebookSearchItem]
+        representing a single matching content block, not a full notebook. Use
+        [`get_by_id`][albert.collections.notebooks.NotebookCollection.get_by_id] or
+        [`get_block_by_id`][albert.collections.notebooks.NotebookCollection.get_block_by_id]
+        to retrieve full notebook content. Results are returned as a lazily
+        paginated iterator.
+
+        !!! example
+            ```python
+            hits = client.notebooks.search(text="recrystallization", max_items=10)
+            first = next(iter(hits))
+            first.notebook_id
+            # 'NTB123'
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text search term matched against block content.
+        project_id : ProjectId, optional
+            Scope the search to notebooks in the given project (format ``PRO...``).
+        sort_by : str, optional
+            Field to sort on.
+        order : OrderBy, optional
+            Sort direction for ``sort_by``.
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matches.
+
+        Returns
+        -------
+        Iterator[NotebookSearchItem]
+            A lazily paginated iterator of block-level search hits.
+        """
+        params: dict[str, Any] = {
+            "text": text,
+            "projectId": project_id,
+            "sortBy": sort_by,
+            "order": order,
+        }
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [NotebookSearchItem.model_validate(x) for x in items],
+        )
 
     def create(self, *, notebook: Notebook) -> Notebook:
         """Find or create a Notebook for the provided notebook.

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -513,7 +513,7 @@ class NotebookSearchItem(BaseAlbertModel):
     block_type: str | None = Field(default=None, alias="blockType")
     """The type of the matching block (for example, ``paragraph``, ``ketcher``, or ``table``)."""
 
-    content: dict[str, Any] | None = Field(default=None)
+    content: Any | None = Field(default=None)
     """The block payload. The shape varies by block type."""
 
     name: str | None = Field(default=None)

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -20,7 +20,7 @@ from albert.core.shared.identifiers import (
     SynthesisId,
     TaskId,
 )
-from albert.core.shared.models.base import BaseResource, EntityLink
+from albert.core.shared.models.base import AuditFields, BaseResource, EntityLink
 from albert.exceptions import AlbertException
 from albert.resources.acls import ACL, ACLContainer
 
@@ -487,6 +487,45 @@ class ListBlock(BaseBlock):
 
     content: ListContent
     """The list entries and style."""
+
+
+class NotebookSearchItem(BaseAlbertModel):
+    """A block-level notebook search hit.
+
+    Returned by
+    [`search`][albert.collections.notebooks.NotebookCollection.search],
+    each hit represents a single matching content block rather than a full
+    notebook. Use
+    [`get_by_id`][albert.collections.notebooks.NotebookCollection.get_by_id]
+    or [`get_block_by_id`][albert.collections.notebooks.NotebookCollection.get_block_by_id]
+    to retrieve full notebook content."""
+
+    block_id: str | None = Field(default=None, alias="blockId")
+    """The ID of the matching block."""
+
+    notebook_id: NotebookId | None = Field(default=None, alias="notebookId")
+    """The ID of the notebook containing the matching block (format ``NTB...``)."""
+
+    project_id: ProjectId | None = Field(default=None, alias="projectId")
+    """The ID of the project the notebook belongs to (format ``PRO...``)."""
+
+    block_type: str | None = Field(default=None, alias="blockType")
+    """The type of the matching block (for example, ``paragraph``, ``ketcher``, or ``table``)."""
+
+    content: dict[str, Any] | None = Field(default=None)
+    """The block payload. The shape varies by block type."""
+
+    name: str | None = Field(default=None)
+    """The notebook name, when indexed."""
+
+    status: str | None = Field(default=None)
+    """The notebook status."""
+
+    created: AuditFields | None = Field(default=None, alias="Created")
+    """Audit information for when the notebook was created."""
+
+    updated: AuditFields | None = Field(default=None, alias="Updated")
+    """Audit information for when the notebook was last updated."""
 
 
 class NotebookLink(BaseAlbertModel):

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -507,8 +507,8 @@ class NotebookSearchItem(BaseAlbertModel):
     notebook_id: NotebookId | None = Field(default=None, alias="notebookId")
     """The ID of the notebook containing the matching block (format ``NTB...``)."""
 
-    project_id: ProjectId | None = Field(default=None, alias="projectId")
-    """The ID of the project the notebook belongs to (format ``PRO...``)."""
+    project_id: str | None = Field(default=None, alias="projectId")
+    """The notebook parent entity ID returned by search (often a project, but may be a task or template)."""
 
     block_type: str | None = Field(default=None, alias="blockType")
     """The type of the matching block (for example, ``paragraph``, ``ketcher``, or ``table``)."""

--- a/src/albert/resources/notebooks.py
+++ b/src/albert/resources/notebooks.py
@@ -12,6 +12,7 @@ from pandas import DataFrame
 from pydantic import Field, model_validator
 
 from albert.core.base import BaseAlbertModel
+from albert.core.shared.enums import Status
 from albert.core.shared.identifiers import (
     CustomTemplateId,
     LinkId,
@@ -518,7 +519,7 @@ class NotebookSearchItem(BaseAlbertModel):
     name: str | None = Field(default=None)
     """The notebook name, when indexed."""
 
-    status: str | None = Field(default=None)
+    status: Status | None = Field(default=None)
     """The notebook status."""
 
     created: AuditFields | None = Field(default=None, alias="Created")

--- a/tests/collections/test_data_templates.py
+++ b/tests/collections/test_data_templates.py
@@ -119,8 +119,13 @@ def test_data_template_get_by_name(client: Albert, seeded_data_templates: list[D
     name = seeded_data_templates[0].name
     expected_id = seeded_data_templates[0].id
 
-    result = client.data_templates.get_by_name(name=name)
-    assert result is not None
+    results = poll_until(
+        lambda: (
+            [found] if (found := client.data_templates.get_by_name(name=name)) is not None else []
+        )
+    )
+    assert results, "Expected get_by_name to find seeded data template"
+    result = results[0]
     assert result.name == name
     assert result.id == expected_id
 

--- a/tests/collections/test_notebooks.py
+++ b/tests/collections/test_notebooks.py
@@ -26,7 +26,7 @@ def seeded_notebook(
 ) -> Iterator[Notebook]:
     notebook = generate_notebook_seeds(seed_prefix=seed_prefix, seeded_projects=seeded_projects)[0]
     seeded = client.notebooks.create(notebook=notebook)
-    seeded.blocks = generate_notebook_block_seeds()
+    seeded.blocks = generate_notebook_block_seeds(seed_prefix=seed_prefix)
     yield client.notebooks.update_block_content(notebook=seeded)
     client.notebooks.delete(id=seeded.id)
 
@@ -118,11 +118,11 @@ def test_search(client: Albert, seed_prefix: str, seeded_notebooks: list[Noteboo
             for hit in client.notebooks.search(
                 text=seed_prefix, project_id=nb.parent_id, max_items=50
             )
-            if hit.notebook_id in seeded_ids
+            if hit.notebook_id in seeded_ids and hit.block_id
         ]
     )
     assert hits, "Expected at least one notebook search hit"
-    assert any(hit.notebook_id == nb.id and hit.block_id for hit in hits)
+    assert any(hit.notebook_id == nb.id for hit in hits)
 
 
 def test_get_block_by_id(client: Albert, seeded_notebooks: list[Notebook]):

--- a/tests/collections/test_notebooks.py
+++ b/tests/collections/test_notebooks.py
@@ -15,6 +15,7 @@ from albert.resources.notebooks import (
 )
 from albert.resources.projects import Project
 from tests.seeding import generate_notebook_block_seeds, generate_notebook_seeds
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("projects")
 
@@ -105,6 +106,23 @@ def test_update_block_content_raises_exception(client: Albert, seeded_notebook: 
     notebook.blocks.extend([header_block1, header_block2])
     with pytest.raises(AlbertException, match="You have Notebook blocks with duplicate ids"):
         client.notebooks.update_block_content(notebook=notebook)
+
+
+def test_search(client: Albert, seed_prefix: str, seeded_notebooks: list[Notebook]):
+    """Test search finds seeded notebook block content scoped to the seed project."""
+    nb = seeded_notebooks[0]
+    seeded_ids = {n.id for n in seeded_notebooks}
+    hits = poll_until(
+        lambda: [
+            hit
+            for hit in client.notebooks.search(
+                text=seed_prefix, project_id=nb.parent_id, max_items=50
+            )
+            if hit.notebook_id in seeded_ids
+        ]
+    )
+    assert hits, "Expected at least one notebook search hit"
+    assert any(hit.notebook_id == nb.id and hit.block_id for hit in hits)
 
 
 def test_get_block_by_id(client: Albert, seeded_notebooks: list[Notebook]):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -761,7 +761,9 @@ def seeded_notebooks(
 ):
     def _seed(nb):
         seed = client.notebooks.create(notebook=nb)
-        seed.blocks = generate_notebook_block_seeds()  # generate each iteration for new block ids
+        seed.blocks = generate_notebook_block_seeds(
+            seed_prefix=seed_prefix
+        )  # generate each iteration for new block ids
         return client.notebooks.update_block_content(notebook=seed)
 
     seeded = _pmap(

--- a/tests/seeding.py
+++ b/tests/seeding.py
@@ -1506,12 +1506,13 @@ def generate_workflow_seeds(
     ]
 
 
-def generate_notebook_block_seeds() -> list[NotebookBlock]:
+def generate_notebook_block_seeds(*, seed_prefix: str = "") -> list[NotebookBlock]:
+    paragraph_text = f"{seed_prefix} I am a paragraph block.".strip()
     return [
         HeaderBlock(content=HeaderContent(level=1, text="I am a header1 block.")),
         HeaderBlock(content=HeaderContent(level=2, text="I am a header2 block.")),
         HeaderBlock(content=HeaderContent(level=3, text="I am a header3 block.")),
-        ParagraphBlock(content=ParagraphContent(text="I am a paragraph block.")),
+        ParagraphBlock(content=ParagraphContent(text=paragraph_text)),
         TableBlock(
             content=TableContent(
                 content=[


### PR DESCRIPTION
## What

`NotebookCollection` now has a `search(...)` method wrapping `GET /api/v3/notebooks/search`, so callers (Ask Albert, scripts) can find notebook **block-level** content via free text with an optional project scope, without dropping to raw `session.get`. Each hit is a new `NotebookSearchItem` model representing one matching block, not a full notebook.

## Why

Unblocks ELN content discovery across projects for agent search ([SDK-103](https://linear.app/albert-invent/issue/SDK-103/add-notebook-collection-search-support)).

## How

- `search()` builds a camelCase `params` dict (`text`, `projectId`, `sortBy`, `order`) and returns an OFFSET-mode `AlbertPaginator`; pagination is caller-controlled via `max_items` only (no public `offset`/`limit`).
- `NotebookSearchItem` maps the OpenSearch block-hit fields (`blockId`, `notebookId`, `projectId`, `blockType`, `content`, `name`, `status`, `Created`, `Updated`) with attribute docstrings; undeclared fields are ignored via the `BaseAlbertModel` default.
- No hydration on hits; callers use `get_by_id` / `get_block_by_id` for full content. `list_by_parent_id` docstring cross-links to `search` for block-content queries.

## Deferred

`globalSearch` (cross-module project search for tasks, inventory, and users on the same endpoint) is **not** included in this PR. The OpenAPI spec documents the query param but not the alternate grouped response shape (`{category, total, data}`), so we are waiting on confirmation from the API team before modeling and exposing it in the SDK.

## Testing

Added `test_search` to `tests/collections/test_notebooks.py` (existing `projects` xdist group): searches seeded notebooks by `seed_prefix` scoped to the seed project, filters hits to the fixture's notebook ids, wraps in `poll_until` for index lag, and asserts a hit with the expected `notebook_id` and non-null `block_id`.

```bash
uv run ruff format .
uv run ruff check . --fix
uv run pytest tests/collections/test_notebooks.py -v -n 4
```

Lint/format pass. Live integration run requires `ALBERT_CLIENT_ID_SDK` / `ALBERT_CLIENT_SECRET_SDK` / `ALBERT_BASE_URL`, which were not available in the build environment; the test file collects cleanly and `NotebookSearchItem` deserialization was validated against the documented wire shape.

Cake session: https://agents.ai.albertinventdev.com/sessions/ea7ea125-16b1-48f9-9f7d-5de76788e6a0