### PR TITLE
feat: support increased intervals

### DIFF
--- a/src/albert/collections/files.py
+++ b/src/albert/collections/files.py
@@ -180,6 +180,7 @@ class FileCollection(BaseCollection):
         content_type: str,
         generic: bool = False,
         category: FileCategory | None = None,
+        metadata: list[dict[str, str]] | None = None,
     ) -> str:
         """Get a temporary signed URL for uploading a file.
 
@@ -211,6 +212,9 @@ class FileCollection(BaseCollection):
             files. Defaults to False.
         category : FileCategory | None, optional
             The file category (e.g. ``SDS``, ``OTHER``). Defaults to None.
+        metadata : list[dict[str, str]] | None, optional
+            Key/value metadata entries (e.g. ``[{"key": "sizeInMB", "value": "0.008640"}]``)
+            included in the presigned signature. Defaults to None.
 
         Returns
         -------
@@ -226,6 +230,7 @@ class FileCollection(BaseCollection):
                     namespace=namespace,
                     content_type=content_type,
                     category=category,
+                    metadata=metadata,
                 )
             ]
         )
@@ -245,6 +250,7 @@ class FileCollection(BaseCollection):
         content_type: str,
         generic: bool = False,
         category: FileCategory | None = None,
+        metadata: list[dict[str, str]] | None = None,
     ) -> None:
         """Sign and upload a file to Albert in one step.
 
@@ -281,6 +287,8 @@ class FileCollection(BaseCollection):
             files. Defaults to False.
         category : FileCategory | None, optional
             The category of the file (e.g. ``SDS``, ``OTHER``). Defaults to None.
+        metadata : list[dict[str, str]] | None, optional
+            Key/value metadata entries forwarded to the sign call. Defaults to None.
 
         Returns
         -------
@@ -292,5 +300,6 @@ class FileCollection(BaseCollection):
             content_type=content_type,
             generic=generic,
             category=category,
+            metadata=metadata,
         )
         requests.put(upload_url, data=data, headers={"Content-Type": content_type})

--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -451,7 +451,8 @@ class PropertyDataCollection(BaseCollection):
         }
 
         response = self.session.get(url=self.base_path, params=params)
-        return CheckPropertyData(response.json())
+        results = [CheckPropertyData(**x) for x in response.json()]
+        return results[0]
 
     @validate_call
     def get_all_task_properties(

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +28,7 @@ from albert.core.shared.identifiers import (
     remove_id_prefix,
 )
 from albert.core.utils import ensure_list
-from albert.exceptions import AlbertHTTPError
+from albert.exceptions import AlbertHTTPError, NotFoundError
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
 from albert.resources.tasks import (
@@ -588,13 +589,14 @@ class TaskCollection(BaseCollection):
             inventory_id,
             lot_id or "None",
         )
-        property_data_collection.bulk_delete_task_data(
-            task_id=task_id,
-            block_id=block_id,
-            inventory_id=inventory_id,
-            lot_id=lot_id,
-            interval_id=interval,
-        )
+        with suppress(NotFoundError):
+            property_data_collection.bulk_delete_task_data(
+                task_id=task_id,
+                block_id=block_id,
+                inventory_id=inventory_id,
+                lot_id=lot_id,
+                interval_id=interval,
+            )
 
         property_data_collection.add_properties_to_task(
             inventory_id=inventory_id,

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -161,16 +161,26 @@ def ensure_interval_id(id: str) -> str:
     if not id:
         raise ValueError("IntervalId cannot be empty")
 
-    # Check if it matches ROW# or ROW#XROW# pattern
-    parts = id.upper().split("X")
-    if len(parts) > 2:
-        raise ValueError(f"IntervalId {id} is invalid. Must be in format ROW# or ROW#XROW#")
+    if id == "default":
+        return id
 
+    if id.upper().startswith("WFL"):
+        if len(id) <= 3:
+            raise ValueError(f"IntervalId {id} is invalid.")
+        return id
+
+    if len(id) == 9 and not id.upper().startswith("ROW") and not id.upper().startswith("WFL"):
+        return id
+
+    parts = id.split("X")
     for part in parts:
-        if not part.startswith("ROW") or not part[3:].isdigit():
-            raise ValueError(f"IntervalId {id} is invalid. Must be in format ROW# or ROW#XROW#")
+        if not part.upper().startswith("ROW") or not part[3:].isdigit():
+            raise ValueError(
+                f"IntervalId {id} is invalid. Must be a ROW chain, WFL id, "
+                f"9-character barcode, or 'default'"
+            )
 
-    return id.upper()
+    return id
 
 
 IntervalId = Annotated[str, AfterValidator(ensure_interval_id)]

--- a/src/albert/resources/worker_jobs.py
+++ b/src/albert/resources/worker_jobs.py
@@ -54,6 +54,21 @@ class WorkerJobMetadata(BaseAlbertModel):
     s3_output_key: str | None = Field(default=None, alias="s3OutputKey")
     """The S3 key for the job's output file."""
 
+    albert_id: str | None = Field(default=None, alias="albertId")
+    """The Albert ID of the entity the job operates on (e.g. a task id)."""
+
+    block_id: str | None = Field(default=None, alias="blockId")
+    """The block id when the job targets a task block."""
+
+    s3_url: str | None = Field(default=None, alias="s3Url")
+    """The S3 key for an interval-combinations input file."""
+
+    new_workflow_id: str | None = Field(default=None, alias="newWorkflowId")
+    """The workflow id assigned to the block for this generation run."""
+
+    old_workflow_id: str | None = Field(default=None, alias="oldWorkflowId")
+    """The previous workflow id, when regenerating combinations after a workflow swap."""
+
 
 class WorkerJobCreateRequest(BaseAlbertModel):
     """Request payload for creating a new worker job."""

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -62,8 +62,8 @@ class Interval(BaseAlbertModel):
         high = Interval(value="60", unit={"id": "UNI9999999"})
         ```"""
 
-    value: str | None = Field(default=None)
-    """The value of this interval. For Special parameters (Equipment, Consumables, Templates) this is the entity ID (e.g. ``"INVC191778"``). For Normal parameters this is a plain scalar string (e.g. ``"23"``). Required."""
+    value: str | dict[str, Any] | EntityLink | None = Field(default=None)
+    """The value of this interval. For Special parameters (Equipment, Consumables, Templates) this is the entity ID or link (e.g. ``"INVC191778"`` or ``{"id": "INVC191778", "name": "..."}``). For Normal parameters this is a plain scalar string (e.g. ``"23"``). May be empty when the backend returns an unset interval slot."""
 
     name: str | None = Field(default=None)
     """The display name of the interval value. Populated for Special parameters (e.g. ``"Pipette 0.01 -0.1 ml (10 - 100 μl)"``). ``None`` for Normal parameters."""
@@ -75,8 +75,8 @@ class Interval(BaseAlbertModel):
 
     @model_validator(mode="after")
     def validate_interval(self) -> Interval:
-        if not self.value:
-            raise ValueError("Interval: 'value' is required.")
+        if self.value is None or self.value == {}:
+            return self
         if self.unit and not getattr(self.unit, "id", None):
             raise ValueError("Interval: 'Unit.id' is required.")
         return self
@@ -394,7 +394,7 @@ class Workflow(BaseResource):
     """The Albert ID of the workflow (``WFL...``). Set when a workflow is created or retrieved from the platform."""
 
     block_mapping: str | None = Field(default=None, alias="blockMapping")
-    """Read-only / informational. When a Workflow is returned in the context of a block, this is hydrated for convenience. See Also --------"""
+    """Caller-supplied correlation key on ``POST /workflows/bulk`` tying each created workflow to its block position (e.g. ``"0"``, ``"1"``). Also returned on read for convenience."""
 
     # post init fields
     _interval_parameters: list[IntervalParameter] = PrivateAttr(default_factory=list)
@@ -408,11 +408,18 @@ class Workflow(BaseResource):
             for parameter_setpoint in parameter_group_setpoint.parameter_setpoints:
                 if parameter_setpoint.intervals is not None:
                     for interval in parameter_setpoint.intervals:
+                        interval_value = interval.value
+                        if isinstance(interval_value, dict):
+                            interval_value = interval_value.get("id") or interval_value.get("name")
+                        elif hasattr(interval_value, "id"):
+                            interval_value = interval_value.id
+                        elif interval_value is not None and not isinstance(interval_value, str):
+                            interval_value = str(interval_value)
                         self._interval_parameters.append(
                             IntervalParameter(
                                 interval_param_name=parameter_setpoint.name,
                                 interval_id=interval.row_id,
-                                interval_value=interval.value,
+                                interval_value=interval_value,
                                 interval_unit=interval.unit.name if interval.unit else None,
                             )
                         )

--- a/tests/core/shared/test_identifiers.py
+++ b/tests/core/shared/test_identifiers.py
@@ -90,6 +90,11 @@ def test_ensure_lot_id_display_format():
 def test_ensure_interval_id():
     assert ensure_interval_id("ROW123") == "ROW123"
     assert ensure_interval_id("ROW123XROW456") == "ROW123XROW456"
+    assert ensure_interval_id("ROW123XROW456XROW789") == "ROW123XROW456XROW789"
+    assert ensure_interval_id("default") == "default"
+    assert ensure_interval_id("WFL375962") == "WFL375962"
+    assert ensure_interval_id("V1a9Km2xL") == "V1a9Km2xL"
+
     with pytest.raises(ValueError, match="IntervalId cannot be empty"):
         ensure_interval_id("")
 
@@ -97,20 +102,14 @@ def test_ensure_interval_id():
 
     assert ensure_row_id("row123Xrow456") == "ROW123XROW456"
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
-        ensure_interval_id("ROW123XROW456XROW789")
-
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="IntervalId .* is invalid"):
         ensure_interval_id("123")
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="IntervalId .* is invalid"):
         ensure_interval_id("123X456")
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="IntervalId .* is invalid"):
         ensure_interval_id("ROW123XROW456X")
-
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
-        ensure_interval_id("ROW123XROW456XROW789")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What

Callers on flag-ON tenants can again deserialize intervalized workflows, read worker-job metadata, check block interval data, import CSV results into empty blocks, and sign file uploads with size metadata — without hitting validation or parsing errors that worked before increased intervals rolled out.

## Why

The increased-intervals flag is live on dev and breaks several existing SDK paths: multi-segment interval IDs and object-valued intervals fail Pydantic validation, `createChildWorkflows` job fields are silently dropped, `check_block_interval_for_data` mis-parses the response array, first-time `import_results` aborts on a 404 pre-delete, and file sign cannot attach metadata required for combination uploads in later phases.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/core/shared/test_identifiers.py -v`
- [x] `uv run pytest tests/collections/test_property_data.py tests/collections/test_workflows.py tests/collections/test_tasks.py -n 4` (59 passed on staging via `~/.stagingenv` + `ALBERT_TOKEN`)

## SDK Changes

Fixes only — no new public methods. Interval ID validation now accepts ROW chains of any length, child workflow IDs (`WFL…`), 9-character barcodes, and `"default"` without case folding. `Interval.value` accepts object and empty shapes from bulk workflow responses. `WorkerJobMetadata` round-trips `createChildWorkflows` fields. Phases 2–5 (read path, rules, engine, orchestrator) will follow in separate PRs.