### PR TITLE
feat(product_design): add search support

### DIFF
--- a/src/albert/collections/product_design.py
+++ b/src/albert/collections/product_design.py
@@ -1,25 +1,38 @@
-from typing import Literal
+from collections.abc import Iterator
+from typing import Any, Literal
 
 from pydantic import validate_call
 
 from albert.collections.base import BaseCollection
+from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
-from albert.core.shared.identifiers import InventoryId
-from albert.resources.product_design import UnpackedProductDesign
+from albert.core.shared.enums import OrderBy, PaginationMode
+from albert.core.shared.identifiers import InventoryId, ProjectId
+from albert.core.utils import ensure_list
+from albert.resources.product_design import ProductDesignSearchItem, UnpackedProductDesign
+
+_SEARCH_PAGE_SIZE = 100  # maximum page size accepted by the product design search endpoint
 
 
 class ProductDesignCollection(BaseCollection):
-    """Unpack formulated products into their full substance-level composition.
+    """Search the product design grid and unpack formulated products.
 
-    "Product design" here refers to unpacking (flattening) a formulation inventory
-    item into its full substance-level composition. An unpacked product resolves a
-    formulation's complete substance composition by recursively traversing its
-    ingredient tree: each sub-formulation is expanded into its own ingredients, with
-    fractional contributions multiplied down through each level and summed at the
-    CAS-number level. It produces two outputs: a row-level inventory list (the direct
-    worksheet ingredients, some of which may themselves be sub-formulations) and a
-    flat CAS-level substance list (fully resolved raw materials with combined weight
-    fractions).
+    Two separate capabilities live here:
+
+    - [`search`][albert.collections.product_design.ProductDesignCollection.search]
+      discovers formulations on the product design grid by free text, facets, and
+      project / inventory filters, returning lightweight formula hits.
+    - [`get_unpacked_products`][albert.collections.product_design.ProductDesignCollection.get_unpacked_products]
+      flattens a formulation inventory item into its full substance-level
+      composition, described below.
+
+    An unpacked product resolves a formulation's complete substance composition by
+    recursively traversing its ingredient tree: each sub-formulation is expanded
+    into its own ingredients, with fractional contributions multiplied down through
+    each level and summed at the CAS-number level. It produces two outputs: a
+    row-level inventory list (the direct worksheet ingredients, some of which may
+    themselves be sub-formulations) and a flat CAS-level substance list (fully
+    resolved raw materials with combined weight fractions).
 
     The calculation assumes a non-reactive, homogeneous mixture: no chemical
     transformations occur and concentrations are additive. When a formulation has
@@ -60,6 +73,8 @@ class ProductDesignCollection(BaseCollection):
 
     Methods
     -------
+    search(...) -> Iterator[ProductDesignSearchItem]
+        Search for formulations on the product design grid matching the given filters.
     get_unpacked_products(inventory_ids, unpack_id="PREDICTION") -> list[UnpackedProductDesign]
         Unpack one or more formulas into their full CAS-level substance composition.
     """
@@ -79,6 +94,119 @@ class ProductDesignCollection(BaseCollection):
         self.base_path = f"/api/{ProductDesignCollection._api_version}/productdesign"
 
     @validate_call
+    def search(
+        self,
+        *,
+        text: str | None = None,
+        project_id: ProjectId | None = None,
+        tags: str | list[str] | None = None,
+        albert_id: str | list[str] | None = None,
+        state: str | list[str] | None = None,
+        data_template: str | list[str] | None = None,
+        inventory_name: str | list[str] | None = None,
+        inventory_id: str | list[str] | None = None,
+        formula_created_by: str | list[str] | None = None,
+        facet_text: str | None = None,
+        facet_field: str | None = None,
+        contains_field: str | list[str] | None = None,
+        contains_text: str | list[str] | None = None,
+        source_field: str | list[str] | None = None,
+        product_grid: bool | None = None,
+        sort_by: str | None = None,
+        order: OrderBy | None = None,
+        max_items: int | None = None,
+    ) -> Iterator[ProductDesignSearchItem]:
+        """Search for formulations on the product design grid matching the given filters.
+
+        Returns lightweight, partially populated
+        [`ProductDesignSearchItem`][albert.resources.product_design.ProductDesignSearchItem]
+        hits, best for free-text lookups, counts, and pulling formula IDs. When you
+        need the complete formula, pass the hit's ``id`` to
+        [`get_by_id`][albert.collections.inventory.InventoryCollection.get_by_id].
+        Results are returned as a lazily paginated iterator.
+
+        !!! example
+            ```python
+            for hit in client.product_design.search(text="shampoo", max_items=10):
+                print(hit.id, hit.name)
+            ```
+
+        Parameters
+        ----------
+        text : str, optional
+            Free-text query matched against formula fields.
+        project_id : ProjectId, optional
+            Scope the search to a project (format ``PRO...``).
+        tags : str or list[str], optional
+            Filter by tag name(s).
+        albert_id : str or list[str], optional
+            Filter by formula Inventory ID(s) (format ``INV...``).
+        state : str or list[str], optional
+            Filter by formula lock/unlock state(s).
+        data_template : str or list[str], optional
+            Filter by data template name(s).
+        inventory_name : str or list[str], optional
+            Filter by ingredient name(s).
+        inventory_id : str or list[str], optional
+            Filter by ingredient Inventory ID(s).
+        formula_created_by : str or list[str], optional
+            Filter by formula creator(s).
+        facet_text : str, optional
+            Text to match within a facet search.
+        facet_field : str, optional
+            Field to search within for facet filtering.
+        contains_field : str or list[str], optional
+            Field(s) to apply a "contains" search to.
+        contains_text : str or list[str], optional
+            Text value(s) for the "contains" search.
+        source_field : str or list[str], optional
+            Restrict which fields are returned on each search hit.
+        product_grid : bool, optional
+            Search the product grid shown on the project homepage.
+        sort_by : str, optional
+            Attribute to sort results by.
+        order : OrderBy, optional
+            The order in which to sort results (``asc`` or ``desc``).
+        max_items : int, optional
+            Maximum number of items to return in total. If None, iterates over all
+            matching items.
+
+        Returns
+        -------
+        Iterator[ProductDesignSearchItem]
+            A lazy iterator of matching formula hits.
+        """
+        params: dict[str, Any] = {
+            "text": text,
+            "projectId": project_id,
+            "tags": ensure_list(tags),
+            "albertId": ensure_list(albert_id),
+            "state": ensure_list(state),
+            "dataTemplate": ensure_list(data_template),
+            "inventoryName": ensure_list(inventory_name),
+            "inventoryId": ensure_list(inventory_id),
+            "formulaCreatedBy": ensure_list(formula_created_by),
+            "facetText": facet_text,
+            "facetField": facet_field,
+            "containsField": ensure_list(contains_field),
+            "containsText": ensure_list(contains_text),
+            "sourceField": ensure_list(source_field),
+            "productGrid": product_grid,
+            "sortBy": sort_by,
+            "order": order,
+            "limit": _SEARCH_PAGE_SIZE,
+        }
+
+        return AlbertPaginator(
+            mode=PaginationMode.OFFSET,
+            path=f"{self.base_path}/search",
+            session=self.session,
+            params=params,
+            max_items=max_items,
+            deserialize=lambda items: [ProductDesignSearchItem.model_validate(x) for x in items],
+        )
+
+    @validate_call
     def get_unpacked_products(
         self,
         *,
@@ -91,7 +219,9 @@ class ProductDesignCollection(BaseCollection):
         their amounts, CAS information, and SDS / regulatory details. One
         [`UnpackedProductDesign`][albert.resources.product_design.UnpackedProductDesign] is returned
         per input formula. Requests are automatically split into batches of 50
-        inventory IDs, so large lists can be passed in a single call.
+        inventory IDs, so large lists can be passed in a single call. To discover
+        formula IDs by text or filters, use
+        [`search`][albert.collections.product_design.ProductDesignCollection.search].
 
         !!! example
             ```python

--- a/src/albert/collections/product_design.py
+++ b/src/albert/collections/product_design.py
@@ -7,7 +7,7 @@ from albert.collections.base import BaseCollection
 from albert.core.pagination import AlbertPaginator
 from albert.core.session import AlbertSession
 from albert.core.shared.enums import OrderBy, PaginationMode
-from albert.core.shared.identifiers import InventoryId, ProjectId
+from albert.core.shared.identifiers import InventoryId, SearchProjectId
 from albert.core.utils import ensure_list
 from albert.resources.product_design import ProductDesignSearchItem, UnpackedProductDesign
 
@@ -98,7 +98,7 @@ class ProductDesignCollection(BaseCollection):
         self,
         *,
         text: str | None = None,
-        project_id: ProjectId | None = None,
+        project_id: SearchProjectId | None = None,
         tags: str | list[str] | None = None,
         albert_id: str | list[str] | None = None,
         state: str | list[str] | None = None,
@@ -135,7 +135,7 @@ class ProductDesignCollection(BaseCollection):
         ----------
         text : str, optional
             Free-text query matched against formula fields.
-        project_id : ProjectId, optional
+        project_id : SearchProjectId, optional
             Scope the search to a project (format ``PRO...``).
         tags : str or list[str], optional
             Filter by tag name(s).

--- a/src/albert/resources/product_design.py
+++ b/src/albert/resources/product_design.py
@@ -3,6 +3,7 @@ from typing import Any
 from pydantic import Field
 
 from albert.core.base import BaseAlbertModel
+from albert.core.shared.identifiers import InventoryId
 
 
 class CasLevelSubstance(BaseAlbertModel):
@@ -212,3 +213,45 @@ class UnpackedProductDesign(BaseAlbertModel):
         default=None, alias="normalizedCasList"
     )
     """The CAS substances with their normalized proportions in the product."""
+
+
+class ProductDesignSearchInventoryLine(BaseAlbertModel):
+    """A single ingredient row on a [`ProductDesignSearchItem`][albert.resources.product_design.ProductDesignSearchItem]."""
+
+    id: InventoryId | None = Field(default=None)
+    """The Inventory ID of the ingredient (format ``INV...``)."""
+
+    name: str | None = Field(default=None)
+    """The name of the ingredient."""
+
+
+class ProductDesignSearchTag(BaseAlbertModel):
+    """A tag attached to a formula hit on the product design grid."""
+
+    tag_id: str | None = Field(default=None, alias="tagId")
+    """The Tag ID (format ``TAG...``)."""
+
+    tag_name: str | None = Field(default=None, alias="tagName")
+    """The name of the tag."""
+
+
+class ProductDesignSearchItem(BaseAlbertModel):
+    """A lightweight formula hit returned by product design grid search.
+
+    Returned by
+    [`search`][albert.collections.product_design.ProductDesignCollection.search],
+    this carries only summary fields for fast listing rather than the full
+    formula. To retrieve the complete formula, pass ``id`` to
+    [`get_by_id`][albert.collections.inventory.InventoryCollection.get_by_id]."""
+
+    id: InventoryId | None = Field(default=None, alias="albertId")
+    """The Inventory ID of the formula (format ``INV...``)."""
+
+    name: str | None = Field(default=None)
+    """The display name of the formula."""
+
+    inventory: list[ProductDesignSearchInventoryLine] | None = Field(default=None)
+    """The ingredient rows of the formula, when returned."""
+
+    tags: list[ProductDesignSearchTag] | None = Field(default=None)
+    """The tags attached to the formula, when returned."""

--- a/tests/collections/test_product_design.py
+++ b/tests/collections/test_product_design.py
@@ -3,8 +3,23 @@ import pytest
 from albert import Albert
 from albert.resources.inventory import InventoryItem
 from albert.resources.product_design import UnpackedProductDesign
+from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("sheets")
+
+
+def test_search(client: Albert, seed_prefix: str, seeded_products: list[InventoryItem]):
+    """Test search finds the seeded formula on the product design grid."""
+    seeded_ids = {p.id for p in seeded_products}
+    hits = poll_until(
+        lambda: [
+            hit
+            for hit in client.product_design.search(text=seed_prefix, max_items=50)
+            if hit.id in seeded_ids
+        ]
+    )
+    assert hits, "Expected seeded formula in product design search results"
+    assert seeded_products[0].id in {hit.id for hit in hits}
 
 
 def test_get_unpacked(client: Albert, seeded_products: list[InventoryItem]):

--- a/tests/collections/test_product_design.py
+++ b/tests/collections/test_product_design.py
@@ -3,18 +3,28 @@ import pytest
 from albert import Albert
 from albert.resources.inventory import InventoryItem
 from albert.resources.product_design import UnpackedProductDesign
+from albert.resources.worksheets import Worksheet
 from tests.utils.wait import poll_until
 
 pytestmark = pytest.mark.xdist_group("sheets")
 
 
-def test_search(client: Albert, seed_prefix: str, seeded_products: list[InventoryItem]):
-    """Test search finds the seeded formula on the product design grid."""
+def test_search(
+    client: Albert,
+    seed_prefix: str,
+    seeded_products: list[InventoryItem],
+    seeded_worksheet: Worksheet,
+):
+    """Test search finds the seeded formula on the product design grid within its project."""
     seeded_ids = {p.id for p in seeded_products}
     hits = poll_until(
         lambda: [
             hit
-            for hit in client.product_design.search(text=seed_prefix, max_items=50)
+            for hit in client.product_design.search(
+                text=seed_prefix,
+                project_id=seeded_worksheet.project_id,
+                max_items=50,
+            )
             if hit.id in seeded_ids
         ]
     )


### PR DESCRIPTION
## What

`client.product_design` now exposes `search(...)`, wrapping the product design grid search endpoint so callers can discover formulations by free text, facets, and project / inventory filters. Search returns lightweight `ProductDesignSearchItem` hits (id, name, ingredient rows, tags) as a lazily paginated iterator. The existing unpack API is unchanged.

## Why

Ask Albert and scripts need to look up formulations on the product design grid without hand-rolling `session.get` calls. This unblocks product-grid formulation lookup for agents (SDK-107).

## How

- GET search with an OFFSET `AlbertPaginator`; callers control result volume via `max_items` only (no public `offset` / `limit`).
- The endpoint caps page size at 100, so the paginator params pin `limit` to that cap (same pattern as workflow search).
- Search hits are intentionally not hydrated; pass a hit's `id` to `client.inventory.get_by_id` for the full formula.
- Grid search (this change) and CAS-level unpack (`get_unpacked_products`) are separate APIs; the class docstring now calls that out.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [ ] `uv run pytest tests/collections/test_product_design.py -v` (integration test added: `test_search` under the `sheets` xdist group, scoped to `seed_prefix` + `seeded_products` ids with `poll_until`; requires live API credentials, not run in this environment)

## SDK Changes

New: `client.product_design.search(...)` and `ProductDesignSearchItem` for formulation discovery on the product design grid.

---

Cake session: https://agents.ai.albertinventdev.com/sessions/593afeff-f69a-4346-8a19-c307607f2c88