### PR TITLE
feat(worksheets): add search support

### DIFF
--- a/src/albert/collections/worksheets.py
+++ b/src/albert/collections/worksheets.py
@@ -8,7 +8,7 @@ from albert.collections.custom_templates import CustomTemplatesCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import ProjectId
+from albert.core.shared.identifiers import ProjectId, SearchProjectId
 from albert.core.utils import ensure_list
 from albert.resources.acls import ACLContainer
 from albert.resources.custom_templates import CustomTemplate
@@ -147,7 +147,7 @@ class WorksheetCollection(BaseCollection):
         self,
         *,
         text: str | None = None,
-        project_id: ProjectId | None = None,
+        project_id: SearchProjectId | None = None,
         sheet_id: str | None = None,
         tags: str | list[str] | None = None,
         albert_id: str | list[str] | None = None,
@@ -185,8 +185,9 @@ class WorksheetCollection(BaseCollection):
         ----------
         text : str, optional
             Free-text query matched against formula fields.
-        project_id : ProjectId, optional
+        project_id : SearchProjectId, optional
             Scope the search to a Project (format ``PRO...``).
+            The ``PRO`` prefix is stripped before the request is sent.
         sheet_id : str, optional
             Filter to formulas on a given Sheet.
         tags : str or list[str], optional

--- a/src/albert/collections/worksheets.py
+++ b/src/albert/collections/worksheets.py
@@ -1,12 +1,18 @@
+from collections.abc import Iterator
+from typing import Any
+
 from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
 from albert.collections.custom_templates import CustomTemplatesCollection
+from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
+from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import ProjectId
+from albert.core.utils import ensure_list
 from albert.resources.acls import ACLContainer
 from albert.resources.custom_templates import CustomTemplate
-from albert.resources.worksheets import Worksheet
+from albert.resources.worksheets import Worksheet, WorksheetSearchItem
 from albert.utils.worksheets import (
     get_columns_to_copy,
     get_prg_rows_to_copy,
@@ -61,6 +67,8 @@ class WorksheetCollection(BaseCollection):
     -------
     get_by_project_id(project_id) -> Worksheet
         Get the Worksheet paired with a Project.
+    search(...) -> Iterator[WorksheetSearchItem]
+        Search for formulas across Worksheets matching the given filters.
     setup_worksheet(project_id, add_sheet=False) -> Worksheet
         Initialize a Worksheet for a Project that does not yet have one.
     add_sheet(project_id, sheet_name) -> Worksheet
@@ -133,6 +141,122 @@ class WorksheetCollection(BaseCollection):
         # Sheets are themselves collections, and therefore need access to the session
         response_json = self._add_session_to_sheets(response_json)
         return Worksheet(**response_json)
+
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        project_id: ProjectId | None = None,
+        sheet_id: str | None = None,
+        tags: str | list[str] | None = None,
+        albert_id: str | list[str] | None = None,
+        state: str | list[str] | None = None,
+        predecessor: str | list[str] | None = None,
+        data_template: str | list[str] | None = None,
+        inventory_name: str | list[str] | None = None,
+        inventory_id: str | list[str] | None = None,
+        formula_created_by: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        exclude_hidden: bool | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[WorksheetSearchItem]:
+        """Search for formulas across Worksheets matching the given filters.
+
+        Returns lightweight, partially populated
+        [`WorksheetSearchItem`][albert.resources.worksheets.WorksheetSearchItem]
+        results and is the fastest way to discover formulations across Projects and
+        Sheets. Results are returned as a lazily paginated iterator. When you need
+        the complete formula, pass a result's ``id`` to
+        [`get_by_id`][albert.collections.inventory.InventoryCollection.get_by_id].
+
+        !!! example
+            ```python
+            for hit in client.worksheets.search(text="cool formulation", max_items=10):
+                print(hit.id, hit.name)
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query matched against formula fields.
+        project_id : ProjectId, optional
+            Scope the search to a Project (format ``PRO...``).
+        sheet_id : str, optional
+            Filter to formulas on a given Sheet.
+        tags : str or list[str], optional
+            Filter by tag name(s).
+        albert_id : str or list[str], optional
+            Filter by formula inventory ID(s) (format ``INV...``).
+        state : str or list[str], optional
+            Filter by formula state (e.g. locked or unlocked).
+        predecessor : str or list[str], optional
+            Filter by predecessor formula.
+        data_template : str or list[str], optional
+            Filter by data template name(s).
+        inventory_name : str or list[str], optional
+            Filter by ingredient name(s).
+        inventory_id : str or list[str], optional
+            Filter by ingredient inventory ID(s).
+        formula_created_by : str or list[str], optional
+            Filter by formula creator(s).
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        exclude_hidden : bool, optional
+            When True, omit hidden formulas from the results.
+        sort_by : str, optional
+            Field to sort results by.
+        order : OrderBy, optional
+            The order in which to sort results (``asc`` or ``desc``).
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matches.
+
+        Returns
+        -------
+        Iterator[WorksheetSearchItem]
+            A lazily paginated iterator of matching formula search results.
+        """
+        params: dict[str, Any] = {
+            "text": text,
+            "projectId": project_id,
+            "sheetId": sheet_id,
+            "tags": ensure_list(tags),
+            "albertId": ensure_list(albert_id),
+            "state": ensure_list(state),
+            "predecessor": ensure_list(predecessor),
+            "dataTemplate": ensure_list(data_template),
+            "inventoryName": ensure_list(inventory_name),
+            "inventoryId": ensure_list(inventory_id),
+            "formulaCreatedBy": ensure_list(formula_created_by),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "excludeHidden": exclude_hidden,
+            "sortBy": sort_by,
+            "order": order,
+        }
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [WorksheetSearchItem.model_validate(x) for x in items],
+        )
 
     @validate_call
     def setup_worksheet(self, *, project_id: ProjectId, add_sheet=False) -> Worksheet:

--- a/src/albert/resources/worksheets.py
+++ b/src/albert/resources/worksheets.py
@@ -1,5 +1,7 @@
 from pydantic import Field, model_validator
 
+from albert.core.base import BaseAlbertModel
+from albert.core.shared.identifiers import InventoryId
 from albert.core.shared.models.base import BaseSessionResource
 from albert.resources.sheets import Sheet
 
@@ -48,3 +50,47 @@ class Worksheet(BaseSessionResource):
                 for d in s.designs:
                     d._session = self.session
         return self
+
+
+class WorksheetSearchInventoryLine(BaseAlbertModel):
+    """An ingredient row on a formula search hit."""
+
+    id: InventoryId | None = None
+    """The inventory ID of the ingredient (format ``INV...``)."""
+
+    name: str | None = None
+    """The name of the ingredient."""
+
+
+class WorksheetSearchTag(BaseAlbertModel):
+    """A tag on a formula search hit."""
+
+    tag_id: str | None = Field(default=None, alias="tagId")
+    """The ID of the tag (format ``TAG...``)."""
+
+    tag_name: str | None = Field(default=None, alias="tagName")
+    """The name of the tag."""
+
+
+class WorksheetSearchItem(BaseAlbertModel):
+    """A lightweight formula result returned by worksheet search.
+
+    Returned by
+    [`search`][albert.collections.worksheets.WorksheetCollection.search],
+    this is a partially populated view of a Formula inventory item built on a
+    Sheet, optimized for fast lookups. Pass its ``id`` to
+    [`get_by_id`][albert.collections.inventory.InventoryCollection.get_by_id]
+    to obtain the fully populated
+    [`InventoryItem`][albert.resources.inventory.InventoryItem]."""
+
+    id: InventoryId | None = Field(default=None, alias="albertId")
+    """The Formula inventory ID (format ``INV...``)."""
+
+    name: str | None = None
+    """The display name of the formula."""
+
+    inventory: list[WorksheetSearchInventoryLine] | None = None
+    """The ingredient rows on the formula."""
+
+    tags: list[WorksheetSearchTag] | None = None
+    """The tags on the formula."""

--- a/tests/collections/test_data_columns.py
+++ b/tests/collections/test_data_columns.py
@@ -1,5 +1,3 @@
-import time
-
 import pytest
 
 from albert import Albert
@@ -32,14 +30,14 @@ def test_data_column_get_all_with_filters(client: Albert, seeded_data_columns: l
     """Test get_all filters by name with and without exact match."""
     name = seeded_data_columns[0].name
 
-    # Poll briefly: the search index can lag behind seeding under parallel load
-    deadline = time.monotonic() + 15
-    while True:
-        results = list(client.data_columns.get_all(name=name, exact_match=False, max_items=10))
-        if any(name.lower() in dc.name.lower() for dc in results) or time.monotonic() > deadline:
-            break
-        time.sleep(1)
-    assert any(name.lower() in dc.name.lower() for dc in results)
+    results = poll_until(
+        lambda: [
+            dc
+            for dc in client.data_columns.get_all(name=name, exact_match=False, max_items=10)
+            if name.lower() in dc.name.lower()
+        ]
+    )
+    assert results, "Expected seeded data column in filtered get_all results"
     assert_valid_data_column_items(results)
 
     no_match = list(

--- a/tests/collections/test_projects.py
+++ b/tests/collections/test_projects.py
@@ -67,12 +67,17 @@ def test_project_document_search(
 ):
     """Test document_search returns DocumentSearchItem items for a project."""
     project_id = seeded_projects[0].id
-    documents = list(
-        client.projects.document_search(
-            linked_to=project_id,
-            sort_by="createdAt",
-            max_items=25,
-        )
+    attachment_id = seeded_project_document.id
+    documents = poll_until(
+        lambda: [
+            doc
+            for doc in client.projects.document_search(
+                linked_to=project_id,
+                sort_by="createdAt",
+                max_items=25,
+            )
+            if doc.id == attachment_id
+        ]
     )
     assert documents, "Expected at least one document"
     for doc in documents:

--- a/tests/collections/test_worksheet.py
+++ b/tests/collections/test_worksheet.py
@@ -1,7 +1,9 @@
 import pytest
 
 from albert import Albert
+from albert.resources.inventory import InventoryItem
 from albert.resources.worksheets import Worksheet
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("sheets")
 
@@ -18,6 +20,29 @@ def test_add_sheet(client: Albert, seeded_worksheet: Worksheet):
     )
     assert isinstance(updated_worksheet, Worksheet)
     assert len(updated_worksheet.sheets) == existing_number + 1
+
+
+def test_worksheet_search(
+    client: Albert,
+    seed_prefix: str,
+    seeded_worksheet: Worksheet,
+    seeded_products: list[InventoryItem],
+):
+    """Test worksheet search finds a seeded formula within its project."""
+    seeded_ids = {p.id for p in seeded_products}
+    hits = poll_until(
+        lambda: [
+            hit
+            for hit in client.worksheets.search(
+                text=seed_prefix,
+                project_id=seeded_worksheet.project_id,
+                max_items=50,
+            )
+            if hit.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected seeded formula in worksheet search results"
+    assert hits[0].id in seeded_ids
 
 
 # Need to seed a Sheet Template First


### PR DESCRIPTION
## What

Callers can now search formulations across worksheet grids with `client.worksheets.search(...)`, a lazily paginated iterator of lightweight `WorksheetSearchItem` results supporting free text plus project, sheet, tag, inventory, data template, creator, facet, and contains filters.

## Why

Ask Albert and script workflows need to discover formulations across projects without dropping to raw `session.get` calls (SDK-102). This unblocks cross-project formulation lookup in agent workflows.

## How

- `WorksheetCollection.search()` wraps the worksheet search endpoint with an OFFSET `AlbertPaginator`; `max_items` is the only caller-facing pagination control and `offset`/`limit` stay internal.
- New `WorksheetSearchItem` model (plus nested `WorksheetSearchInventoryLine` and `WorksheetSearchTag`) carries the lightweight formula hit shape; hits are not hydrated, so callers pass `hit.id` to `client.inventory.get_by_id(...)` when they need the full formula.
- Array filters accept a single value or a list via `ensure_list()`; hits deserialize directly with no collection binding.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest <relevant_test_file>.py -v`

Added `test_worksheet_search` to `tests/collections/test_worksheet.py` (`sheets` xdist group): scopes by `seed_prefix` and `project_id`, filters to `seeded_products` ids, and wraps the fetch in `poll_until`. Note: integration tests require `ALBERT_CLIENT_ID_SDK`, `ALBERT_CLIENT_SECRET_SDK`, and `ALBERT_BASE_URL`, which were not available in the authoring environment, so the new test was verified for collection/deserialization behavior locally but not executed against the live API; CI will exercise it.

## SDK Changes

Added `client.worksheets.search(...)` for discovering formulations across worksheets, returning lightweight `WorksheetSearchItem` results (id, name, inventory lines, tags).