### PR TITLE
feat(synthesis): add search support

### DIFF
--- a/src/albert/collections/synthesis.py
+++ b/src/albert/collections/synthesis.py
@@ -1,15 +1,24 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Iterator
 from typing import Any
 
 from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
+from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import NotebookId, SynthesisId
+from albert.core.utils import ensure_list
 from albert.exceptions import AlbertException
-from albert.resources.synthesis import ReactantValues, RowSequence, Synthesis
+from albert.resources.synthesis import (
+    ReactantValues,
+    RowSequence,
+    Synthesis,
+    SynthesisSearchItem,
+)
 
 
 class SynthesisCollection(BaseCollection):
@@ -60,6 +69,8 @@ class SynthesisCollection(BaseCollection):
         Create a synthesis record for a notebook Ketcher block.
     get_by_id(id, include_recommendations=False, include_predictions=False, version=None) -> Synthesis
         Get a single synthesis record by its ID.
+    search(...) -> Iterator[SynthesisSearchItem]
+        Search for synthesis records matching the given filters, returning lightweight hits.
     update(synthesis) -> Synthesis
         Update an existing synthesis record.
     update_canvas_data(synthesis_id, smiles, data, png) -> Synthesis
@@ -184,6 +195,132 @@ class SynthesisCollection(BaseCollection):
             params=params,
         )
         return Synthesis(**response.json())
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        created_by: str | list[str] | None = None,
+        created_by_name: str | list[str] | None = None,
+        smiles: str | list[str] | None = None,
+        product_created: str | list[str] | None = None,
+        chemical_name: str | list[str] | None = None,
+        cas: str | list[str] | None = None,
+        reactant_name: str | list[str] | None = None,
+        reactant_cas: str | list[str] | None = None,
+        product_name: str | list[str] | None = None,
+        product_cas: str | list[str] | None = None,
+        project_id: str | list[str] | None = None,
+        inventory_id: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[SynthesisSearchItem]:
+        """Search for synthesis records matching the given filters.
+
+        Returns lightweight
+        [`SynthesisSearchItem`][albert.resources.synthesis.SynthesisSearchItem] hits, best for
+        free-text lookups and pulling IDs. Results are returned as a lazily paginated
+        iterator. Pass a hit's ID to
+        [`get_by_id`][albert.collections.synthesis.SynthesisCollection.get_by_id] to fetch the
+        fully populated [`Synthesis`][albert.resources.synthesis.Synthesis].
+
+        !!! example
+            ```python
+            hits = client.synthesis.search(text="amide coupling", max_items=10)
+            first = next(iter(hits))
+            first.name
+            # 'Amide coupling'
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query matched against synthesis names and metadata.
+        created_by : str or list[str], optional
+            Filter by creator user ID(s).
+        created_by_name : str or list[str], optional
+            Filter by creator display name(s).
+        smiles : str or list[str], optional
+            Filter by SMILES structure(s).
+        product_created : str or list[str], optional
+            Filter by product-created flag(s).
+        chemical_name : str or list[str], optional
+            Filter by chemical name(s).
+        cas : str or list[str], optional
+            Filter by CAS number(s).
+        reactant_name : str or list[str], optional
+            Filter by reactant name(s).
+        reactant_cas : str or list[str], optional
+            Filter by reactant CAS number(s).
+        product_name : str or list[str], optional
+            Filter by product name(s).
+        product_cas : str or list[str], optional
+            Filter by product CAS number(s).
+        project_id : str or list[str], optional
+            Filter by Project ID(s) (format ``PRO...``).
+        inventory_id : str or list[str], optional
+            Filter by linked Inventory ID(s) (format ``INV...``).
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        source_field : str or list[str], optional
+            Restrict which fields are returned on each search hit.
+        sort_by : str, optional
+            Attribute to sort results by.
+        order : OrderBy, optional
+            The order in which to sort results (``asc`` or ``desc``).
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matching items.
+
+        Returns
+        -------
+        Iterator[SynthesisSearchItem]
+            A lazily paginated iterator of matching lightweight synthesis hits.
+        """
+        params: dict[str, Any] = {
+            "text": text,
+            "createdBy": ensure_list(created_by),
+            "createdByName": ensure_list(created_by_name),
+            "smiles": ensure_list(smiles),
+            "productCreated": ensure_list(product_created),
+            "chemicalName": ensure_list(chemical_name),
+            "cas": ensure_list(cas),
+            "reactantName": ensure_list(reactant_name),
+            "reactantCas": ensure_list(reactant_cas),
+            "productName": ensure_list(product_name),
+            "productCas": ensure_list(product_cas),
+            "projectId": ensure_list(project_id),
+            "inventoryId": ensure_list(inventory_id),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "sourceField": ensure_list(source_field),
+            "sortBy": sort_by,
+            "order": order,
+        }
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [SynthesisSearchItem.model_validate(x) for x in items],
+        )
 
     @validate_call
     def update_canvas_data(

--- a/src/albert/collections/synthesis.py
+++ b/src/albert/collections/synthesis.py
@@ -10,7 +10,7 @@ from albert.collections.base import BaseCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import NotebookId, SynthesisId
+from albert.core.shared.identifiers import NotebookId, SearchProjectId, SynthesisId
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertException
 from albert.resources.synthesis import (
@@ -211,7 +211,7 @@ class SynthesisCollection(BaseCollection):
         reactant_cas: str | list[str] | None = None,
         product_name: str | list[str] | None = None,
         product_cas: str | list[str] | None = None,
-        project_id: str | list[str] | None = None,
+        project_id: SearchProjectId | list[SearchProjectId] | None = None,
         inventory_id: str | list[str] | None = None,
         facet_text: str | None = None,
         facet_field: str | None = None,
@@ -263,7 +263,7 @@ class SynthesisCollection(BaseCollection):
             Filter by product name(s).
         product_cas : str or list[str], optional
             Filter by product CAS number(s).
-        project_id : str or list[str], optional
+        project_id : SearchProjectId or list[SearchProjectId], optional
             Filter by Project ID(s) (format ``PRO...``).
         inventory_id : str or list[str], optional
             Filter by linked Inventory ID(s) (format ``INV...``).

--- a/src/albert/collections/synthesis.py
+++ b/src/albert/collections/synthesis.py
@@ -212,7 +212,7 @@ class SynthesisCollection(BaseCollection):
         product_name: str | list[str] | None = None,
         product_cas: str | list[str] | None = None,
         project_id: SearchProjectId | list[SearchProjectId] | None = None,
-        inventory_id: str | list[str] | None = None,
+        inventory_id: InventoryId | list[InventoryId] | None = None,
         facet_text: str | None = None,
         facet_field: str | None = None,
         contains_field: str | list[str] | None = None,
@@ -265,7 +265,7 @@ class SynthesisCollection(BaseCollection):
             Filter by product CAS number(s).
         project_id : SearchProjectId or list[SearchProjectId], optional
             Filter by Project ID(s) (format ``PRO...``).
-        inventory_id : str or list[str], optional
+        inventory_id : InventoryId or list[InventoryId], optional
             Filter by linked Inventory ID(s) (format ``INV...``).
         facet_text : str, optional
             Text to match within a facet search.

--- a/src/albert/collections/synthesis.py
+++ b/src/albert/collections/synthesis.py
@@ -10,7 +10,12 @@ from albert.collections.base import BaseCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import NotebookId, SearchProjectId, SynthesisId
+from albert.core.shared.identifiers import (
+    NotebookId,
+    SearchInventoryId,
+    SearchProjectId,
+    SynthesisId,
+)
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertException
 from albert.resources.synthesis import (
@@ -212,7 +217,7 @@ class SynthesisCollection(BaseCollection):
         product_name: str | list[str] | None = None,
         product_cas: str | list[str] | None = None,
         project_id: SearchProjectId | list[SearchProjectId] | None = None,
-        inventory_id: InventoryId | list[InventoryId] | None = None,
+        inventory_id: SearchInventoryId | list[SearchInventoryId] | None = None,
         facet_text: str | None = None,
         facet_field: str | None = None,
         contains_field: str | list[str] | None = None,
@@ -265,7 +270,7 @@ class SynthesisCollection(BaseCollection):
             Filter by product CAS number(s).
         project_id : SearchProjectId or list[SearchProjectId], optional
             Filter by Project ID(s) (format ``PRO...``).
-        inventory_id : InventoryId or list[InventoryId], optional
+        inventory_id : SearchInventoryId or list[SearchInventoryId], optional
             Filter by linked Inventory ID(s) (format ``INV...``).
         facet_text : str, optional
             Text to match within a facet search.

--- a/src/albert/resources/synthesis.py
+++ b/src/albert/resources/synthesis.py
@@ -125,6 +125,22 @@ class Synthesis(BaseAlbertModel):
     """Audit information about the most recent update."""
 
 
+class SynthesisSearchItem(BaseAlbertModel):
+    """Lightweight representation of a synthesis record returned from search.
+
+    Returned by
+    [`search`][albert.collections.synthesis.SynthesisCollection.search],
+    this carries only the ID and display name for fast lookups. Fetch the fully
+    populated [`Synthesis`][albert.resources.synthesis.Synthesis] by ID via
+    [`get_by_id`][albert.collections.synthesis.SynthesisCollection.get_by_id]."""
+
+    id: SynthesisId | None = Field(default=None, alias="albertId")
+    """The Synthesis ID (format ``SYN...``)."""
+
+    name: str | None = None
+    """The human-readable name of the synthesis."""
+
+
 class ReactantValues(BaseAlbertModel):
     """The quantities entered for a single reactant row.
 

--- a/tests/collections/test_synthesis.py
+++ b/tests/collections/test_synthesis.py
@@ -1,0 +1,35 @@
+from contextlib import suppress
+
+import pytest
+
+from albert import Albert
+from albert.exceptions import AlbertException
+from albert.resources.notebooks import Notebook
+from tests.utils.wait import poll_until
+
+pytestmark = pytest.mark.xdist_group("projects")
+
+
+def test_synthesis_search(client: Albert, seed_prefix: str, seeded_notebooks: list[Notebook]):
+    """Test search finds a newly created synthesis record and its ID is usable."""
+    synthesis = client.synthesis.create(
+        parent_id=seeded_notebooks[0].id,
+        name=f"{seed_prefix} amide coupling",
+    )
+    try:
+        hits = poll_until(
+            lambda: [
+                item
+                for item in client.synthesis.search(text=seed_prefix, max_items=50)
+                if item.id == synthesis.id
+            ]
+        )
+        assert hits, "Expected created synthesis in search results"
+        hit = hits[0]
+        assert hit.id == synthesis.id
+
+        fetched = client.synthesis.get_by_id(id=hit.id)
+        assert fetched.id == synthesis.id
+    finally:
+        with suppress(AlbertException):
+            client.session.delete(url=f"{client.synthesis.base_path}/{synthesis.id}")

--- a/tests/collections/test_synthesis.py
+++ b/tests/collections/test_synthesis.py
@@ -11,16 +11,21 @@ pytestmark = pytest.mark.xdist_group("projects")
 
 
 def test_synthesis_search(client: Albert, seed_prefix: str, seeded_notebooks: list[Notebook]):
-    """Test search finds a newly created synthesis record and its ID is usable."""
+    """Test search finds a newly created synthesis record scoped to its project."""
+    notebook = seeded_notebooks[0]
     synthesis = client.synthesis.create(
-        parent_id=seeded_notebooks[0].id,
+        parent_id=notebook.id,
         name=f"{seed_prefix} amide coupling",
     )
     try:
         hits = poll_until(
             lambda: [
                 item
-                for item in client.synthesis.search(text=seed_prefix, max_items=50)
+                for item in client.synthesis.search(
+                    text=seed_prefix,
+                    project_id=notebook.parent_id,
+                    max_items=50,
+                )
                 if item.id == synthesis.id
             ]
         )


### PR DESCRIPTION
## What

`client.synthesis.search(...)` is now available, wrapping `GET /api/v3/synthesis/search`. Callers can discover synthesis records via free text, chemical structure filters (SMILES, CAS, reactant/product names), project and inventory scope, and creator filters, with results returned as a lazily paginated iterator of lightweight `SynthesisSearchItem` hits (`id`, `name`).

## Why

Implements SDK-105. Ask Albert and scripts need to look up synthesis/reaction records by name, SMILES, CAS, or reactant/product chemistry without dropping to raw `session.get` calls.

## How

- Follows the established GET + `PaginationMode.OFFSET` search pattern (as in `CustomTemplatesCollection.search`); `max_items` is the only caller-facing pagination control, with `offset`/`limit` managed internally by `AlbertPaginator`.
- Array filters accept `str | list[str]` and are normalized with `ensure_list()`; camelCase wire params omit `None` values.
- `SynthesisSearchItem` stays minimal (`albertId` -> `id`, `name`) per the ticket; undeclared response fields are dropped by the default `extra="ignore"`. Full records are fetched via `get_by_id(id=hit.id)`.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_synthesis.py -v -n 4` — blocked locally: no Albert credentials (`ALBERT_CLIENT_ID_SDK` / `ALBERT_CLIENT_SECRET_SDK` / `ALBERT_BASE_URL`) in this environment; test collects and fails only at client auth. Relies on CI.

New integration test `test_synthesis_search` (xdist group `projects`): creates a private synthesis on `seeded_notebooks[0]` named with `seed_prefix`, polls `search(text=seed_prefix)` via `poll_until` scoped to the created ID, asserts the hit, and confirms the hit ID round-trips through `get_by_id`. Cleanup runs in `try/finally`.

## SDK Changes

`SynthesisCollection.search(...)`: search synthesis records by free text, chemistry, project, or creator filters, returning lightweight `SynthesisSearchItem` hits.

Ticket: SDK-105
Cake session: https://agents.ai.albertinventdev.com/sessions/3eb2ffb8-1294-45a0-a643-6b3f6de9e2ca