### PR TITLE
feat(teams): add search support

### DIFF
--- a/src/albert/collections/teams.py
+++ b/src/albert/collections/teams.py
@@ -1,15 +1,16 @@
 from collections.abc import Iterator
+from typing import Any
 
 from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
-from albert.core.shared.enums import PaginationMode
+from albert.core.shared.enums import OrderBy, PaginationMode
 from albert.core.shared.identifiers import TeamId, UserId
 from albert.core.utils import ensure_list
 from albert.exceptions import AlbertException
-from albert.resources.teams import Team, TeamMember
+from albert.resources.teams import Team, TeamMember, TeamSearchItem
 from albert.resources.users import User
 
 
@@ -46,6 +47,8 @@ class TeamCollection(BaseCollection):
 
     Methods
     -------
+    search(...) -> Iterator[TeamSearchItem]
+        Search teams with free text and filters, returning partial items.
     get_all(name, exact_match, created_by, updated_by, user_id, max_items) -> Iterator[Team]
         Lists all teams with optional filters.
     get_by_id(id) -> Team
@@ -81,6 +84,86 @@ class TeamCollection(BaseCollection):
             return user.id
         return user
 
+    @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        status: str | None = None,
+        team_id: str | list[str] | None = None,
+        search_field: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        additional_field: str | list[str] | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[TeamSearchItem]:
+        """Search for teams matching the given filters.
+
+        Returns partial (unhydrated)
+        [`TeamSearchItem`][albert.resources.teams.TeamSearchItem] entities, best for
+        free-text lookups and pulling IDs. Results are returned lazily as an
+        iterator that pages through matches on demand. Call ``hydrate()`` on an item
+        to fetch its full [`Team`][albert.resources.teams.Team]. For exact name
+        listing, use [`get_all`][albert.collections.teams.TeamCollection.get_all].
+
+        !!! example
+            ```python
+            for item in client.teams.search(text="Coatings", max_items=10):
+                print(item.id, item.name)
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query matched against team fields.
+        status : str, optional
+            Filter by team status.
+        team_id : str or list[str], optional
+            Filter by Team ID(s) (format ``TEM...``).
+        search_field : str or list[str], optional
+            Restrict which indexed fields the free-text query searches.
+        source_field : str or list[str], optional
+            Restrict which fields are returned on each search hit.
+        additional_field : str or list[str], optional
+            Additional fields to include on each search hit.
+        sort_by : str, optional
+            Attribute to sort results by.
+        order : OrderBy, optional
+            The order in which to sort results (``asc`` or ``desc``).
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matching items.
+
+        Returns
+        -------
+        Iterator[TeamSearchItem]
+            A lazy iterator of matching partial teams. Call ``hydrate()`` on an
+            item to fetch its full [`Team`][albert.resources.teams.Team].
+        """
+        payload: dict[str, Any] = {
+            "text": text,
+            "status": status,
+            "teamId": ensure_list(team_id),
+            "searchField": ensure_list(search_field),
+            "sourceField": ensure_list(source_field),
+            "additionalField": ensure_list(additional_field),
+            "sortBy": sort_by,
+            "order": order,
+        }
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            method="POST",
+            json=payload,
+            max_items=max_items,
+            deserialize=lambda items: [
+                TeamSearchItem.model_validate(x)._bind_collection(self) for x in items
+            ],
+        )
+
     def get_all(
         self,
         *,
@@ -92,6 +175,9 @@ class TeamCollection(BaseCollection):
         max_items: int | None = None,
     ) -> Iterator[Team]:
         """List all teams with optional filters.
+
+        Best for exact name listing. For free-text search, use
+        [`search`][albert.collections.teams.TeamCollection.search].
 
         !!! example
             ```python

--- a/src/albert/resources/teams.py
+++ b/src/albert/resources/teams.py
@@ -5,6 +5,7 @@ from pydantic import Field, model_validator
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.identifiers import TeamId, UserId
 from albert.core.shared.models.base import BaseResource
+from albert.resources._mixins import HydrationMixin
 
 TeamRole = Literal["TeamOwner", "TeamViewer"]
 
@@ -68,3 +69,36 @@ class Team(BaseResource):
                 if user["id"] in role_map and "fgc" not in user:
                     user["fgc"] = role_map[user["id"]]
         return data
+
+
+class TeamSearchItem(BaseAlbertModel, HydrationMixin[Team]):
+    """Lightweight representation of a Team returned from search.
+
+    Returned by
+    [`search`][albert.collections.teams.TeamCollection.search],
+    this carries only summary fields for fast listing. Call ``hydrate()`` (or fetch
+    by ``id`` via
+    [`get_by_id`][albert.collections.teams.TeamCollection.get_by_id])
+    to obtain the fully populated
+    [`Team`][albert.resources.teams.Team]."""
+
+    id: TeamId | None = Field(default=None, alias="albertId")
+    """The Albert Team ID (format ``TEM...``)."""
+
+    name: str | None = None
+    """The display name of the team."""
+
+    created_by_name: str | None = Field(default=None, alias="createdByName")
+    """The display name of the user who created the team."""
+
+    updated_by_name: str | None = Field(default=None, alias="updatedByName")
+    """The display name of the user who last updated the team."""
+
+    created_at: str | None = Field(default=None, alias="createdAt")
+    """ISO 8601 timestamp of when the team was created."""
+
+    updated_at: str | None = Field(default=None, alias="updatedAt")
+    """ISO 8601 timestamp of when the team was last updated."""
+
+    members: list[TeamMember] | None = Field(default=None, alias="user")
+    """The members of the team. Roles may be absent on search hits."""

--- a/tests/collections/test_teams.py
+++ b/tests/collections/test_teams.py
@@ -7,6 +7,7 @@ from albert import Albert
 from albert.exceptions import AlbertException, NotFoundError
 from albert.resources.teams import Team, TeamMember
 from albert.resources.users import User
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("teams")
 
@@ -65,6 +66,25 @@ def test_get_all(client: Albert, seeded_team: Team):
     by_name = list(client.teams.get_all(name=seeded_team.name, exact_match=True))
     assert len(by_name) == 1
     assert by_name[0].id == seeded_team.id
+
+
+def test_search(client: Albert, seed_prefix: str, seeded_team: Team):
+    """Test search finds the seeded team and hits hydrate to a full Team."""
+    hits = poll_until(
+        lambda: [
+            item
+            for item in client.teams.search(text=seed_prefix, max_items=50)
+            if item.id == seeded_team.id
+        ]
+    )
+    assert hits, "Expected seeded team in search results"
+    hit = hits[0]
+    assert hit.id == seeded_team.id
+
+    hydrated = hit.hydrate()
+    assert isinstance(hydrated, Team)
+    assert hydrated.id == hit.id
+    assert hydrated.name == seeded_team.name
 
 
 def test_update(client: Albert, seed_prefix: str, second_user: User):


### PR DESCRIPTION
## What

Callers can now search teams via `client.teams.search(...)`, a lazily paginated iterator of lightweight `TeamSearchItem` hits backed by the team search endpoint. Each hit carries summary fields (`id`, `name`, creator/updater display names, timestamps, members) and can be upgraded to a fully populated `Team` via `hit.hydrate()`.

## Why

Resolves SDK-106. Ask Albert and scripts need to resolve teams by free text, status, or team ID without hand-rolling raw `session.post` calls. OpenSearch-backed `search` complements the existing exact-name `get_all` listing.

## How

- Follows the established `ProjectCollection.search` / `DataColumnCollection.search` pattern: POST-only, OFFSET-mode `AlbertPaginator`, `max_items` as the only caller-facing pagination control (`offset`/`limit` stay internal).
- `None` filters are omitted from the wire payload; array filters (`team_id`, `search_field`, `source_field`, `additional_field`) go through `ensure_list()`.
- New `TeamSearchItem` model uses `HydrationMixin[Team]`, so `hydrate()` delegates to `TeamCollection.get_by_id`.
- Purely additive: no existing signatures, return types, or models changed.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_teams.py -v -n 4` — blocked locally: this environment has no `ALBERT_CLIENT_ID_SDK` / `ALBERT_CLIENT_SECRET_SDK` / `ALBERT_BASE_URL` credentials, so the integration suite cannot construct a client. New `test_search` follows the required pattern (scoped to `seed_prefix`, id-filtered to `seeded_team`, wrapped in `poll_until`, hydration assert) and is expected to run in CI.

## SDK Changes

Added `TeamCollection.search(...)` for free-text team search returning partial `TeamSearchItem` results with `hydrate()` support.