### PR TITLE
feat(intervals): support increased intervals

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,7 +3,8 @@
 Single source of truth for coding-agent guidance in this repo.
 
 **Read `OPINIONS.md` before changing anything it covers** — patch/update logic,
-pagination, resource naming, deprecations, releases, and testing edge cases.
+pagination, resource naming, keyword-only arguments on public methods, deprecations,
+releases, and testing edge cases.
 `AGENTS.md` states what to do; `OPINIONS.md` explains the traps.
 
 ## Project Basics
@@ -31,6 +32,10 @@ pagination, resource naming, deprecations, releases, and testing edge cases.
 - **Validate at boundaries only.** Trust internal code and type hints. Only validate user input and external API responses.
 - Collections inherit from `BaseCollection` and accept an `AlbertSession`.
 - Public collection methods use `@validate_call` for runtime validation.
+- **Always use keyword-only arguments (`*`) for public methods.** Place `*` immediately
+  after `self` (or `cls`) on all public collection, resource, and client methods
+  (e.g. `def get_by_id(self, *, id: str) -> Cas:`). Never expose positional parameters on
+  public APIs. See `OPINIONS.md` for rationale.
 - Resources use `BaseAlbertModel`/`BaseResource` with Pydantic `Field` and aliases.
 - **Field documentation lives on attribute docstrings**, not in class-level ``Attributes`` sections.
   ``BaseAlbertModel`` sets ``use_attribute_docstrings=True``, so Pydantic emits them as

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,3 +2,8 @@
 
 @AGENTS.md
 @OPINIONS.md
+
+## Key Guidelines
+
+- **Always use keyword-only arguments (`*`) for public methods** on collections, resources, and clients (`def method(self, *, ...)`). See `OPINIONS.md`.
+

--- a/OPINIONS.md
+++ b/OPINIONS.md
@@ -74,6 +74,33 @@ The SDK convention is `max_items: int | None = None` (unbounded by default).
 Why: `substances_v4.search()` shipped with `max_items=100`, silently capping every
 search at 100 results. Fixed in commit fa639977.
 
+## Public methods — always keyword-only arguments (`*`)
+
+All public methods on collections, resources, and client classes must declare their parameters as keyword-only using a bare `*` after `self` (or `cls`):
+
+```python
+def get_by_id(self, *, id: str) -> Cas: ...
+
+
+def build_rule_condition(
+    self,
+    *,
+    parameter: str,
+    operator: RuleOperator | str,
+    value: str | float | int | None = None,
+    unit: str | Unit | None = None,
+    group: str | None = None,
+) -> RuleCondition: ...
+```
+
+Why:
+- Prevents positional argument bugs at call sites, especially when methods take multiple IDs, strings, or optional flags.
+- Preserves backwards compatibility: new optional parameters can be added or existing parameters reordered without breaking caller code.
+- Self-documenting call sites: `client.tasks.get_by_id(id="TAS123")` makes intent explicit compared to `client.tasks.get_by_id("TAS123")`.
+- Integrates cleanly with Pydantic's `@validate_call`, providing clear validation error messages when arguments are passed incorrectly.
+
+Never expose positional arguments on public collection or resource methods. Private helpers (`_`-prefixed), standard dunder methods (`__init__`, `__getitem__`, etc.), or standard Python protocol implementations are the only exceptions.
+
 ## Resource & search model naming
 
 - When a search endpoint returns a different shape than the main resource, name the

--- a/docs/core/models.md
+++ b/docs/core/models.md
@@ -1,3 +1,26 @@
-::: albert.core.shared.models.base
+::: albert.core.shared.models.base.AuditFields
+    options:
+      show_bases: false
+
+::: albert.core.shared.models.base.EntityLink
+    options:
+      show_bases: false
+
+::: albert.core.shared.models.base.EntityLinkWithName
+    options:
+      show_bases: false
+      filters:
+        - "!^_"
+        - "!^name$"
+
+::: albert.core.shared.models.base.LocalizedNames
+    options:
+      show_bases: false
+
+::: albert.core.shared.models.base.BaseResource
+    options:
+      show_bases: false
+
+::: albert.core.shared.models.base.BaseSessionResource
     options:
       show_bases: false

--- a/docs/examples/tasks.md
+++ b/docs/examples/tasks.md
@@ -2,7 +2,12 @@
 
 Tasks in Albert Invent are a way to manage and track your daily work and collaborate with colleagues. There are three types of tasks: Batch Tasks, Property Tasks, and General Tasks.
 
-## Intervals, Rules, and Overrides Overview
+## Intervals, Rules, and Overrides Overview (🧪 Beta)
+
+!!! warning "Beta Feature!"
+    Increased intervals combination support is currently in beta and behind a platform feature flag.
+    Please do not use in production or without explicit guidance from Albert. This feature currently
+    falls outside of the Albert support contract, but we'd love your feedback!
 
 When designing experiments or testing formulations, scientists frequently vary one or more workflow parameters across discrete values. On [`PropertyTask`][albert.resources.tasks.PropertyTask] blocks, Albert Invent manages this matrix of conditions through **intervals**, **rules**, and **combination overrides**.
 
@@ -45,8 +50,6 @@ Each task block specifies an `intervals_start_from` strategy that controls the i
 While platform APIs require workflow-local internal IDs (`parameter_group_id`, `parameter_id`, and `row_id`), the Albert Python SDK provides value-based helpers on [`Workflow`][albert.resources.workflows.Workflow] so you can work entirely with human-readable parameter names and values:
 
 - [`workflow.build_rule`][albert.resources.workflows.Workflow.build_rule]: Assembles a rule from single or compound condition criteria.
-- [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Semantic builder for Exclude Mode rules.
-- [`workflow.build_inclusion_rule`][albert.resources.workflows.Workflow.build_inclusion_rule]: Semantic builder for Include Mode rules.
 - [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Resolves parameter name, operator, value, and unit into a [`RuleCondition`][albert.resources.interval_combinations.RuleCondition].
 - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Generates a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] from a parameter-value dictionary.
 
@@ -70,7 +73,7 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
 
     # 2. Build rules and overrides using human-readable parameter names and values
     # Rule: Exclude all variants with both high heat and high speed
-    rule = workflow.build_exclusion_rule(
+    rule = workflow.build_rule(
         name="Exclude high heat with high speed",
         conditions=[
             ("Temperature", ">=", 90),
@@ -79,7 +82,7 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     )
     # Override: Skip a specific room-temperature/extreme-speed condition not caught by the general high-heat rule
     override = workflow.build_override(
-        {"Temperature": 25, "Speed": 2000},
+        parameter_values={"Temperature": 25, "Speed": 2000},
         action="skip",
     )
 
@@ -112,11 +115,9 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     
     Instead of manually resolving internal IDs, use the helper methods on your [`Workflow`][albert.resources.workflows.Workflow] instance:
     
-    - [`workflow.build_rule`][albert.resources.workflows.Workflow.build_rule]: Constructs an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] with human-readable conditions using tuples (e.g. `conditions=[("Temperature", ">=", 90)]`) or keyword arguments (`parameter="Temperature", operator=">=", value=90`).
-    - [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Semantic builder for Exclude Mode rules.
-    - [`workflow.build_inclusion_rule`][albert.resources.workflows.Workflow.build_inclusion_rule]: Semantic builder for Include Mode rules.
+    - [`workflow.build_rule`][albert.resources.workflows.Workflow.build_rule]: Constructs an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] with human-readable conditions using tuples (e.g. `conditions=[("Temperature", ">=", 90)]`), [`Condition`][albert.resources.interval_combinations.Condition] named tuples, or single-condition keyword arguments (`parameter="Temperature", operator=">=", value=90`).
     - [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Constructs an individual [`RuleCondition`][albert.resources.interval_combinations.RuleCondition] with resolved group, parameter, and row IDs.
-    - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] directly from a dictionary of parameter names and values (e.g. `workflow.build_override({"Temperature": 25, "Speed": 2000}, action="skip")`).
+    - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] directly from a dictionary of parameter names and values (e.g. `workflow.build_override(parameter_values={"Temperature": 25, "Speed": 2000}, action="skip")`).
 
 !!! warning "Property Tasks only"
     Child-workflow interval combinations are exclusively supported on [`PropertyTask`][albert.resources.tasks.PropertyTask]. They cannot be created or evaluated on [`BatchTask`][albert.resources.tasks.BatchTask] or [`GeneralTask`][albert.resources.tasks.GeneralTask].
@@ -174,7 +175,7 @@ In this mode:
     workflow = client.workflows.get_by_id(id="WFL456")
 
     # 1. Define inclusion rule using workflow helper (low temperatures only)
-    rule = workflow.build_inclusion_rule(
+    rule = workflow.build_rule(
         name="Include low temperature variants",
         conditions=[
             ("Temperature", "<", 40),
@@ -184,12 +185,12 @@ In this mode:
     # 2. Cherry-pick specific higher-temperature benchmark combinations
     # that would otherwise be omitted by the rule (Temperature < 40)
     override_1 = workflow.build_override(
-        {"Temperature": 60, "Speed": 500},
+        parameter_values={"Temperature": 60, "Speed": 500},
         action="unskip",
         is_manual=True,
     )
     override_2 = workflow.build_override(
-        {"Temperature": 90, "Speed": 1000},
+        parameter_values={"Temperature": 90, "Speed": 1000},
         action="unskip",
         is_manual=True,
     )
@@ -241,7 +242,7 @@ You can update rules and overrides on an existing task block at any time using [
     block = next(b for b in task.blocks if b.id == block_id)
     workflow = client.workflows.get_by_id(id=block.workflow[0].id)
 
-    new_rule = workflow.build_exclusion_rule(
+    new_rule = workflow.build_rule(
         name="Exclude cold temperatures",
         conditions=[
             ("Temperature", "<", 15),

--- a/docs/examples/tasks.md
+++ b/docs/examples/tasks.md
@@ -2,6 +2,54 @@
 
 Tasks in Albert Invent are a way to manage and track your daily work and collaborate with colleagues. There are three types of tasks: Batch Tasks, Property Tasks, and General Tasks.
 
+## Intervals, Rules, and Overrides Overview
+
+When designing experiments or testing formulations, scientists frequently vary one or more workflow parameters across discrete values. On [`PropertyTask`][albert.resources.tasks.PropertyTask] blocks, Albert Invent manages this matrix of conditions through **intervals**, **rules**, and **combination overrides**.
+
+### What are intervals?
+
+An **interval** is a discrete setpoint value assigned to a parameter within a workflow. When multiple parameters define intervals:
+
+- **Cartesian Product**: Albert Invent computes all combinations of values across every intervalized parameter. For example, testing 3 temperatures (25 °C, 60 °C, 90 °C) and 2 stir speeds (500 RPM, 1500 RPM) creates \(3 \times 2 = 6\) experimental combinations.
+- **Child Workflows**: Each combination materializes as an independent child workflow record (`WFL...`) linked to the task block.
+- **Interval Barcodes**: Every combination receives a unique, persistent barcode (e.g. `OhI8ap0HY`) that remains stable across rule updates as long as the parameter setpoints are unchanged.
+
+### Starting modes (`intervals_start_from`)
+
+Each task block specifies an `intervals_start_from` strategy that controls the initial baseline before rules and overrides are applied:
+
+- **Exclude Mode (`"all"`, default)**: Starts with the full Cartesian product (all combinations included). Rules and overrides prune out infeasible, unsafe, or unwanted combinations.
+- **Include Mode (`"none"`)**: Starts with zero combinations (an empty set). Rules and overrides selectively pull in combinations, ideal for sparse screening or targeted Designs of Experiment (DoE).
+
+### What are rules?
+
+**Rules** dynamically evaluate combination variants against criteria defined on parameter values:
+
+- **Conditions**: A condition compares a parameter against a threshold using operators (`=`, `!=`, `>`, `>=`, `<`, `<=`).
+- **AND logic within a rule**: All conditions inside a single rule must match for that rule to trigger.
+- **OR logic across rules**: If *any* rule triggers:
+    - In **Exclude Mode** (`"all"`), the combination is excluded from the task.
+    - In **Include Mode** (`"none"`), the combination is included in the task.
+
+### What are overrides?
+
+**Overrides** target a single, specific combination identified by its exact parameter values (e.g. Temperature = 100 °C and Speed = 2000 RPM):
+
+- `skip`: Explicitly excludes the combination.
+- `unskip`: Explicitly keeps or forces the inclusion of the combination.
+- `is_manual=True`: In Include Mode, designates a manually cherry-picked combination.
+- **Precedence**: Overrides are evaluated first and always take precedence over rules. For example, an `unskip` override guarantees a combination is retained even if an exclusion rule would otherwise drop it.
+
+### Value-based helpers
+
+While platform APIs require workflow-local internal IDs (`parameter_group_id`, `parameter_id`, and `row_id`), the Albert Python SDK provides value-based helpers on [`Workflow`][albert.resources.workflows.Workflow] so you can work entirely with human-readable parameter names and values:
+
+- [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Assembles an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] from single or compound condition criteria.
+- [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Resolves parameter name, operator, value, and unit into a [`RuleCondition`][albert.resources.interval_combinations.RuleCondition].
+- [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Generates a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] from a parameter-value dictionary.
+
+---
+
 ## Create an intervalized Property task in Exclude Mode
 
 When testing multiple formulation variants or process conditions, a Property Task can evaluate intervals across workflow parameters (such as temperature, speed, or concentration). Each combination of parameter setpoints materializes as a child workflow variant.

--- a/docs/examples/tasks.md
+++ b/docs/examples/tasks.md
@@ -44,7 +44,9 @@ Each task block specifies an `intervals_start_from` strategy that controls the i
 
 While platform APIs require workflow-local internal IDs (`parameter_group_id`, `parameter_id`, and `row_id`), the Albert Python SDK provides value-based helpers on [`Workflow`][albert.resources.workflows.Workflow] so you can work entirely with human-readable parameter names and values:
 
-- [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Assembles an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] from single or compound condition criteria.
+- [`workflow.build_rule`][albert.resources.workflows.Workflow.build_rule]: Assembles a rule from single or compound condition criteria.
+- [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Semantic builder for Exclude Mode rules.
+- [`workflow.build_inclusion_rule`][albert.resources.workflows.Workflow.build_inclusion_rule]: Semantic builder for Include Mode rules.
 - [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Resolves parameter name, operator, value, and unit into a [`RuleCondition`][albert.resources.interval_combinations.RuleCondition].
 - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Generates a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] from a parameter-value dictionary.
 
@@ -67,6 +69,7 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     workflow = client.workflows.get_by_id(id="WFL456")
 
     # 2. Build rules and overrides using human-readable parameter names and values
+    # Rule: Exclude all variants with both high heat and high speed
     rule = workflow.build_exclusion_rule(
         name="Exclude high heat with high speed",
         conditions=[
@@ -74,8 +77,9 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
             ("Speed", ">=", 1500),
         ],
     )
+    # Override: Skip a specific room-temperature/extreme-speed condition not caught by the general high-heat rule
     override = workflow.build_override(
-        {"Temperature": 100, "Speed": 2000},
+        {"Temperature": 25, "Speed": 2000},
         action="skip",
     )
 
@@ -108,9 +112,11 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     
     Instead of manually resolving internal IDs, use the helper methods on your [`Workflow`][albert.resources.workflows.Workflow] instance:
     
-    - [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Constructs an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] with human-readable conditions (e.g. `conditions=[("Temperature", ">=", 90)]`).
+    - [`workflow.build_rule`][albert.resources.workflows.Workflow.build_rule]: Constructs an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] with human-readable conditions using tuples (e.g. `conditions=[("Temperature", ">=", 90)]`) or keyword arguments (`parameter="Temperature", operator=">=", value=90`).
+    - [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Semantic builder for Exclude Mode rules.
+    - [`workflow.build_inclusion_rule`][albert.resources.workflows.Workflow.build_inclusion_rule]: Semantic builder for Include Mode rules.
     - [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Constructs an individual [`RuleCondition`][albert.resources.interval_combinations.RuleCondition] with resolved group, parameter, and row IDs.
-    - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] directly from a dictionary of parameter names and values (e.g. `workflow.build_override({"Temperature": 100, "Speed": 2000}, action="skip")`).
+    - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] directly from a dictionary of parameter names and values (e.g. `workflow.build_override({"Temperature": 25, "Speed": 2000}, action="skip")`).
 
 !!! warning "Property Tasks only"
     Child-workflow interval combinations are exclusively supported on [`PropertyTask`][albert.resources.tasks.PropertyTask]. They cannot be created or evaluated on [`BatchTask`][albert.resources.tasks.BatchTask] or [`GeneralTask`][albert.resources.tasks.GeneralTask].
@@ -168,21 +174,22 @@ In this mode:
     workflow = client.workflows.get_by_id(id="WFL456")
 
     # 1. Define inclusion rule using workflow helper (low temperatures only)
-    rule = workflow.build_exclusion_rule(
+    rule = workflow.build_inclusion_rule(
         name="Include low temperature variants",
-        parameter="Temperature",
-        operator="<",
-        value=40,
+        conditions=[
+            ("Temperature", "<", 40),
+        ],
     )
 
-    # 2. Pick specific parameter combinations to include manually via build_override
+    # 2. Cherry-pick specific higher-temperature benchmark combinations
+    # that would otherwise be omitted by the rule (Temperature < 40)
     override_1 = workflow.build_override(
-        {"Temperature": 25, "Speed": 500},
+        {"Temperature": 60, "Speed": 500},
         action="unskip",
         is_manual=True,
     )
     override_2 = workflow.build_override(
-        {"Temperature": 50, "Speed": 1000},
+        {"Temperature": 90, "Speed": 1000},
         action="unskip",
         is_manual=True,
     )
@@ -213,7 +220,7 @@ In this mode:
 
 ## Modify rules and regenerate combinations on an existing task
 
-You can update rules and overrides on an existing task block at any time. Saving new rules updates the block configuration, but **does not automatically recalculate combinations**. You must trigger combination regeneration to materialize the updated combinations.
+You can update rules and overrides on an existing task block at any time using [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules]. By default, the SDK automatically recalculates the Cartesian product and regenerates child-workflow combinations on Albert Invent.
 
 !!! example "Update block rules and regenerate combinations"
     ```python
@@ -236,9 +243,9 @@ You can update rules and overrides on an existing task block at any time. Saving
 
     new_rule = workflow.build_exclusion_rule(
         name="Exclude cold temperatures",
-        parameter="Temperature",
-        operator="<",
-        value=15,
+        conditions=[
+            ("Temperature", "<", 15),
+        ],
     )
 
     # Combinations are regenerated automatically on Albert Invent by default

--- a/docs/examples/tasks.md
+++ b/docs/examples/tasks.md
@@ -2,6 +2,264 @@
 
 Tasks in Albert Invent are a way to manage and track your daily work and collaborate with colleagues. There are three types of tasks: Batch Tasks, Property Tasks, and General Tasks.
 
+## Create an intervalized Property task in Exclude Mode
+
+When testing multiple formulation variants or process conditions, a Property Task can evaluate intervals across workflow parameters (such as temperature, speed, or concentration). Each combination of parameter setpoints materializes as a child workflow variant.
+
+In **Exclude Mode** (`intervals_start_from="all"`, the default), combination generation starts with all possible Cartesian product variants included. You can define exclusion rules to filter out unwanted combinations (such as incompatible parameter settings) and overrides to force-include or force-skip specific variants.
+
+!!! example "Create a Property Task with exclusion rules and overrides"
+    ```python
+    from albert import Albert
+    from albert.resources.interval_combinations import (
+        CombinationOverride,
+        ExclusionRule,
+        OverrideAction,
+        RuleCondition,
+        RuleOperator,
+    )
+    from albert.resources.tasks import Block, PropertyTask
+
+    client = Albert()
+
+    # 1. Fetch an existing workflow containing intervalized parameters
+    workflow = client.workflows.get_by_id(id="WFL456")
+
+    # 2. Build a compound override key for a specific combination to skip
+    skip_key = workflow.get_override_key({"Temperature": 100, "Speed": 2000})
+
+    # 3. Create the task with rules, overrides, and automatic combination generation
+    task = client.tasks.create_with_combinations(
+        task=PropertyTask(
+            name="Adhesive Viscosity Screen",
+            parent_id="PRO123",
+            blocks=[
+                Block(
+                    data_template=[{"id": "DAT100"}],
+                    workflow=[{"id": workflow.id}],
+                    intervals_start_from="all",
+                    rules=[
+                        ExclusionRule(
+                            name="Exclude high heat with high speed",
+                            conditions=[
+                                RuleCondition(
+                                    parameter_group_id="PRG200",
+                                    parameter_id="PRM101",
+                                    operator=RuleOperator.GTE,
+                                    value="90",
+                                    unit_id="UNI1",
+                                ),
+                                RuleCondition(
+                                    parameter_group_id="PRG200",
+                                    parameter_id="PRM102",
+                                    operator=RuleOperator.GTE,
+                                    value="1500",
+                                    unit_id="UNI2",
+                                ),
+                            ],
+                        )
+                    ],
+                    overrides=[
+                        CombinationOverride(
+                            key=skip_key,
+                            action=OverrideAction.SKIP,
+                        ),
+                    ],
+                )
+            ],
+        ),
+        wait=True,
+    )
+
+    # 4. Iterate over the materialized combinations
+    block_id = task.blocks[0].id
+    for combo in client.tasks.get_block_combinations(task_id=task.id, block_id=block_id):
+        print(combo.id, combo.name, combo.interval_barcode)
+    ```
+
+!!! warning "Property Tasks only"
+    Child-workflow interval combinations are exclusively supported on [`PropertyTask`][albert.resources.tasks.PropertyTask]. They cannot be created or evaluated on [`BatchTask`][albert.resources.tasks.BatchTask] or [`GeneralTask`][albert.resources.tasks.GeneralTask].
+
+!!! warning "Platform combinations cap"
+    The platform enforces a maximum safety cap of 2,000 combinations per block. If your parameter intervals expand to more than 2,000 combinations (after applying rules and overrides), creation will fail.
+
+!!! warning "Embedded combinations truncation"
+    When a block contains 500 or more combinations, embedded combination lists on the task block payload are omitted to prevent payload bloat. Always use [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations] to iterate through combinations.
+
+!!! note "Override precedence"
+    Direct overrides always take precedence over rules:
+    
+    - `OverrideAction.SKIP`: Immediately excludes a combination, bypassing rules evaluation.
+    - `OverrideAction.UNSKIP`: Immediately preserves a combination, even if an exclusion rule matches.
+
+!!! note "Handling partial failures and retrying failed blocks"
+    When `wait=True` is used, the task itself is created first on the platform before combination generation begins. If background generation fails on any block, the SDK raises `CombinationGenerationError`.
+    
+    Rather than re-creating the entire task (which would result in a duplicate task), inspect `err.task` and `err.failed_blocks`, and retry generation for only the failed blocks:
+    
+    ```python
+    from albert.exceptions import CombinationGenerationError
+
+    try:
+        task = client.tasks.create_with_combinations(task=property_task, wait=True)
+    except CombinationGenerationError as err:
+        print(f"Task {err.task.id} was created, but combination jobs failed on: {err.failed_blocks}")
+        for block_id in err.failed_blocks:
+            client.tasks.generate_block_combinations(
+                task_id=err.task.id,
+                block_id=block_id,
+                wait=True,
+            )
+    ```
+
+!!! note "Asynchronous background generation"
+    For large tasks with many blocks, you can pass `wait=False` to launch generation without blocking. Each block will contain `job_id` and `job_state` (such as `"submitted"` or `"in_progress"`), allowing your script to proceed or track job completion independently.
+
+## Create an intervalized Property task in Include Mode
+
+In **Include Mode** (`intervals_start_from="none"`), combination generation starts with *zero* active combinations. This mode is ideal for sparse designs of experiment (DoE) or targeted screening where you only want specific combinations evaluated.
+
+In this mode:
+- Rules act as **inclusion rules**: only combinations satisfying rule conditions are kept.
+- Overrides with `action=OverrideAction.UNSKIP` and `is_manual=True` allow you to cherry-pick individual combinations into the task.
+
+!!! example "Create a Property Task in Include Mode with manual overrides"
+    ```python
+    from albert import Albert
+    from albert.resources.interval_combinations import (
+        CombinationOverride,
+        ExclusionRule,
+        OverrideAction,
+        RuleCondition,
+        RuleOperator,
+    )
+    from albert.resources.tasks import Block, PropertyTask
+
+    client = Albert()
+
+    workflow = client.workflows.get_by_id(id="WFL456")
+
+    # Pick specific parameter combinations to include manually
+    include_key_1 = workflow.get_override_key({"Temperature": 25, "Speed": 500})
+    include_key_2 = workflow.get_override_key({"Temperature": 50, "Speed": 1000})
+
+    task = client.tasks.create_with_combinations(
+        task=PropertyTask(
+            name="Targeted Low-Temperature Screen",
+            parent_id="PRO123",
+            blocks=[
+                Block(
+                    data_template=[{"id": "DAT100"}],
+                    workflow=[{"id": workflow.id}],
+                    intervals_start_from="none",
+                    # Only include combinations where temperature is under 40 °C
+                    rules=[
+                        ExclusionRule(
+                            name="Include low temperature variants",
+                            conditions=[
+                                RuleCondition(
+                                    parameter_group_id="PRG200",
+                                    parameter_id="PRM101",
+                                    operator=RuleOperator.LT,
+                                    value="40",
+                                    unit_id="UNI1",
+                                ),
+                            ],
+                        )
+                    ],
+                    # Manually add specific combinations outside or within the rule
+                    overrides=[
+                        CombinationOverride(
+                            key=include_key_1,
+                            action=OverrideAction.UNSKIP,
+                            is_manual=True,
+                        ),
+                        CombinationOverride(
+                            key=include_key_2,
+                            action=OverrideAction.UNSKIP,
+                            is_manual=True,
+                        ),
+                    ],
+                )
+            ],
+        ),
+        wait=True,
+    )
+
+    combos = list(client.tasks.get_block_combinations(task_id=task.id, block_id=task.blocks[0].id))
+    print(f"Materialized {len(combos)} combinations.")
+    ```
+
+!!! note "The `is_manual` flag"
+    Setting `is_manual=True` on a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] is only valid when `intervals_start_from="none"`. It designates an override as an explicit manual addition to an otherwise empty set of combinations.
+
+## Modify rules and regenerate combinations on an existing task
+
+You can update rules and overrides on an existing task block at any time. Saving new rules updates the block configuration, but **does not automatically recalculate combinations**. You must trigger combination regeneration to materialize the updated combinations.
+
+!!! example "Update block rules and regenerate combinations"
+    ```python
+    from albert import Albert
+    from albert.resources.interval_combinations import (
+        CombinationOverride,
+        ExclusionRule,
+        OverrideAction,
+        RuleCondition,
+        RuleOperator,
+    )
+
+    client = Albert()
+    task_id = "TASFOR1"
+    block_id = "BLK1"
+
+    # 1. Inspect existing rules and overrides on the block
+    current_rules = client.tasks.get_block_rules(task_id=task_id, block_id=block_id)
+    print("Existing rules count:", len(current_rules.rules))
+    print("Existing overrides count:", len(current_rules.overrides))
+
+    # 2. Update the block with new rules (and clear previous overrides)
+    # Combinations are regenerated automatically on Albert Invent by default
+    updated_rules = client.tasks.set_block_rules(
+        task_id=task_id,
+        block_id=block_id,
+        rules=[
+            ExclusionRule(
+                name="Exclude cold temperatures",
+                conditions=[
+                    RuleCondition(
+                        parameter_group_id="PRG200",
+                        parameter_id="PRM101",
+                        operator=RuleOperator.LT,
+                        value="15",
+                        unit_id="UNI1",
+                    )
+                ],
+            )
+        ],
+        overrides=[],  # Passing an empty list clears existing overrides
+    )
+    print("Regeneration status:", updated_rules.job.state)
+
+    # 3. Read the updated combination variants
+    updated_combos = list(client.tasks.get_block_combinations(task_id=task_id, block_id=block_id))
+    print(f"Active combinations after rules update: {len(updated_combos)}")
+    ```
+
+!!! note "Automatic combination regeneration"
+    [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] automatically re-evaluates the Cartesian product and regenerates child-workflow combinations on the platform (`generate_combinations=True` by default). It automatically detects the block's current workflow and passes it as `old_workflow_id` so obsolete combinations are cleanly voided and unchanged barcodes are preserved.
+    
+    If you only wish to save rule definitions without immediately triggering background generation jobs, pass `generate_combinations=False`.
+
+!!! note "Unset vs. empty convention"
+    [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] distinguishes between omitting a field and passing an empty list:
+    
+    - Omitting `rules` (or passing `rules=None`) leaves the block's existing rules untouched.
+    - Passing `rules=[]` clears all existing rules on the block.
+    - The same convention applies to `overrides`.
+
+!!! note "Workflow replacement (swapping workflows)"
+    If you swap a block's workflow using [`update_block_workflow`][albert.collections.tasks.TaskCollection.update_block_workflow], pass the **replaced** workflow ID as `old_workflow_id` when calling [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations] so the platform archives the old child workflows and provisions the new ones cleanly.
+
 ## Import results
 
 This feature enables users to import a .csv file straight into the Data Template of a Property Task allowing them to easily mass enter results without having to type them in manually or copy-paste.

--- a/docs/examples/tasks.md
+++ b/docs/examples/tasks.md
@@ -11,13 +11,6 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
 !!! example "Create a Property Task with exclusion rules and overrides"
     ```python
     from albert import Albert
-    from albert.resources.interval_combinations import (
-        CombinationOverride,
-        ExclusionRule,
-        OverrideAction,
-        RuleCondition,
-        RuleOperator,
-    )
     from albert.resources.tasks import Block, PropertyTask
 
     client = Albert()
@@ -25,8 +18,18 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     # 1. Fetch an existing workflow containing intervalized parameters
     workflow = client.workflows.get_by_id(id="WFL456")
 
-    # 2. Build a compound override key for a specific combination to skip
-    skip_key = workflow.get_override_key({"Temperature": 100, "Speed": 2000})
+    # 2. Build rules and overrides using human-readable parameter names and values
+    rule = workflow.build_exclusion_rule(
+        name="Exclude high heat with high speed",
+        conditions=[
+            ("Temperature", ">=", 90),
+            ("Speed", ">=", 1500),
+        ],
+    )
+    override = workflow.build_override(
+        {"Temperature": 100, "Speed": 2000},
+        action="skip",
+    )
 
     # 3. Create the task with rules, overrides, and automatic combination generation
     task = client.tasks.create_with_combinations(
@@ -38,33 +41,8 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
                     data_template=[{"id": "DAT100"}],
                     workflow=[{"id": workflow.id}],
                     intervals_start_from="all",
-                    rules=[
-                        ExclusionRule(
-                            name="Exclude high heat with high speed",
-                            conditions=[
-                                RuleCondition(
-                                    parameter_group_id="PRG200",
-                                    parameter_id="PRM101",
-                                    operator=RuleOperator.GTE,
-                                    value="90",
-                                    unit_id="UNI1",
-                                ),
-                                RuleCondition(
-                                    parameter_group_id="PRG200",
-                                    parameter_id="PRM102",
-                                    operator=RuleOperator.GTE,
-                                    value="1500",
-                                    unit_id="UNI2",
-                                ),
-                            ],
-                        )
-                    ],
-                    overrides=[
-                        CombinationOverride(
-                            key=skip_key,
-                            action=OverrideAction.SKIP,
-                        ),
-                    ],
+                    rules=[rule],
+                    overrides=[override],
                 )
             ],
         ),
@@ -76,6 +54,15 @@ In **Exclude Mode** (`intervals_start_from="all"`, the default), combination gen
     for combo in client.tasks.get_block_combinations(task_id=task.id, block_id=block_id):
         print(combo.id, combo.name, combo.interval_barcode)
     ```
+
+!!! tip "Value-based helpers for rules and overrides"
+    Rule conditions and combination overrides require workflow-local internal IDs (`parameter_group_id`, `parameter_id`, and `row_id`) that change when workflows are saved or updated.
+    
+    Instead of manually resolving internal IDs, use the helper methods on your [`Workflow`][albert.resources.workflows.Workflow] instance:
+    
+    - [`workflow.build_exclusion_rule`][albert.resources.workflows.Workflow.build_exclusion_rule]: Constructs an [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule] with human-readable conditions (e.g. `conditions=[("Temperature", ">=", 90)]`).
+    - [`workflow.build_rule_condition`][albert.resources.workflows.Workflow.build_rule_condition]: Constructs an individual [`RuleCondition`][albert.resources.interval_combinations.RuleCondition] with resolved group, parameter, and row IDs.
+    - [`workflow.build_override`][albert.resources.workflows.Workflow.build_override]: Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride] directly from a dictionary of parameter names and values (e.g. `workflow.build_override({"Temperature": 100, "Speed": 2000}, action="skip")`).
 
 !!! warning "Property Tasks only"
     Child-workflow interval combinations are exclusively supported on [`PropertyTask`][albert.resources.tasks.PropertyTask]. They cannot be created or evaluated on [`BatchTask`][albert.resources.tasks.BatchTask] or [`GeneralTask`][albert.resources.tasks.GeneralTask].
@@ -126,22 +113,31 @@ In this mode:
 !!! example "Create a Property Task in Include Mode with manual overrides"
     ```python
     from albert import Albert
-    from albert.resources.interval_combinations import (
-        CombinationOverride,
-        ExclusionRule,
-        OverrideAction,
-        RuleCondition,
-        RuleOperator,
-    )
     from albert.resources.tasks import Block, PropertyTask
 
     client = Albert()
 
     workflow = client.workflows.get_by_id(id="WFL456")
 
-    # Pick specific parameter combinations to include manually
-    include_key_1 = workflow.get_override_key({"Temperature": 25, "Speed": 500})
-    include_key_2 = workflow.get_override_key({"Temperature": 50, "Speed": 1000})
+    # 1. Define inclusion rule using workflow helper (low temperatures only)
+    rule = workflow.build_exclusion_rule(
+        name="Include low temperature variants",
+        parameter="Temperature",
+        operator="<",
+        value=40,
+    )
+
+    # 2. Pick specific parameter combinations to include manually via build_override
+    override_1 = workflow.build_override(
+        {"Temperature": 25, "Speed": 500},
+        action="unskip",
+        is_manual=True,
+    )
+    override_2 = workflow.build_override(
+        {"Temperature": 50, "Speed": 1000},
+        action="unskip",
+        is_manual=True,
+    )
 
     task = client.tasks.create_with_combinations(
         task=PropertyTask(
@@ -152,34 +148,8 @@ In this mode:
                     data_template=[{"id": "DAT100"}],
                     workflow=[{"id": workflow.id}],
                     intervals_start_from="none",
-                    # Only include combinations where temperature is under 40 °C
-                    rules=[
-                        ExclusionRule(
-                            name="Include low temperature variants",
-                            conditions=[
-                                RuleCondition(
-                                    parameter_group_id="PRG200",
-                                    parameter_id="PRM101",
-                                    operator=RuleOperator.LT,
-                                    value="40",
-                                    unit_id="UNI1",
-                                ),
-                            ],
-                        )
-                    ],
-                    # Manually add specific combinations outside or within the rule
-                    overrides=[
-                        CombinationOverride(
-                            key=include_key_1,
-                            action=OverrideAction.UNSKIP,
-                            is_manual=True,
-                        ),
-                        CombinationOverride(
-                            key=include_key_2,
-                            action=OverrideAction.UNSKIP,
-                            is_manual=True,
-                        ),
-                    ],
+                    rules=[rule],
+                    overrides=[override_1, override_2],
                 )
             ],
         ),
@@ -200,13 +170,6 @@ You can update rules and overrides on an existing task block at any time. Saving
 !!! example "Update block rules and regenerate combinations"
     ```python
     from albert import Albert
-    from albert.resources.interval_combinations import (
-        CombinationOverride,
-        ExclusionRule,
-        OverrideAction,
-        RuleCondition,
-        RuleOperator,
-    )
 
     client = Albert()
     task_id = "TASFOR1"
@@ -218,24 +181,23 @@ You can update rules and overrides on an existing task block at any time. Saving
     print("Existing overrides count:", len(current_rules.overrides))
 
     # 2. Update the block with new rules (and clear previous overrides)
+    # Fetch the block's current workflow to build rules using parameter names
+    task = client.tasks.get_by_id(id=task_id)
+    block = next(b for b in task.blocks if b.id == block_id)
+    workflow = client.workflows.get_by_id(id=block.workflow[0].id)
+
+    new_rule = workflow.build_exclusion_rule(
+        name="Exclude cold temperatures",
+        parameter="Temperature",
+        operator="<",
+        value=15,
+    )
+
     # Combinations are regenerated automatically on Albert Invent by default
     updated_rules = client.tasks.set_block_rules(
         task_id=task_id,
         block_id=block_id,
-        rules=[
-            ExclusionRule(
-                name="Exclude cold temperatures",
-                conditions=[
-                    RuleCondition(
-                        parameter_group_id="PRG200",
-                        parameter_id="PRM101",
-                        operator=RuleOperator.LT,
-                        value="15",
-                        unit_id="UNI1",
-                    )
-                ],
-            )
-        ],
+        rules=[new_rule],
         overrides=[],  # Passing an empty list clears existing overrides
     )
     print("Regeneration status:", updated_rules.job.state)

--- a/docs/resources/interval_combinations.md
+++ b/docs/resources/interval_combinations.md
@@ -1,0 +1,1 @@
+::: albert.resources.interval_combinations

--- a/docs/resources/smart_projects.md
+++ b/docs/resources/smart_projects.md
@@ -1,0 +1,1 @@
+::: albert.resources.smart_projects

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -243,6 +243,7 @@ nav:
           - Roles: resources/roles.md
           - SDS (🧪 Beta): resources/sds.md
           - Smart Datasets (🧪Beta): resources/smart_datasets.md
+          - Smart Projects (🧪Beta): resources/smart_projects.md
           - Storage Classes: resources/storage_classes.md
           - Storage Locations: resources/storage_locations.md
           - Substances: resources/substances.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,6 +223,7 @@ nav:
           - Hazards: resources/hazards.md
           - Identifiers: resources/identifiers.md
           - Inventory: resources/inventory.md
+          - Interval Combinations: resources/interval_combinations.md
           - Label Templates: resources/label_templates.md
           - Links: resources/links.md
           - Lists: resources/lists.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -223,7 +223,7 @@ nav:
           - Hazards: resources/hazards.md
           - Identifiers: resources/identifiers.md
           - Inventory: resources/inventory.md
-          - Interval Combinations: resources/interval_combinations.md
+          - Interval Combinations (🧪 Beta): resources/interval_combinations.md
           - Label Templates: resources/label_templates.md
           - Links: resources/links.md
           - Lists: resources/lists.md

--- a/src/albert/collections/design_runs.py
+++ b/src/albert/collections/design_runs.py
@@ -193,7 +193,7 @@ class DesignRunCollection(BaseCollection):
         populated ``violations`` is a normal result and is not raised as an exception.
 
         Pre-check failures (e.g. dataset not ``READY``, objective out of scope, invalid
-        settings) are raised as [`AlbertClientError`][albert.exceptions.AlbertClientError],
+        settings) are raised as `AlbertClientError`,
         the same class of failure as calling
         [`create_optimization`][albert.collections.design_runs.DesignRunCollection.create_optimization]
         with a bad configuration.
@@ -219,7 +219,7 @@ class DesignRunCollection(BaseCollection):
         AlbertClientError
             Pre-check failures (invalid configuration before validation can run).
         AlbertHTTPError
-            Other request failures. See [`AlbertHTTPError`][albert.exceptions.AlbertHTTPError].
+            Other request failures.
         """
         body = OptimizationDesignRunRequest(
             smart_dataset_id=smart_dataset_id,
@@ -246,7 +246,7 @@ class DesignRunCollection(BaseCollection):
         populated ``violations`` is a normal result and is not raised as an exception.
 
         Pre-check failures (e.g. dataset not ``READY``, invalid settings) are raised as
-        [`AlbertClientError`][albert.exceptions.AlbertClientError], the same class of
+        `AlbertClientError`, the same class of
         failure as calling
         [`create_doe`][albert.collections.design_runs.DesignRunCollection.create_doe]
         with a bad configuration.
@@ -272,7 +272,7 @@ class DesignRunCollection(BaseCollection):
         AlbertClientError
             Pre-check failures (invalid configuration before validation can run).
         AlbertHTTPError
-            Other request failures. See [`AlbertHTTPError`][albert.exceptions.AlbertHTTPError].
+            Other request failures.
         """
         body = DOEDesignRunRequest(
             smart_dataset_id=smart_dataset_id,

--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -121,7 +121,7 @@ class PropertyDataCollection(BaseCollection):
         Get results across all block/inventory combinations of a task.
     check_for_task_data(task_id) -> list[CheckPropertyData]
         Report which block/interval combinations of a task have data.
-    check_block_interval_for_data(block_id, task_id, interval_id) -> CheckPropertyData
+    check_block_interval_for_data(block_id, task_id, interval_id) -> list[CheckPropertyData]
         Report whether one block interval has data.
     add_properties_to_task(...) -> list[TaskPropertyData]
         Add new result values to a task block.
@@ -413,18 +413,19 @@ class PropertyDataCollection(BaseCollection):
     @validate_call
     def check_block_interval_for_data(
         self, *, block_id: BlockId, task_id: TaskId, interval_id: IntervalId
-    ) -> CheckPropertyData:
+    ) -> list[CheckPropertyData]:
         """Report whether one specific block interval has data.
 
         A single-interval version of [`check_for_task_data`][albert.collections.property_data.PropertyDataCollection.check_for_task_data].
+        Returns one entry per inventory/lot combination on that interval.
 
         !!! example
             ```python
-            status = client.property_data.check_block_interval_for_data(
+            statuses = client.property_data.check_block_interval_for_data(
                 block_id="BLK1", task_id="TASFOR1", interval_id="ROW1"
             )
-            status.data_exists
-            # True
+            [s.data_exists for s in statuses]
+            # [True]
             ```
 
         Parameters
@@ -435,12 +436,12 @@ class PropertyDataCollection(BaseCollection):
             The task the block belongs to (format ``TAS...``).
         interval_id : IntervalId
             The interval combination to check (e.g. ``"ROW1"``, ``"ROW1XROW2"``,
-            or ``"default"``). See [`check_for_task_data`][albert.collections.property_data.PropertyDataCollection.check_for_task_data] to list interval IDs.
+            a child workflow id, a barcode, or ``"default"``). See [`check_for_task_data`][albert.collections.property_data.PropertyDataCollection.check_for_task_data] to list interval IDs.
 
         Returns
         -------
-        CheckPropertyData
-            The data status of the given block interval.
+        list[CheckPropertyData]
+            The data status of each inventory/lot combination on the given block interval.
         """
         params = {
             "entity": "block",
@@ -451,7 +452,7 @@ class PropertyDataCollection(BaseCollection):
         }
 
         response = self.session.get(url=self.base_path, params=params)
-        return CheckPropertyData(response.json())
+        return [CheckPropertyData(**x) for x in response.json()]
 
     @validate_call
     def get_all_task_properties(

--- a/src/albert/collections/property_data.py
+++ b/src/albert/collections/property_data.py
@@ -121,7 +121,7 @@ class PropertyDataCollection(BaseCollection):
         Get results across all block/inventory combinations of a task.
     check_for_task_data(task_id) -> list[CheckPropertyData]
         Report which block/interval combinations of a task have data.
-    check_block_interval_for_data(block_id, task_id, interval_id) -> list[CheckPropertyData]
+    check_block_interval_for_data(block_id, task_id, interval_id) -> CheckPropertyData
         Report whether one block interval has data.
     add_properties_to_task(...) -> list[TaskPropertyData]
         Add new result values to a task block.
@@ -413,19 +413,18 @@ class PropertyDataCollection(BaseCollection):
     @validate_call
     def check_block_interval_for_data(
         self, *, block_id: BlockId, task_id: TaskId, interval_id: IntervalId
-    ) -> list[CheckPropertyData]:
+    ) -> CheckPropertyData:
         """Report whether one specific block interval has data.
 
         A single-interval version of [`check_for_task_data`][albert.collections.property_data.PropertyDataCollection.check_for_task_data].
-        Returns one entry per inventory/lot combination on that interval.
 
         !!! example
             ```python
-            statuses = client.property_data.check_block_interval_for_data(
+            status = client.property_data.check_block_interval_for_data(
                 block_id="BLK1", task_id="TASFOR1", interval_id="ROW1"
             )
-            [s.data_exists for s in statuses]
-            # [True]
+            status.data_exists
+            # True
             ```
 
         Parameters
@@ -440,8 +439,8 @@ class PropertyDataCollection(BaseCollection):
 
         Returns
         -------
-        list[CheckPropertyData]
-            The data status of each inventory/lot combination on the given block interval.
+        CheckPropertyData
+            The data status of the given block interval.
         """
         params = {
             "entity": "block",
@@ -452,7 +451,7 @@ class PropertyDataCollection(BaseCollection):
         }
 
         response = self.session.get(url=self.base_path, params=params)
-        return [CheckPropertyData(**x) for x in response.json()]
+        return CheckPropertyData(**response.json()[0])
 
     @validate_call
     def get_all_task_properties(

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import time
+import uuid
 from collections.abc import Iterator
 from contextlib import suppress
 from enum import Enum
 from pathlib import Path
 from typing import Any
 
+import requests
 from pydantic import validate_call
 from requests.exceptions import RetryError
 
@@ -13,6 +16,7 @@ from albert.collections.attachments import AttachmentCollection
 from albert.collections.base import BaseCollection
 from albert.collections.data_templates import DataTemplateCollection
 from albert.collections.property_data import PropertyDataCollection
+from albert.collections.workflows import WorkflowCollection
 from albert.core.logging import logger
 from albert.core.pagination import AlbertPaginator, MappedPaginator
 from albert.core.session import AlbertSession
@@ -29,7 +33,7 @@ from albert.core.shared.identifiers import (
     remove_id_prefix,
 )
 from albert.core.utils import ensure_list
-from albert.exceptions import AlbertHTTPError, NotFoundError
+from albert.exceptions import AlbertHTTPError, CombinationGenerationError, NotFoundError
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
 from albert.resources.interval_combinations import (
@@ -41,6 +45,7 @@ from albert.resources.interval_combinations import (
 from albert.resources.tasks import (
     BaseTask,
     BatchTask,
+    Block,
     CsvTableInput,
     CsvTableResponseItem,
     GeneralTask,
@@ -52,6 +57,14 @@ from albert.resources.tasks import (
     TaskPatchPayload,
     TaskSearchItem,
 )
+from albert.resources.worker_jobs import (
+    WorkerJob,
+    WorkerJobCreateRequest,
+    WorkerJobMetadata,
+    WorkerJobState,
+)
+from albert.resources.workflows import Workflow
+from albert.utils.interval_combinations import generate_interval_combinations
 from albert.utils.tasks import (
     CSV_EXTENSIONS,
     build_property_payload,
@@ -63,6 +76,7 @@ from albert.utils.tasks import (
     map_csv_headers_to_columns,
     resolve_attachment,
 )
+from albert.utils.worker_jobs import poll_worker_job
 
 
 class _BlockCombinationsPaginator(AlbertPaginator):
@@ -127,6 +141,8 @@ class TaskCollection(BaseCollection):
     -------
     create(task) -> BaseTask
         Create a PropertyTask, BatchTask, or GeneralTask.
+    create_with_combinations(task, wait=True) -> PropertyTask
+        Create a Property task and orchestrate combination generation across all its blocks.
     get_by_id(id) -> BaseTask
         Get a single fully populated task by its ID.
     search(...) -> Iterator[TaskSearchItem]
@@ -147,8 +163,10 @@ class TaskCollection(BaseCollection):
         Get the child-workflow combinations of a block.
     get_block_rules(task_id, block_id) -> BlockRules
         Get combination rules and overrides for a block.
-    set_block_rules(task_id, block_id, rules=None, overrides=None) -> BlockRules
-        Set combination rules and overrides for a block.
+    set_block_rules(task_id, block_id, rules=None, overrides=None, generate_combinations=True, wait=True) -> BlockRules
+        Set combination rules and overrides for a block, automatically regenerating combinations.
+    generate_block_combinations(task_id, block_id, old_workflow_id=None, wait=True) -> WorkerJob
+        Generate child-workflow interval combinations for a task block.
     import_results(...) -> BaseTask
         Import measured results into a Property task from a file or attachment.
     get_history(id, ...) -> TaskHistory
@@ -214,6 +232,201 @@ class TaskCollection(BaseCollection):
         response = self.session.post(url=url, json=payload)
         task_data = response.json()[0]
         return TaskAdapter.validate_python(task_data)
+
+    @validate_call
+    def create_with_combinations(
+        self,
+        *,
+        task: PropertyTask,
+        wait: bool = True,
+    ) -> PropertyTask:
+        """Create a Property task and generate interval combinations across all its blocks.
+
+        Provides an all-in-one method to create a Property task and materialize
+        combination variants for every block:
+        1. Automatically saves any unsaved [`Workflow`][albert.resources.workflows.Workflow]
+           objects defined on the task blocks, preserving block ordering.
+        2. Sets ``intervals_start_from="all"`` (exclude mode) on any blocks where the
+           mode is not explicitly configured.
+        3. Creates the task and saves any configured block rules ([`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule])
+           or overrides ([`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]).
+        4. Sequentially triggers combination generation for each block, pacing requests
+           to ensure steady platform processing.
+        5. If ``wait=True`` (the default), waits for combination generation to complete across
+           all blocks and returns the refreshed task with combination details populated.
+           If ``wait=False``, returns immediately after launching generation, leaving
+           job tracking identifiers on each block.
+
+        To view the generated combinations after creation, use
+        [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations].
+        To update rules or regenerate combinations on an existing task later, use
+        [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] and
+        [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations].
+
+        !!! example
+            ```python
+            from albert import Albert
+            from albert.resources.tasks import Block, PropertyTask
+
+            client = Albert()
+            task = client.tasks.create_with_combinations(
+                task=PropertyTask(
+                    name="Viscosity screen",
+                    parent_id="PROA123",
+                    blocks=[
+                        Block(
+                            data_template=[{"id": "DAT123"}],
+                            workflow=[{"id": "WFL456"}],
+                        ),
+                    ],
+                ),
+                wait=True,
+            )
+            task.id
+            # 'TASFOR1'
+            ```
+
+        Parameters
+        ----------
+        task : PropertyTask
+            The Property task definition to create, containing one or more
+            [`Block`][albert.resources.tasks.Block] instances. Each block must have a
+            data template and a workflow (either an existing workflow ID or a new
+            [`Workflow`][albert.resources.workflows.Workflow] object), plus optional rules
+            and overrides.
+        wait : bool, default True
+            Whether to wait for combination generation to complete across all blocks.
+            If False, returns immediately after submitting generation jobs.
+
+        Returns
+        -------
+        PropertyTask
+            The created Property task. If ``wait=True``, returns the re-fetched task with
+            combinations populated. If ``wait=False``, returns the task with job identifiers
+            assigned on each block.
+
+        Raises
+        ------
+        TypeError
+            If ``task`` is not a ``PropertyTask``.
+        CombinationGenerationError
+            If ``wait=True`` and combination generation fails on one or more blocks.
+            The exception carries the created task (``err.task``) and failed block IDs
+            (``err.failed_blocks``) so callers can inspect or retry specific blocks using
+            [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations].
+        """
+        if not isinstance(task, PropertyTask):
+            raise TypeError("task must be a PropertyTask")
+
+        workflow_collection = WorkflowCollection(session=self.session)
+
+        # 1. Ensure all workflows have an ID (create unsaved workflows if needed)
+        if task.blocks:
+            for i, block in enumerate(task.blocks):
+                if not block.workflow:
+                    continue
+                for w in block.workflow:
+                    if isinstance(w, Workflow) and not w.id:
+                        w.block_mapping = str(i)
+                        created_wfls = workflow_collection.create(workflows=[w])
+                        w.id = created_wfls[0].id
+                    elif isinstance(w, dict) and not w.get("id"):
+                        w["blockMapping"] = str(i)
+                        created_wfls = workflow_collection.create(workflows=[Workflow(**w)])
+                        w["id"] = created_wfls[0].id
+
+            # 2. Fill intervals_start_from on any block where it is unset
+            for block in task.blocks:
+                if block.intervals_start_from is None:
+                    block.intervals_start_from = "all"
+
+        # 3. Create the task via standard create
+        created_task = self.create(task=task)
+        if not isinstance(created_task, PropertyTask):
+            raise TypeError(f"Created task {created_task.id} is not a PropertyTask")
+
+        if not created_task.blocks:
+            return created_task
+
+        # 4. Persist rules and overrides if specified on any block
+        rules_payload = []
+        for orig_b, created_b in zip(task.blocks, created_task.blocks, strict=False):
+            if orig_b.rules or orig_b.overrides:
+                rules_payload.append(
+                    {
+                        "blockId": created_b.id,
+                        "rules": [
+                            r.model_dump(by_alias=True, mode="json", exclude_none=True)
+                            for r in (orig_b.rules or [])
+                        ],
+                        "overrides": [
+                            o.model_dump(by_alias=True, mode="json", exclude_none=True)
+                            for o in (orig_b.overrides or [])
+                        ],
+                    }
+                )
+        if rules_payload:
+            self.session.put(f"{self.base_path}/{created_task.id}/rules", json=rules_payload)
+
+        # 5. Sequentially trigger generate_block_combinations for each block with 10s gap
+        min_job_gap_seconds = 10.0
+        jobs: dict[str, WorkerJob] = {}
+        last_job_time = 0.0
+
+        for i, created_b in enumerate(created_task.blocks):
+            if i > 0 and last_job_time > 0:
+                elapsed = time.time() - last_job_time
+                remaining = min_job_gap_seconds - elapsed
+                if remaining > 0:
+                    time.sleep(remaining)
+
+            job = self.generate_block_combinations(
+                task_id=created_task.id,
+                block_id=created_b.id,
+                old_workflow_id=None,
+                wait=False,
+            )
+            last_job_time = time.time()
+            jobs[created_b.id] = job
+
+        # 6. Handle wait semantics
+        if wait:
+            failed_blocks: list[str] = []
+            job_states: dict[str, str] = {}
+            for blk_id, job in jobs.items():
+                try:
+                    completed_job = poll_worker_job(
+                        session=self.session,
+                        job_id=job.albert_id,
+                        raise_on_failure=False,
+                        job_description=f"Create child workflows for task {created_task.id} block {blk_id}",
+                    )
+                    job_states[blk_id] = completed_job.state.value
+                    if completed_job.state != WorkerJobState.SUCCESSFUL:
+                        failed_blocks.append(blk_id)
+                except Exception:
+                    failed_blocks.append(blk_id)
+                    job_states[blk_id] = "failed"
+
+            if failed_blocks:
+                refetched = self.get_by_id(id=created_task.id)
+                raise CombinationGenerationError(
+                    f"Combination generation failed for blocks: {', '.join(failed_blocks)}",
+                    task=refetched,
+                    failed_blocks=failed_blocks,
+                    job_states=job_states,
+                )
+
+            refetched = self.get_by_id(id=created_task.id)
+            if not isinstance(refetched, PropertyTask):
+                raise TypeError(f"Refetched task {refetched.id} is not a PropertyTask")
+            return refetched
+
+        for blk in created_task.blocks:
+            if blk.id in jobs:
+                blk.job_id = jobs[blk.id].albert_id
+                blk.job_state = jobs[blk.id].state.value
+        return created_task
 
     @validate_call
     def add_block(
@@ -358,10 +571,15 @@ class TaskCollection(BaseCollection):
     def get_block_combinations(
         self, *, task_id: TaskId, block_id: BlockId, max_items: int | None = None
     ) -> Iterator[IntervalCombinationItem]:
-        """Get the child-workflow combinations of a task block.
+        """Get the child-workflow interval combinations of a task block.
 
-        Use this instead of any combinations array embedded on the task or block.
-        That embedded array is empty once the block has 500 or more combinations.
+        Retrieves the combinations generated for a task block by
+        [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]
+        or [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations].
+
+        Always use this method rather than reading combinations directly from the task
+        or block record: for blocks with 500 or more combinations, embedded combination
+        lists on the block are truncated or omitted.
 
         Results are returned as a lazily paginated iterator. Do not infer the end
         of results from page size: a page can under-return while more combinations
@@ -369,6 +587,9 @@ class TaskCollection(BaseCollection):
 
         !!! example
             ```python
+            from albert import Albert
+
+            client = Albert()
             combos = client.tasks.get_block_combinations(
                 task_id="TASFOR1", block_id="BLK1"
             )
@@ -379,9 +600,13 @@ class TaskCollection(BaseCollection):
         Parameters
         ----------
         task_id : TaskId
-            The task containing the block (format ``TAS...``).
+            The Property task ID containing the block (format ``TAS...``), obtained
+            from [`create`][albert.collections.tasks.TaskCollection.create],
+            [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations],
+            or [`get_by_id`][albert.collections.tasks.TaskCollection.get_by_id].
         block_id : BlockId
-            The block whose combinations to list (format ``BLK...``).
+            The block ID whose combinations to list (format ``BLK...``), obtained
+            from ``task.blocks[i].id`` on a fetched task.
         max_items : int, optional
             Maximum number of combinations to return. If None, iterates over all
             combinations.
@@ -410,12 +635,21 @@ class TaskCollection(BaseCollection):
     ) -> BlockRules:
         """Get combination rules and overrides for a task block.
 
-        Returns all rules and overrides configured on the specified block.
-        Saving a rule does not by itself change any combinations until
-        `generate_block_combinations` runs.
+        Returns the rules ([`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule])
+        and overrides ([`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride])
+        currently configured on the specified block.
+
+        Use this method to inspect existing rules before updating them with
+        [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules].
+        Note that modifying rules on a block does not change its generated combinations
+        until [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations]
+        is run.
 
         !!! example
             ```python
+            from albert import Albert
+
+            client = Albert()
             rules_data = client.tasks.get_block_rules(
                 task_id="TASFOR1", block_id="BLK1"
             )
@@ -428,14 +662,18 @@ class TaskCollection(BaseCollection):
         Parameters
         ----------
         task_id : TaskId
-            The task containing the block (format ``TAS...``).
+            The Property task ID containing the block (format ``TAS...``), obtained
+            from [`create`][albert.collections.tasks.TaskCollection.create],
+            [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations],
+            or [`get_by_id`][albert.collections.tasks.TaskCollection.get_by_id].
         block_id : BlockId
-            The block whose rules to retrieve (format ``BLK...``).
+            The block ID whose rules to retrieve (format ``BLK...``), obtained
+            from ``task.blocks[i].id`` on a fetched task.
 
         Returns
         -------
         BlockRules
-            The rules and overrides for the block.
+            The rules and overrides configured on the block.
         """
         url = f"{self.base_path}/{task_id}/blocks/{block_id}/rules"
         response = self.session.get(url)
@@ -457,6 +695,30 @@ class TaskCollection(BaseCollection):
             overrides=data.get("overrides", []),
         )
 
+    @staticmethod
+    def _get_block_current_workflow_id(block: Block) -> str | None:
+        """Resolve the active/final workflow ID for a block."""
+        new_workflow_id: str | None = None
+        unset_category_ids: list[str] = []
+        for w in block.workflow or []:
+            if getattr(w, "name", None) == "No Parameter Group" and len(block.workflow) > 1:
+                continue
+            category = getattr(w, "category", None)
+            if category == "FINAL":
+                return w.id
+            if category == "INITIAL":
+                continue
+            if category is None:
+                unset_category_ids.append(w.id)
+            else:
+                new_workflow_id = w.id
+        if new_workflow_id is None and unset_category_ids:
+            # Before the worker assigns categories, FINAL is conventionally first on the block.
+            return unset_category_ids[0]
+        if new_workflow_id is None and block.workflow:
+            return block.workflow[0].id
+        return new_workflow_id
+
     @validate_call
     def set_block_rules(
         self,
@@ -465,20 +727,35 @@ class TaskCollection(BaseCollection):
         block_id: BlockId,
         rules: list[ExclusionRule] | None = None,
         overrides: list[CombinationOverride] | None = None,
+        generate_combinations: bool = True,
+        old_workflow_id: WorkflowId | None = None,
+        wait: bool = True,
     ) -> BlockRules:
         """Set combination rules and overrides for a task block.
 
-        Replaces the rules and/or overrides for the specified block.
-        Saving rules does not by itself change any combinations until
-        `generate_block_combinations` runs.
+        Configures or replaces exclusion rules and overrides on the specified block, and
+        by default immediately recomputes and regenerates child-workflow combinations on
+        Albert Invent.
 
-        Follows the unset-is-not-empty convention: omitting ``rules`` (or leaving
-        it as ``None``) leaves the block's existing rules untouched. Passing
-        ``rules=[]`` clears all rules on the block. The same applies to ``overrides``.
-        At least one of ``rules`` or ``overrides`` must be provided.
+        Follows the unset-is-not-empty convention:
+        - Omitting ``rules`` (or leaving it as ``None``) leaves existing rules untouched.
+        - Passing an empty list (``rules=[]``) clears all rules on the block.
+        - The same convention applies to ``overrides``.
+        - At least one of ``rules`` or ``overrides`` must be provided.
+
+        When ``generate_combinations=True`` (the default), the method persists the rules and
+        immediately triggers [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations],
+        passing the block's current workflow as ``old_workflow_id`` so that unchanged barcodes
+        are preserved and obsolete combinations are voided. Set ``generate_combinations=False``
+        to save rule definitions only without triggering combination regeneration.
+
+        Override keys can be constructed easily using
+        [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key]
+        on the block's parent workflow.
 
         !!! example
             ```python
+            from albert import Albert
             from albert.resources.interval_combinations import (
                 CombinationOverride,
                 ExclusionRule,
@@ -487,7 +764,8 @@ class TaskCollection(BaseCollection):
                 RuleOperator,
             )
 
-            client.tasks.set_block_rules(
+            client = Albert()
+            block_rules = client.tasks.set_block_rules(
                 task_id="TASFOR1",
                 block_id="BLK1",
                 rules=[
@@ -520,31 +798,55 @@ class TaskCollection(BaseCollection):
                     ),
                 ],
             )
+            # Combinations are regenerated automatically:
+            print(block_rules.job.state)
+            # 'successful'
             ```
 
         Parameters
         ----------
         task_id : TaskId
-            The task containing the block (format ``TAS...``).
+            The Property task ID containing the block (format ``TAS...``), obtained
+            from [`create`][albert.collections.tasks.TaskCollection.create],
+            [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations],
+            or [`get_by_id`][albert.collections.tasks.TaskCollection.get_by_id].
         block_id : BlockId
-            The block whose rules to set (format ``BLK...``).
+            The block ID whose rules to set (format ``BLK...``), obtained
+            from ``task.blocks[i].id`` on a fetched task.
         rules : list[ExclusionRule], optional
             Replacement rules for the block. If omitted (``None``), existing rules
             are left untouched. If an empty list (``[]``), existing rules are cleared.
         overrides : list[CombinationOverride], optional
             Replacement overrides for the block. If omitted (``None``), existing
             overrides are left untouched. If an empty list (``[]``), existing
-            overrides are cleared.
+            overrides are cleared. Override keys can be generated via
+            [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key].
+        generate_combinations : bool, default True
+            Whether to automatically regenerate child-workflow combinations after saving
+            rules. Defaults to True.
+        old_workflow_id : WorkflowId, optional
+            Prior workflow ID to pass to the generation job for barcode preservation
+            and voiding obsolete combinations. Defaults to the block's current workflow ID.
+        wait : bool, default True
+            Whether to wait for the background generation worker job to finish when
+            ``generate_combinations=True``. If False, returns immediately after submitting
+            the job.
 
         Returns
         -------
         BlockRules
-            The updated rules and overrides for the block.
+            The updated rules and overrides for the block. If ``generate_combinations=True``,
+            the [`job`][albert.resources.interval_combinations.BlockRules.job] attribute contains
+            the completed (or in-progress) background worker job.
 
         Raises
         ------
         ValueError
-            If both ``rules`` and ``overrides`` are omitted.
+            If both ``rules`` and ``overrides`` are omitted, or if the block is not found.
+        TypeError
+            If the task is not a PropertyTask.
+        AlbertException
+            If combination generation fails or exceeds platform caps.
         """
         if rules is None and overrides is None:
             raise ValueError("At least one of 'rules' or 'overrides' must be provided.")
@@ -582,12 +884,205 @@ class TaskCollection(BaseCollection):
         resp_data = response.json()
 
         block_data = next((item for item in resp_data if item.get("blockId") == block_id), {})
-        return BlockRules(
+        block_rules = BlockRules(
             task_id=task_id,
             block_id=block_id,
             rules=block_data.get("rules", []),
             overrides=block_data.get("overrides", []),
         )
+
+        if generate_combinations:
+            target_old_workflow_id = old_workflow_id
+            if target_old_workflow_id is None:
+                task = self.get_by_id(id=task_id)
+                if not isinstance(task, PropertyTask):
+                    raise TypeError(f"Task {task_id} must be a PropertyTask")
+                target_block = next((b for b in task.blocks if b.id == block_id), None)
+                if target_block is None:
+                    raise ValueError(f"Block {block_id} not found on task {task_id}")
+                target_old_workflow_id = self._get_block_current_workflow_id(target_block)
+
+            block_rules.job = self.generate_block_combinations(
+                task_id=task_id,
+                block_id=block_id,
+                old_workflow_id=target_old_workflow_id,
+                wait=wait,
+            )
+
+        return block_rules
+
+    @validate_call
+    def generate_block_combinations(
+        self,
+        *,
+        task_id: TaskId,
+        block_id: BlockId,
+        old_workflow_id: WorkflowId | None = None,
+        wait: bool = True,
+    ) -> WorkerJob:
+        """Generate child-workflow interval combinations for a task block.
+
+        Calculates combination variants from the block's workflow, rules, and overrides,
+        then launches a background generation job to materialize the child workflows
+        on the platform.
+
+        How to set ``old_workflow_id`` across common caller scenarios:
+        - **First-time generation** (or retrying after a failed create job): leave
+          ``old_workflow_id=None`` (the default).
+        - **Regenerating after updating rules**: pass the block's current workflow ID
+          (e.g. from ``block.workflow[0].id``).
+        - **Regenerating after swapping a workflow**: pass the previous workflow ID
+          that was replaced (the one passed to
+          [`update_block_workflow`][albert.collections.tasks.TaskCollection.update_block_workflow]).
+
+        Once generation finishes, retrieve the resulting combinations using
+        [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations].
+
+        !!! example
+            ```python
+            from albert import Albert
+
+            client = Albert()
+            job = client.tasks.generate_block_combinations(
+                task_id="TASFOR1",
+                block_id="BLK1",
+                wait=True,
+            )
+            job.state
+            # 'successful'
+
+            combos = list(client.tasks.get_block_combinations(task_id="TASFOR1", block_id="BLK1"))
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The Property task ID containing the block (format ``TAS...``), obtained
+            from [`create`][albert.collections.tasks.TaskCollection.create],
+            [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations],
+            or [`get_by_id`][albert.collections.tasks.TaskCollection.get_by_id].
+        block_id : BlockId
+            The block ID whose combinations to generate (format ``BLK...``), obtained
+            from ``task.blocks[i].id`` on a fetched task.
+        old_workflow_id : WorkflowId, optional
+            The ID of the workflow being replaced or re-evaluated (format ``WFL...``).
+            Leave None for first-time generation or create retries. Pass the block's
+            current workflow ID when re-evaluating rules on an existing block.
+        wait : bool, default True
+            Whether to wait until background generation reaches a terminal state.
+            If False, returns immediately after the generation job is submitted.
+
+        Returns
+        -------
+        WorkerJob
+            The background worker job representing child workflow generation, with
+            fields like ``state`` (e.g. ``"successful"``) and ``albert_id``.
+
+        Raises
+        ------
+        ValueError
+            If the block is not found or has no assigned workflow.
+        TypeError
+            If the task is not a PropertyTask.
+        AlbertException
+            If the generated combinations exceed the platform cap of 2,000, or if
+            ``wait=True`` and the background generation job fails.
+        """
+        task = self.get_by_id(id=task_id)
+        if not isinstance(task, PropertyTask):
+            raise TypeError(f"Task {task_id} must be a PropertyTask")
+
+        target_block = next((b for b in task.blocks if b.id == block_id), None)
+        if target_block is None:
+            raise ValueError(f"Block {block_id} not found on task {task_id}")
+
+        new_workflow_id = self._get_block_current_workflow_id(target_block)
+        if not new_workflow_id:
+            raise ValueError(f"No workflow found for block {block_id} on task {task_id}")
+
+        # Fetch the full parent workflow with setpoints and intervals
+        wfl_response = self.session.get(f"/api/v3/workflows/{new_workflow_id}")
+        parent_workflow = Workflow.model_validate(wfl_response.json())
+
+        # Fetch block rules and overrides
+        block_rules = self.get_block_rules(task_id=task_id, block_id=block_id)
+        start_from = target_block.intervals_start_from or "all"
+
+        # Check if the parent workflow has any intervalized parameters
+        has_interval_params = any(
+            any(
+                bool(getattr(sp, "intervals", None))
+                for sp in getattr(g, "parameter_setpoints", [])
+            )
+            for g in (parent_workflow.parameter_group_setpoints or [])
+        )
+
+        s3_url: str | None = None
+        if has_interval_params:
+            combinations_payload = generate_interval_combinations(
+                workflow=parent_workflow,
+                rules=block_rules.rules,
+                overrides=block_rules.overrides,
+                intervals_start_from=start_from,
+            )
+
+            if combinations_payload.combinations:
+                file_key = (
+                    f"intervalcombinations/{task_id}/{block_id}/{uuid.uuid4().hex[:10]}.json"
+                )
+                sign_payload = {
+                    "files": [
+                        {
+                            "name": file_key,
+                            "namespace": "result",
+                            "contentType": "application/json",
+                        }
+                    ]
+                }
+                sign_resp = self.session.post("/api/v3/files/sign", json=sign_payload)
+                signed_url = sign_resp.json()[0]["URL"]
+
+                payload_bytes = combinations_payload.model_dump_json(
+                    by_alias=True, exclude_none=True
+                ).encode("utf-8")
+                s3_resp = requests.put(
+                    signed_url,
+                    data=payload_bytes,
+                    headers={"Content-Type": "application/json"},
+                )
+                s3_resp.raise_for_status()
+                s3_url = file_key
+
+        worker_metadata = WorkerJobMetadata(
+            parent_type="TAS",
+            albert_id=task_id,
+            block_id=block_id,
+            new_workflow_id=new_workflow_id,
+            old_workflow_id=old_workflow_id,
+            s3_url=s3_url,
+        )
+        worker_req = WorkerJobCreateRequest(
+            job_type="createChildWorkflows",
+            metadata=worker_metadata,
+        )
+        job_resp = self.session.post(
+            "/api/v3/worker-jobs",
+            json=worker_req.model_dump(by_alias=True, mode="json", exclude_none=True),
+        )
+        resp_data = job_resp.json()
+        if isinstance(resp_data, list):
+            resp_data = resp_data[0]
+        job = WorkerJob.model_validate(resp_data)
+
+        if wait:
+            job = poll_worker_job(
+                session=self.session,
+                job_id=job.albert_id,
+                raise_on_failure=True,
+                job_description=f"Create child workflows for task {task_id} block {block_id}",
+            )
+
+        return job
 
     @validate_call
     def remove_block(self, *, task_id: TaskId, block_id: BlockId) -> None:

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -255,10 +255,36 @@ class TaskCollection(BaseCollection):
         """Create a Property task and generate interval combinations across all its blocks (🧪 Beta).
 
         Provides an all-in-one method to create a Property task and materialize
-        combination variants for every block:
+        child-workflow combination variants across every task block.
+
+        Intervals, Modes, Rules, and Overrides:
+        - **Intervals and Cartesian Product**: When workflow parameters define discrete
+          setpoints (intervals), Albert computes the Cartesian product across every
+          intervalized parameter. Each combination materializes as an independent child
+          workflow record linked to the task block with a unique, persistent interval barcode.
+        - **Starting Baseline (`intervals_start_from`)**:
+          - Exclude Mode (``"all"``, default): starts with all possible Cartesian product
+            variants active. Rules and overrides prune out infeasible, unsafe, or unwanted
+            combinations.
+          - Include Mode (``"none"``): starts with zero active combinations (an empty set).
+            Rules and overrides selectively pull in combinations, ideal for sparse screening
+            or targeted Designs of Experiment (DoE).
+        - **Rules (Criteria-Based Filtering)**:
+          Rules dynamically evaluate combination variants against criteria defined on parameter
+          values. All conditions within a single rule must match (AND logic). If any rule on the
+          block triggers (OR logic), the combination is excluded (in Exclude Mode) or included
+          (in Include Mode).
+        - **Overrides (Targeted Setpoint Overrides)**:
+          Overrides target a single, specific combination identified by its exact parameter values:
+          ``action="skip"`` explicitly excludes the variant, while ``action="unskip"`` keeps or
+          forces its inclusion. In Include Mode (``"none"``), set ``is_manual=True`` to designate
+          a manually cherry-picked combination. Overrides are evaluated first and always take
+          precedence over rules.
+
+        Execution Steps:
         1. Automatically saves any unsaved [`Workflow`][albert.resources.workflows.Workflow]
            objects defined on the task blocks, preserving block ordering.
-        2. Sets ``intervals_start_from="all"`` (exclude mode) on any blocks where the
+        2. Sets ``intervals_start_from="all"`` (Exclude Mode) on any blocks where the
            mode is not explicitly configured.
         3. Creates the task and saves any configured block rules ([`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule])
            or overrides ([`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]).
@@ -659,6 +685,11 @@ class TaskCollection(BaseCollection):
         and overrides ([`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride])
         currently configured on the specified block.
 
+        Rules evaluate criteria against parameter setpoints (using AND logic within a
+        rule and OR logic across rules) to prune combinations in Exclude Mode or include
+        combinations in Include Mode. Overrides target specific parameter combinations (with
+        ``skip`` or ``unskip`` actions) and always take precedence over rules.
+
         Use this method to inspect existing rules before updating them with
         [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules]
         (which automatically regenerates child-workflow combinations by default).
@@ -757,9 +788,24 @@ class TaskCollection(BaseCollection):
     ) -> BlockRules:
         """Set combination rules and overrides for a task block (🧪 Beta).
 
-        Configures or replaces exclusion rules and overrides on the specified block, and
+        Configures or replaces rules and overrides on the specified block, and
         by default immediately recomputes and regenerates child-workflow combinations on
         Albert Invent.
+
+        Rules, Overrides, and Baseline Modes:
+        - **Rules (Criteria-Based Filtering)**:
+          A rule consists of one or more conditions comparing parameter values against
+          thresholds. All conditions within a rule must match (AND logic). If any rule
+          matches (OR logic across rules):
+          - In Exclude Mode (``intervals_start_from="all"``, default), the combination is excluded.
+          - In Include Mode (``intervals_start_from="none"``), the combination is included.
+        - **Overrides (Targeted Setpoint Overrides)**:
+          Overrides target a specific combination variant by its exact parameter values:
+          - ``action=OverrideAction.SKIP``: explicitly excludes the combination.
+          - ``action=OverrideAction.UNSKIP``: explicitly keeps or forces inclusion of the combination.
+          - In Include Mode (``"none"``), set ``is_manual=True`` to designate a manually
+            cherry-picked combination.
+          - Overrides are evaluated first and always take precedence over rules.
 
         Follows the unset-is-not-empty convention:
         - Omitting ``rules`` (or leaving it as ``None``) leaves existing rules untouched.
@@ -941,6 +987,17 @@ class TaskCollection(BaseCollection):
         Calculates combination variants from the block's workflow, rules, and overrides,
         then launches a background generation job to materialize the child workflows
         on the platform.
+
+        Combination Generation Lifecycle:
+        - **Cartesian Product**: Evaluates combinations across all intervalized workflow parameters
+          starting from the block's baseline mode (``intervals_start_from="all"`` for Exclude Mode,
+          starting with all combinations; or ``"none"`` for Include Mode, starting with an empty set).
+        - **Rules and Overrides**: Applies rules (AND logic within a rule, OR logic across rules)
+          and overrides (which take precedence over rules) to determine active combinations.
+        - **Child Workflows and Barcodes**: Each active combination materializes as an independent
+          child workflow record linked to the task block. Every combination receives a unique,
+          persistent interval barcode that remains stable across rule updates as long as the
+          parameter setpoints are unchanged.
 
         How to set ``old_workflow_id`` across common caller scenarios:
         - **First-time generation** (or retrying after a failed create job): leave

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -141,7 +141,7 @@ class TaskCollection(BaseCollection):
     -------
     create(task) -> BaseTask
         Create a PropertyTask, BatchTask, or GeneralTask.
-    create_with_combinations(task, wait=True) -> PropertyTask
+    create_with_combinations(task, wait=True) -> PropertyTask (🧪 Beta)
         Create a Property task and orchestrate combination generation across all its blocks.
     get_by_id(id) -> BaseTask
         Get a single fully populated task by its ID.
@@ -159,13 +159,13 @@ class TaskCollection(BaseCollection):
         Remove a Block from a Property or Batch task.
     update_block_workflow(task_id, block_id, workflow_id) -> None
         Swap the Workflow assigned to a Block.
-    get_block_combinations(task_id, block_id, max_items=None) -> Iterator[IntervalCombinationItem]
+    get_block_combinations(task_id, block_id, max_items=None) -> Iterator[IntervalCombinationItem] (🧪 Beta)
         Get the child-workflow combinations of a block.
-    get_block_rules(task_id, block_id) -> BlockRules
+    get_block_rules(task_id, block_id) -> BlockRules (🧪 Beta)
         Get combination rules and overrides for a block.
-    set_block_rules(task_id, block_id, rules=None, overrides=None, generate_combinations=True, wait=True) -> BlockRules
+    set_block_rules(task_id, block_id, rules=None, overrides=None, generate_combinations=True, wait=True) -> BlockRules (🧪 Beta)
         Set combination rules and overrides for a block, automatically regenerating combinations.
-    generate_block_combinations(task_id, block_id, old_workflow_id=None, wait=True) -> WorkerJob
+    generate_block_combinations(task_id, block_id, old_workflow_id=None, wait=True) -> WorkerJob (🧪 Beta)
         Generate child-workflow interval combinations for a task block.
     import_results(...) -> BaseTask
         Import measured results into a Property task from a file or attachment.
@@ -240,7 +240,7 @@ class TaskCollection(BaseCollection):
         task: PropertyTask,
         wait: bool = True,
     ) -> PropertyTask:
-        """Create a Property task and generate interval combinations across all its blocks.
+        """Create a Property task and generate interval combinations across all its blocks (🧪 Beta).
 
         Provides an all-in-one method to create a Property task and materialize
         combination variants for every block:
@@ -262,6 +262,12 @@ class TaskCollection(BaseCollection):
         To update rules or regenerate combinations on an existing task later, use
         [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] and
         [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations].
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -571,7 +577,7 @@ class TaskCollection(BaseCollection):
     def get_block_combinations(
         self, *, task_id: TaskId, block_id: BlockId, max_items: int | None = None
     ) -> Iterator[IntervalCombinationItem]:
-        """Get the child-workflow interval combinations of a task block.
+        """Get the child-workflow interval combinations of a task block (🧪 Beta).
 
         Retrieves the combinations generated for a task block by
         [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]
@@ -584,6 +590,12 @@ class TaskCollection(BaseCollection):
         Results are returned as a lazily paginated iterator. Do not infer the end
         of results from page size: a page can under-return while more combinations
         remain.
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -633,7 +645,7 @@ class TaskCollection(BaseCollection):
         task_id: TaskId,
         block_id: BlockId,
     ) -> BlockRules:
-        """Get combination rules and overrides for a task block.
+        """Get combination rules and overrides for a task block (🧪 Beta).
 
         Returns the rules ([`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule])
         and overrides ([`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride])
@@ -644,6 +656,12 @@ class TaskCollection(BaseCollection):
         Note that modifying rules on a block does not change its generated combinations
         until [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations]
         is run.
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -731,7 +749,7 @@ class TaskCollection(BaseCollection):
         old_workflow_id: WorkflowId | None = None,
         wait: bool = True,
     ) -> BlockRules:
-        """Set combination rules and overrides for a task block.
+        """Set combination rules and overrides for a task block (🧪 Beta).
 
         Configures or replaces exclusion rules and overrides on the specified block, and
         by default immediately recomputes and regenerates child-workflow combinations on
@@ -752,6 +770,12 @@ class TaskCollection(BaseCollection):
         Override keys can be constructed easily using
         [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key]
         on the block's parent workflow.
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -920,7 +944,7 @@ class TaskCollection(BaseCollection):
         old_workflow_id: WorkflowId | None = None,
         wait: bool = True,
     ) -> WorkerJob:
-        """Generate child-workflow interval combinations for a task block.
+        """Generate child-workflow interval combinations for a task block (🧪 Beta).
 
         Calculates combination variants from the block's workflow, rules, and overrides,
         then launches a background generation job to materialize the child workflows
@@ -937,6 +961,12 @@ class TaskCollection(BaseCollection):
 
         Once generation finishes, retrieve the resulting combinations using
         [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations].
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from contextlib import suppress
+from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -31,7 +32,12 @@ from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError, NotFoundError
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
-from albert.resources.interval_combinations import IntervalCombinationItem
+from albert.resources.interval_combinations import (
+    BlockRules,
+    CombinationOverride,
+    ExclusionRule,
+    IntervalCombinationItem,
+)
 from albert.resources.tasks import (
     BaseTask,
     BatchTask,
@@ -139,6 +145,10 @@ class TaskCollection(BaseCollection):
         Swap the Workflow assigned to a Block.
     get_block_combinations(task_id, block_id, max_items=None) -> Iterator[IntervalCombinationItem]
         Get the child-workflow combinations of a block.
+    get_block_rules(task_id, block_id) -> BlockRules
+        Get combination rules and overrides for a block.
+    set_block_rules(task_id, block_id, rules=None, overrides=None) -> BlockRules
+        Set combination rules and overrides for a block.
     import_results(...) -> BaseTask
         Import measured results into a Property task from a file or attachment.
     get_history(id, ...) -> TaskHistory
@@ -389,6 +399,194 @@ class TaskCollection(BaseCollection):
             session=self.session,
             max_items=max_items,
             deserialize=lambda items: [IntervalCombinationItem(**item) for item in items],
+        )
+
+    @validate_call
+    def get_block_rules(
+        self,
+        *,
+        task_id: TaskId,
+        block_id: BlockId,
+    ) -> BlockRules:
+        """Get combination rules and overrides for a task block.
+
+        Returns all rules and overrides configured on the specified block.
+        Saving a rule does not by itself change any combinations until
+        `generate_block_combinations` runs.
+
+        !!! example
+            ```python
+            rules_data = client.tasks.get_block_rules(
+                task_id="TASFOR1", block_id="BLK1"
+            )
+            for rule in rules_data.rules:
+                print(rule.name, rule.conditions)
+            for override in rules_data.overrides:
+                print(override.key, override.action)
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The task containing the block (format ``TAS...``).
+        block_id : BlockId
+            The block whose rules to retrieve (format ``BLK...``).
+
+        Returns
+        -------
+        BlockRules
+            The rules and overrides for the block.
+        """
+        url = f"{self.base_path}/{task_id}/blocks/{block_id}/rules"
+        response = self.session.get(url)
+        data = response.json()
+
+        all_rules = list(data.get("rules", {}).get("items", []))
+        last_key = data.get("rules", {}).get("lastKey")
+        while last_key:
+            next_resp = self.session.get(url, params={"startKey": last_key})
+            next_data = next_resp.json()
+            rules_obj = next_data.get("rules", {})
+            all_rules.extend(rules_obj.get("items", []))
+            last_key = rules_obj.get("lastKey")
+
+        return BlockRules(
+            task_id=data["taskId"],
+            block_id=data["blockId"],
+            rules=all_rules,
+            overrides=data.get("overrides", []),
+        )
+
+    @validate_call
+    def set_block_rules(
+        self,
+        *,
+        task_id: TaskId,
+        block_id: BlockId,
+        rules: list[ExclusionRule] | None = None,
+        overrides: list[CombinationOverride] | None = None,
+    ) -> BlockRules:
+        """Set combination rules and overrides for a task block.
+
+        Replaces the rules and/or overrides for the specified block.
+        Saving rules does not by itself change any combinations until
+        `generate_block_combinations` runs.
+
+        Follows the unset-is-not-empty convention: omitting ``rules`` (or leaving
+        it as ``None``) leaves the block's existing rules untouched. Passing
+        ``rules=[]`` clears all rules on the block. The same applies to ``overrides``.
+        At least one of ``rules`` or ``overrides`` must be provided.
+
+        !!! example
+            ```python
+            from albert.resources.interval_combinations import (
+                CombinationOverride,
+                ExclusionRule,
+                OverrideAction,
+                RuleCondition,
+                RuleOperator,
+            )
+
+            client.tasks.set_block_rules(
+                task_id="TASFOR1",
+                block_id="BLK1",
+                rules=[
+                    ExclusionRule(
+                        name="Exclude high temp and high speed",
+                        conditions=[
+                            RuleCondition(
+                                parameter_group_id="PRG247776",
+                                parameter_id="PRM100",
+                                row_id="ROW2",
+                                operator=RuleOperator.GTE,
+                                value="90",
+                                unit_id="UNI1",
+                            ),
+                            RuleCondition(
+                                parameter_group_id="PRG247776",
+                                parameter_id="PRM200",
+                                row_id="ROW5",
+                                operator=RuleOperator.GTE,
+                                value="1500",
+                                unit_id="UNI2",
+                            ),
+                        ],
+                    )
+                ],
+                overrides=[
+                    CombinationOverride(
+                        key="PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9",
+                        action=OverrideAction.SKIP,
+                    ),
+                ],
+            )
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The task containing the block (format ``TAS...``).
+        block_id : BlockId
+            The block whose rules to set (format ``BLK...``).
+        rules : list[ExclusionRule], optional
+            Replacement rules for the block. If omitted (``None``), existing rules
+            are left untouched. If an empty list (``[]``), existing rules are cleared.
+        overrides : list[CombinationOverride], optional
+            Replacement overrides for the block. If omitted (``None``), existing
+            overrides are left untouched. If an empty list (``[]``), existing
+            overrides are cleared.
+
+        Returns
+        -------
+        BlockRules
+            The updated rules and overrides for the block.
+
+        Raises
+        ------
+        ValueError
+            If both ``rules`` and ``overrides`` are omitted.
+        """
+        if rules is None and overrides is None:
+            raise ValueError("At least one of 'rules' or 'overrides' must be provided.")
+
+        block_payload: dict[str, Any] = {"blockId": block_id}
+
+        if rules is not None:
+            rules_list = []
+            for r in rules:
+                rule_dict: dict[str, Any] = {
+                    "conditions": [
+                        c.model_dump(by_alias=True, mode="json", exclude_none=True)
+                        for c in r.conditions
+                    ]
+                }
+                if r.name is not None:
+                    rule_dict["name"] = r.name
+                rules_list.append(rule_dict)
+            block_payload["rules"] = rules_list
+
+        if overrides is not None:
+            overrides_list = []
+            for o in overrides:
+                override_dict: dict[str, Any] = {
+                    "key": o.key,
+                    "action": o.action.value if isinstance(o.action, Enum) else o.action,
+                }
+                if o.is_manual is not None:
+                    override_dict["isManual"] = o.is_manual
+                overrides_list.append(override_dict)
+            block_payload["overrides"] = overrides_list
+
+        url = f"{self.base_path}/{task_id}/rules"
+        response = self.session.put(url, json=[block_payload])
+        resp_data = response.json()
+
+        block_data = next((item for item in resp_data if item.get("blockId") == block_id), {})
+        return BlockRules(
+            task_id=task_id,
+            block_id=block_id,
+            rules=block_data.get("rules", []),
+            overrides=block_data.get("overrides", []),
         )
 
     @validate_call

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -4,7 +4,6 @@ import time
 import uuid
 from collections.abc import Iterator
 from contextlib import suppress
-from enum import Enum
 from pathlib import Path
 from typing import Any
 
@@ -33,7 +32,12 @@ from albert.core.shared.identifiers import (
     remove_id_prefix,
 )
 from albert.core.utils import ensure_list
-from albert.exceptions import AlbertHTTPError, CombinationGenerationError, NotFoundError
+from albert.exceptions import (
+    AlbertException,
+    AlbertHTTPError,
+    CombinationGenerationError,
+    NotFoundError,
+)
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
 from albert.resources.interval_combinations import (
@@ -77,6 +81,14 @@ from albert.utils.tasks import (
     resolve_attachment,
 )
 from albert.utils.worker_jobs import poll_worker_job
+
+_BLOCK_COMBINATION_JOB_GAP_SECONDS: float = 10.0
+"""Minimum interval in seconds between kicking off consecutive block combination worker jobs.
+
+Submitting multiple block child-workflow generation jobs concurrently on a newly created task
+can trigger backend database lock contention or worker queue race conditions on the parent task
+record. Pacing consecutive job submissions by 10 seconds allows each job to initialize cleanly.
+"""
 
 
 class _BlockCombinationsPaginator(AlbertPaginator):
@@ -324,6 +336,7 @@ class TaskCollection(BaseCollection):
         if not isinstance(task, PropertyTask):
             raise TypeError("task must be a PropertyTask")
 
+        task = task.model_copy(deep=True)
         workflow_collection = WorkflowCollection(session=self.session)
 
         # 1. Ensure all workflows have an ID (create unsaved workflows if needed)
@@ -336,10 +349,6 @@ class TaskCollection(BaseCollection):
                         w.block_mapping = str(i)
                         created_wfls = workflow_collection.create(workflows=[w])
                         w.id = created_wfls[0].id
-                    elif isinstance(w, dict) and not w.get("id"):
-                        w["blockMapping"] = str(i)
-                        created_wfls = workflow_collection.create(workflows=[Workflow(**w)])
-                        w["id"] = created_wfls[0].id
 
             # 2. Fill intervals_start_from on any block where it is unset
             for block in task.blocks:
@@ -374,15 +383,14 @@ class TaskCollection(BaseCollection):
         if rules_payload:
             self.session.put(f"{self.base_path}/{created_task.id}/rules", json=rules_payload)
 
-        # 5. Sequentially trigger generate_block_combinations for each block with 10s gap
-        min_job_gap_seconds = 10.0
+        # 5. Sequentially trigger generate_block_combinations for each block with paced delay
         jobs: dict[str, WorkerJob] = {}
         last_job_time = 0.0
 
         for i, created_b in enumerate(created_task.blocks):
             if i > 0 and last_job_time > 0:
                 elapsed = time.time() - last_job_time
-                remaining = min_job_gap_seconds - elapsed
+                remaining = _BLOCK_COMBINATION_JOB_GAP_SECONDS - elapsed
                 if remaining > 0:
                     time.sleep(remaining)
 
@@ -410,7 +418,7 @@ class TaskCollection(BaseCollection):
                     job_states[blk_id] = completed_job.state.value
                     if completed_job.state != WorkerJobState.SUCCESSFUL:
                         failed_blocks.append(blk_id)
-                except Exception:
+                except (TimeoutError, AlbertException):
                     failed_blocks.append(blk_id)
                     job_states[blk_id] = "failed"
 
@@ -880,30 +888,14 @@ class TaskCollection(BaseCollection):
         block_payload: dict[str, Any] = {"blockId": block_id}
 
         if rules is not None:
-            rules_list = []
-            for r in rules:
-                rule_dict: dict[str, Any] = {
-                    "conditions": [
-                        c.model_dump(by_alias=True, mode="json", exclude_none=True)
-                        for c in r.conditions
-                    ]
-                }
-                if r.name is not None:
-                    rule_dict["name"] = r.name
-                rules_list.append(rule_dict)
-            block_payload["rules"] = rules_list
+            block_payload["rules"] = [
+                r.model_dump(by_alias=True, mode="json", exclude_none=True) for r in rules
+            ]
 
         if overrides is not None:
-            overrides_list = []
-            for o in overrides:
-                override_dict: dict[str, Any] = {
-                    "key": o.key,
-                    "action": o.action.value if isinstance(o.action, Enum) else o.action,
-                }
-                if o.is_manual is not None:
-                    override_dict["isManual"] = o.is_manual
-                overrides_list.append(override_dict)
-            block_payload["overrides"] = overrides_list
+            block_payload["overrides"] = [
+                o.model_dump(by_alias=True, mode="json", exclude_none=True) for o in overrides
+            ]
 
         url = f"{self.base_path}/{task_id}/rules"
         response = self.session.put(url, json=[block_payload])
@@ -1009,6 +1001,12 @@ class TaskCollection(BaseCollection):
         WorkerJob
             The background worker job representing child workflow generation, with
             fields like ``state`` (e.g. ``"successful"``) and ``albert_id``.
+
+        Notes
+        -----
+        When triggering combination generation across multiple blocks sequentially on the
+        same task, pace consecutive calls by at least 10 seconds to avoid backend task lock
+        contention during worker job initialization.
 
         Raises
         ------

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -31,6 +31,7 @@ from albert.core.utils import ensure_list
 from albert.exceptions import AlbertHTTPError, NotFoundError
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
+from albert.resources.interval_combinations import IntervalCombinationItem
 from albert.resources.tasks import (
     BaseTask,
     BatchTask,
@@ -56,6 +57,18 @@ from albert.utils.tasks import (
     map_csv_headers_to_columns,
     resolve_attachment,
 )
+
+
+class _BlockCombinationsPaginator(AlbertPaginator):
+    """KEY-mode paginator for GET /tasks/{id}/blocks/{blockId}/combinations.
+
+    The envelope lists items under ``combinations``, not ``Items``. ``lastKey`` is
+    omitted when exhausted; a page may under-return because of DynamoDB's 1MB cap,
+    so completion is inferred from ``lastKey``, not page size.
+    """
+
+    def _response_items(self, data: dict[str, Any]) -> list:
+        return data.get("combinations") or []
 
 
 class TaskCollection(BaseCollection):
@@ -124,6 +137,8 @@ class TaskCollection(BaseCollection):
         Remove a Block from a Property or Batch task.
     update_block_workflow(task_id, block_id, workflow_id) -> None
         Swap the Workflow assigned to a Block.
+    get_block_combinations(task_id, block_id, max_items=None) -> Iterator[IntervalCombinationItem]
+        Get the child-workflow combinations of a block.
     import_results(...) -> BaseTask
         Import measured results into a Property task from a file or attachment.
     get_history(id, ...) -> TaskHistory
@@ -328,6 +343,53 @@ class TaskCollection(BaseCollection):
             }
         ]
         self.session.patch(url=url, json=patch)
+
+    @validate_call
+    def get_block_combinations(
+        self, *, task_id: TaskId, block_id: BlockId, max_items: int | None = None
+    ) -> Iterator[IntervalCombinationItem]:
+        """Get the child-workflow combinations of a task block.
+
+        Use this instead of any combinations array embedded on the task or block.
+        That embedded array is empty once the block has 500 or more combinations.
+
+        Results are returned as a lazily paginated iterator. Do not infer the end
+        of results from page size: a page can under-return while more combinations
+        remain.
+
+        !!! example
+            ```python
+            combos = client.tasks.get_block_combinations(
+                task_id="TASFOR1", block_id="BLK1"
+            )
+            [(c.id, c.interval_barcode) for c in combos]
+            # [('WFL999', 'OhI8ap0HY')]
+            ```
+
+        Parameters
+        ----------
+        task_id : TaskId
+            The task containing the block (format ``TAS...``).
+        block_id : BlockId
+            The block whose combinations to list (format ``BLK...``).
+        max_items : int, optional
+            Maximum number of combinations to return. If None, iterates over all
+            combinations.
+
+        Returns
+        -------
+        Iterator[IntervalCombinationItem]
+            A lazily paginated iterator of combinations. After iteration,
+            ``has_more`` is True when ``max_items`` stopped the iterator and more
+            combinations remain.
+        """
+        return _BlockCombinationsPaginator(
+            mode=PaginationMode.KEY,
+            path=f"{self.base_path}/{task_id}/blocks/{block_id}/combinations",
+            session=self.session,
+            max_items=max_items,
+            deserialize=lambda items: [IntervalCombinationItem(**item) for item in items],
+        )
 
     @validate_call
     def remove_block(self, *, task_id: TaskId, block_id: BlockId) -> None:

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -660,10 +660,8 @@ class TaskCollection(BaseCollection):
         currently configured on the specified block.
 
         Use this method to inspect existing rules before updating them with
-        [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules].
-        Note that modifying rules on a block does not change its generated combinations
-        until [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations]
-        is run.
+        [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules]
+        (which automatically regenerates child-workflow combinations by default).
 
         !!! warning "Beta Feature!"
             Increased intervals combination support is currently in beta and behind a platform

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
+from contextlib import suppress
 from pathlib import Path
 from typing import Any
 
@@ -27,7 +28,7 @@ from albert.core.shared.identifiers import (
     remove_id_prefix,
 )
 from albert.core.utils import ensure_list
-from albert.exceptions import AlbertHTTPError
+from albert.exceptions import AlbertHTTPError, NotFoundError
 from albert.resources.attachments import AttachmentCategory
 from albert.resources.data_templates import ImportMode
 from albert.resources.tasks import (
@@ -588,13 +589,14 @@ class TaskCollection(BaseCollection):
             inventory_id,
             lot_id or "None",
         )
-        property_data_collection.bulk_delete_task_data(
-            task_id=task_id,
-            block_id=block_id,
-            inventory_id=inventory_id,
-            lot_id=lot_id,
-            interval_id=interval,
-        )
+        with suppress(NotFoundError):
+            property_data_collection.bulk_delete_task_data(
+                task_id=task_id,
+                block_id=block_id,
+                inventory_id=inventory_id,
+                lot_id=lot_id,
+                interval_id=interval,
+            )
 
         property_data_collection.add_properties_to_task(
             inventory_id=inventory_id,

--- a/src/albert/collections/tasks.py
+++ b/src/albert/collections/tasks.py
@@ -767,9 +767,11 @@ class TaskCollection(BaseCollection):
         are preserved and obsolete combinations are voided. Set ``generate_combinations=False``
         to save rule definitions only without triggering combination regeneration.
 
-        Override keys can be constructed easily using
-        [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key]
-        on the block's parent workflow.
+        Rules and overrides can be constructed easily from parameter names and values using
+        [`Workflow.build_rule`][albert.resources.workflows.Workflow.build_rule] and
+        [`Workflow.build_override`][albert.resources.workflows.Workflow.build_override]
+        on the block's parent workflow. Override keys can also be computed directly using
+        [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key].
 
         !!! warning "Beta Feature!"
             Increased intervals combination support is currently in beta and behind a platform

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -177,6 +177,10 @@ def ensure_interval_id(id: str) -> str:
     if upper.startswith("WFL"):
         return upper
 
+    # Platform-generated combination barcodes are 9-character case-sensitive alphanumeric
+    # nanoids (e.g. "OhI8ap0HY", "V1a9Km2xL") that lack an identifying prefix. Matching
+    # solely on length is permissive (accepting any 9-character string), but unavoidable
+    # given barcode unpredictability across tenants while preserving exact case.
     if len(id) == _INTERVAL_BARCODE_LEN:
         return id
 

--- a/src/albert/core/shared/identifiers.py
+++ b/src/albert/core/shared/identifiers.py
@@ -157,20 +157,33 @@ def ensure_search_inventory_id(id: str) -> str:
 SearchInventoryId = Annotated[str, AfterValidator(ensure_search_inventory_id)]
 
 
+_ROW_CHAIN_RE = re.compile(r"^ROW\d+(?:XROW\d+)*$")
+_INTERVAL_BARCODE_LEN = 9
+
+
 def ensure_interval_id(id: str) -> str:
     if not id:
         raise ValueError("IntervalId cannot be empty")
 
-    # Check if it matches ROW# or ROW#XROW# pattern
-    parts = id.upper().split("X")
-    if len(parts) > 2:
-        raise ValueError(f"IntervalId {id} is invalid. Must be in format ROW# or ROW#XROW#")
+    if id.lower() == "default":
+        return "default"
 
-    for part in parts:
-        if not part.startswith("ROW") or not part[3:].isdigit():
-            raise ValueError(f"IntervalId {id} is invalid. Must be in format ROW# or ROW#XROW#")
+    # ROW chains and WFL ids follow Albert ID uppercasing. Barcodes are
+    # case-sensitive and must not be folded.
+    upper = id.upper()
+    if _ROW_CHAIN_RE.fullmatch(upper):
+        return upper
 
-    return id.upper()
+    if upper.startswith("WFL"):
+        return upper
+
+    if len(id) == _INTERVAL_BARCODE_LEN:
+        return id
+
+    raise ValueError(
+        f"IntervalId {id} is invalid. Must be a ROW chain (ROW# or ROW#XROW#...), "
+        "a WFL id, a 9-character barcode, or 'default'"
+    )
 
 
 IntervalId = Annotated[str, AfterValidator(ensure_interval_id)]

--- a/src/albert/exceptions.py
+++ b/src/albert/exceptions.py
@@ -1,5 +1,6 @@
 import contextlib
 from collections.abc import AsyncIterator, Iterator
+from typing import Any
 
 import httpx
 import requests
@@ -152,3 +153,57 @@ def handle_http_errors() -> Iterator[None]:
         # TODO: Enable debug logging via requests directly
         logger.debug("Albert HTTP Error %s", albert_error)
         raise albert_error from e
+
+
+class CombinationGenerationError(AlbertException):
+    """Raised when background combination generation fails for one or more task blocks.
+
+    Raised by [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]
+    when ``wait=True`` and combination generation does not complete successfully on all blocks.
+
+    Because the task itself has already been created on the platform, this exception
+    carries the created task instance and details about which blocks failed. This allows
+    callers to inspect the task state and retry generation for only the failed blocks
+    using [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations].
+
+    Attributes
+    ----------
+    task : PropertyTask or None
+        The created Property task, re-fetched from the platform.
+    failed_blocks : list[str]
+        List of block IDs (format ``BLK...``) whose combination generation failed.
+    job_states : dict[str, str]
+        Mapping of block IDs to their final job states (e.g. ``{"BLK1": "successful", "BLK2": "failed"}``).
+
+    !!! example
+        ```python
+        from albert import Albert
+        from albert.exceptions import CombinationGenerationError
+        from albert.resources.tasks import Block, PropertyTask
+
+        client = Albert()
+        try:
+            task = client.tasks.create_with_combinations(task=prop_task)
+        except CombinationGenerationError as err:
+            print(f"Task {err.task.id} was created, but some blocks failed combination generation.")
+            for block_id in err.failed_blocks:
+                # Retry generation on the failed block:
+                client.tasks.generate_block_combinations(
+                    task_id=err.task.id,
+                    block_id=block_id,
+                )
+        ```
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        task: Any = None,
+        failed_blocks: list[str] | None = None,
+        job_states: dict[str, str] | None = None,
+    ):
+        super().__init__(message)
+        self.task = task
+        self.failed_blocks = failed_blocks or []
+        self.job_states = job_states or {}

--- a/src/albert/exceptions.py
+++ b/src/albert/exceptions.py
@@ -1,11 +1,16 @@
+from __future__ import annotations
+
 import contextlib
 from collections.abc import AsyncIterator, Iterator
-from typing import Any
+from typing import TYPE_CHECKING
 
 import httpx
 import requests
 
 from albert.core.logging import logger
+
+if TYPE_CHECKING:
+    from albert.resources.tasks import PropertyTask
 
 
 class AlbertException(Exception):
@@ -18,7 +23,7 @@ class AlbertAuthError(AlbertException):
     """Raised when authentication fails (e.g., bad credentials, expired token)."""
 
 
-def _restore_albert_http_error(cls: type, message: str) -> "AlbertHTTPError":
+def _restore_albert_http_error(cls: type, message: str) -> AlbertHTTPError:
     """Reconstruct an AlbertHTTPError from a pickled message string.
 
     Python's default exception pickling stores args and calls __init__(*args)
@@ -195,11 +200,15 @@ class CombinationGenerationError(AlbertException):
         ```
     """
 
+    task: PropertyTask | None
+    failed_blocks: list[str]
+    job_states: dict[str, str]
+
     def __init__(
         self,
         message: str,
         *,
-        task: Any = None,
+        task: PropertyTask | None = None,
         failed_blocks: list[str] | None = None,
         job_states: dict[str, str] | None = None,
     ):

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -86,11 +86,17 @@ class OverrideAction(str, Enum):
 
 
 class Condition(NamedTuple):
-    """Specification for a rule condition before resolving workflow-local IDs.
+    """Specification for a rule condition before resolving workflow-local IDs (🧪 Beta).
 
     Used with [`Workflow.build_rule`][albert.resources.workflows.Workflow.build_rule] to specify
     criteria using parameter names or short names. Can be instantiated as a named tuple or
     passed as a plain tuple (e.g. ``("Temperature", ">=", 90)``).
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
     """
 
     parameter: str

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -87,7 +87,7 @@ class RuleCondition(BaseAlbertModel):
     operator: RuleOperator
     """Comparison operator used to evaluate this condition."""
 
-    value: str | float | int
+    value: str | float | int | None = Field(default=None, alias="value")
     """Threshold value to compare against."""
 
     unit_id: str | None = Field(default=None, alias="unitId")
@@ -162,3 +162,70 @@ class BlockRules(BaseAlbertModel):
                 data = dict(data)
                 data["rules"] = rules["items"]
         return data
+
+
+class CombinationParameter(BaseAlbertModel):
+    """A single parameter within a generated combination parameter group."""
+
+    id: str
+    """Parameter ID (format ``PRM...``)."""
+
+    prg_prm_row_id: str | None = Field(default=None, alias="prgPrmRowId")
+    """The parameter sequence row ID within the group."""
+
+    row_id: str = Field(alias="rowId")
+    """The parameter setpoint row ID from the workflow."""
+
+    category: str = Field(default="Normal")
+    """Category of the parameter (``"Normal"`` or ``"Special"``)."""
+
+    short_name: str | None = Field(default=None, alias="shortName")
+    """Short name for the parameter, used for special parameters."""
+
+    required: bool = Field(default=False)
+    """Whether the parameter is required."""
+
+    interval_row_id: str | None = Field(default=None, alias="intervalRowId")
+    """The interval setpoint row ID (format ``ROW...``), or ``None`` if fixed."""
+
+    name: str
+    """Display name of the parameter."""
+
+    value: Any = Field(default=None)
+    """Realized value for this combination."""
+
+    unit: dict[str, Any] | None = Field(default=None, alias="Unit")
+    """Unit definition for the value, if any."""
+
+    is_interval: bool = Field(default=False, alias="isInterval")
+    """Whether this parameter is intervalized in this combination."""
+
+
+class CombinationParameterGroup(BaseAlbertModel):
+    """A parameter group within a generated combination."""
+
+    id: str
+    """Parameter group ID (format ``PRG...`` or ``DAT...``)."""
+
+    prg_sequence: int | None = Field(default=None, alias="prgSequence")
+    """Position sequence of the parameter group in the workflow."""
+
+    row_id: str = Field(alias="rowId")
+    """The group setpoint row ID on the parent workflow."""
+
+    parameters: list[CombinationParameter] = Field(alias="Parameters")
+    """Parameters in this group for this combination."""
+
+
+class CombinationLeaf(BaseAlbertModel):
+    """One realized combination containing its configured parameter groups."""
+
+    parameter_groups: list[CombinationParameterGroup] = Field(alias="ParameterGroups")
+    """The parameter groups defining this combination."""
+
+
+class IntervalCombinationPayload(BaseAlbertModel):
+    """The combinations payload written to S3 to trigger child workflow generation."""
+
+    combinations: list[CombinationLeaf]
+    """The list of combination definitions."""

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -142,10 +142,18 @@ class RuleCondition(BaseAlbertModel):
 
 
 class ExclusionRule(BaseAlbertModel):
-    """An exclusion rule composed of one or more conditions (🧪 Beta).
+    """A combination rule composed of one or more conditions (🧪 Beta).
 
-    All conditions within a rule must match (AND) for the rule to trigger.
-    A combination is excluded if any rule matches (OR).
+    Rules evaluate combination variants against criteria defined on parameter values:
+    - **Conditions**: compare a parameter against a threshold using an operator (``=``, ``!=``, ``>``, ``>=``, ``<``, ``<=``).
+    - **AND logic within a rule**: all conditions inside a single rule must match for the rule to trigger.
+    - **OR logic across rules**: if any rule on the block triggers, its outcome applies.
+    - **Baseline mode behavior (`intervals_start_from`)**:
+      - In Exclude Mode (``"all"``, default), matching combinations are excluded.
+      - In Include Mode (``"none"``), matching combinations are included.
+
+    Use [`Workflow.build_rule`][albert.resources.workflows.Workflow.build_rule] to construct
+    rules from human-readable parameter names and values.
 
     !!! warning "Beta Feature!"
         Increased intervals combination support is currently in beta and behind a platform
@@ -169,10 +177,17 @@ Rule = ExclusionRule
 
 
 class CombinationOverride(BaseAlbertModel):
-    """A manual skip or unskip override for a specific combination condition (🧪 Beta).
+    """A targeted skip or unskip override for a specific combination condition (🧪 Beta).
+
+    Overrides pinpoint an exact combination in the Cartesian product space:
+    - ``action=OverrideAction.SKIP``: explicitly excludes the combination.
+    - ``action=OverrideAction.UNSKIP``: explicitly keeps or forces inclusion of the combination.
+    - **Precedence**: overrides are evaluated first and always take precedence over rules (e.g. an ``unskip`` override guarantees a combination is retained even if an exclusion rule matches).
+    - **Manual cherry-picking (`is_manual=True`)**: in Include Mode (``intervals_start_from="none"``), designates an individual combination cherry-picked into an otherwise empty set.
 
     Keyed by the compound override key (format ``{groupId}#{paramId}#{rowId}-...``),
-    which can be generated using [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key].
+    which can be generated using [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key]
+    or built directly via [`Workflow.build_override`][albert.resources.workflows.Workflow.build_override].
 
     !!! warning "Beta Feature!"
         Increased intervals combination support is currently in beta and behind a platform
@@ -196,6 +211,13 @@ class CombinationOverride(BaseAlbertModel):
 
 class BlockRules(BaseAlbertModel):
     """Combination rules and overrides for a task block (🧪 Beta).
+
+    Encapsulates the rules and overrides that govern how interval combinations
+    are evaluated and filtered on a task block:
+    - **Rules** define parameter criteria evaluated with AND logic within each rule and
+      OR logic across rules (excluding matches in Exclude Mode, including in Include Mode).
+    - **Overrides** pinpoint specific combinations for forced inclusion (``unskip``)
+      or exclusion (``skip``) and take precedence over rules.
 
     Returned by [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules]
     and [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules].

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -1,0 +1,39 @@
+from pydantic import Field
+
+from albert.core.base import BaseAlbertModel
+
+
+class IntervalCombinationItem(BaseAlbertModel):
+    """One child-workflow interval combination on a task block.
+
+    Returned by
+    [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations].
+    Use that method rather than any combinations array embedded on a task or block:
+    the embedded array is empty once the block has 500 or more combinations.
+
+    !!! example
+        ```python
+        from albert import Albert
+
+        client = Albert()
+        combo = next(
+            client.tasks.get_block_combinations(task_id="TASFOR1", block_id="BLK1", max_items=1)
+        )
+        combo.id
+        # 'WFL999'
+        combo.interval_barcode
+        # 'OhI8ap0HY'
+        ```
+    """
+
+    id: str | None = None
+    """The child workflow id for this combination (format ``WFL...``)."""
+
+    name: str | None = None
+    """Display name of the combination (parameter names and values)."""
+
+    interval_barcode: str | None = Field(default=None, alias="intervalBarcode")
+    """Case-sensitive barcode for the combination. Serialized as ``intervalBarcode``."""
+
+    interval_row_key: str | None = Field(default=None, alias="intervalRowKey")
+    """Legacy ROW-chain key (e.g. ``ROW3XROW7``). Serialized as ``intervalRowKey``."""

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -1,4 +1,7 @@
-from pydantic import Field
+from enum import Enum
+from typing import Any
+
+from pydantic import Field, model_validator
 
 from albert.core.base import BaseAlbertModel
 
@@ -40,3 +43,122 @@ class IntervalCombinationItem(BaseAlbertModel):
 
     interval_row_key: str | None = Field(default=None, alias="intervalRowKey")
     """Legacy ROW-chain key (e.g. ``ROW3XROW7``). Serialized as ``intervalRowKey``."""
+
+
+class RuleOperator(str, Enum):
+    """Comparison operator used to evaluate a rule condition against a parameter value.
+
+    Note: Distinct from `parameter_groups.Operator` (which uses ``neq`` and has
+    ``between``) and `targets.ComparisonOperator` (which lacks ``ne`` and has
+    ``in_set``). Defined resource-specifically per AGENTS.md exact-match rule.
+    """
+
+    GT = "gt"
+    LT = "lt"
+    EQ = "eq"
+    GTE = "gte"
+    LTE = "lte"
+    NE = "ne"
+
+
+class OverrideAction(str, Enum):
+    """Action to apply for a combination override."""
+
+    SKIP = "skip"
+    UNSKIP = "unskip"
+
+
+class RuleCondition(BaseAlbertModel):
+    """A single condition within an exclusion rule.
+
+    References a parameter group or data template, a parameter, a parameter row,
+    and a comparison operator and threshold value.
+    """
+
+    parameter_group_id: str = Field(alias="prgId")
+    """Parameter group or data template ID (format ``PRG...`` or ``DAT...``)."""
+
+    parameter_id: str = Field(alias="prmId")
+    """Parameter ID (format ``PRM...``)."""
+
+    row_id: str | None = Field(default=None, alias="rowId")
+    """Parameter row ID within the workflow (format ``ROW...``)."""
+
+    operator: RuleOperator
+    """Comparison operator used to evaluate this condition."""
+
+    value: str | float | int
+    """Threshold value to compare against."""
+
+    unit_id: str | None = Field(default=None, alias="unitId")
+    """Unit ID for the threshold value (format ``UNI...``)."""
+
+    name: str | None = None
+    """Display name of the parameter."""
+
+
+class ExclusionRule(BaseAlbertModel):
+    """An exclusion rule composed of one or more conditions.
+
+    All conditions within a rule must match (AND) for the rule to trigger.
+    A combination is excluded if any rule matches (OR).
+    """
+
+    id: str | None = None
+    """Server-assigned rule ID (UUID). Assigned when persisted."""
+
+    name: str | None = None
+    """Human-readable label for the rule."""
+
+    conditions: list[RuleCondition] = Field(default_factory=list)
+    """List of conditions that must all be satisfied for this rule to trigger."""
+
+
+class CombinationOverride(BaseAlbertModel):
+    """A manual skip or unskip override for a specific combination condition.
+
+    Keyed by the compound override key (format ``{groupId}#{paramId}#{rowId}-...``),
+    which can be generated using [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key].
+    """
+
+    id: str | None = None
+    """Server-assigned override ID (UUID). Assigned when persisted."""
+
+    key: str
+    """Compound key identifying the parameter-row pair(s) being overridden."""
+
+    action: OverrideAction
+    """Action to apply (``OverrideAction.SKIP`` or ``OverrideAction.UNSKIP``)."""
+
+    is_manual: bool | None = Field(default=None, alias="isManual")
+    """Whether the override was manually added."""
+
+
+class BlockRules(BaseAlbertModel):
+    """Combination rules and overrides for a task block.
+
+    Returned by [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules]
+    and [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules].
+    """
+
+    task_id: str = Field(alias="taskId")
+    """The task ID (format ``TAS...``)."""
+
+    block_id: str = Field(alias="blockId")
+    """The block ID (format ``BLK...``)."""
+
+    rules: list[ExclusionRule] = Field(default_factory=list)
+    """Combination rules configured on this block."""
+
+    overrides: list[CombinationOverride] = Field(default_factory=list)
+    """Combination overrides configured on this block."""
+
+    @model_validator(mode="before")
+    @classmethod
+    def _unwrap_rules(cls, data: Any) -> Any:
+        if isinstance(data, dict):
+            rules = data.get("rules")
+            if isinstance(rules, dict) and "items" in rules:
+                data = dict(data)
+                data["rules"] = rules["items"]
+        return data

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -3,6 +3,9 @@ from pydantic import Field
 from albert.core.base import BaseAlbertModel
 
 
+# TODO: GET /tasks/{id}/blocks/{blockId}/combinations also returns
+# parentWorkflowId on the response envelope (not per item). Expose it
+# if that id is not already available from the task/block read path.
 class IntervalCombinationItem(BaseAlbertModel):
     """One child-workflow interval combination on a task block.
 

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any
+from typing import Any, NamedTuple
 
 from pydantic import Field, model_validator
 
 from albert.core.base import BaseAlbertModel
+from albert.core.shared.identifiers import (
+    DataTemplateId,
+    ParameterGroupId,
+    ParameterId,
+    RowId,
+    UnitId,
+)
+from albert.resources.units import Unit
 from albert.resources.worker_jobs import WorkerJob
 
 
@@ -13,12 +21,18 @@ from albert.resources.worker_jobs import WorkerJob
 # parentWorkflowId on the response envelope (not per item). Expose it
 # if that id is not already available from the task/block read path.
 class IntervalCombinationItem(BaseAlbertModel):
-    """One child-workflow interval combination on a task block.
+    """One child-workflow interval combination on a task block (🧪 Beta).
 
     Returned by
     [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations].
     Use that method rather than any combinations array embedded on a task or block:
     the embedded array is empty once the block has 500 or more combinations.
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
 
     !!! example
         ```python
@@ -71,20 +85,41 @@ class OverrideAction(str, Enum):
     UNSKIP = "unskip"
 
 
+class Condition(NamedTuple):
+    """Specification for a rule condition before resolving workflow-local IDs.
+
+    Used with [`Workflow.build_rule`][albert.resources.workflows.Workflow.build_rule] to specify
+    criteria using parameter names or short names. Can be instantiated as a named tuple or
+    passed as a plain tuple (e.g. ``("Temperature", ">=", 90)``).
+    """
+
+    parameter: str
+    operator: RuleOperator | str
+    value: str | float | int | None = None
+    unit: str | Unit | None = None
+    group: str | None = None
+
+
 class RuleCondition(BaseAlbertModel):
-    """A single condition within an exclusion rule.
+    """A single condition within an exclusion rule (🧪 Beta).
 
     References a parameter group or data template, a parameter, a parameter row,
     and a comparison operator and threshold value.
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
     """
 
-    parameter_group_id: str = Field(alias="prgId")
+    parameter_group_id: ParameterGroupId | DataTemplateId | str = Field(alias="prgId")
     """Parameter group or data template ID (format ``PRG...`` or ``DAT...``)."""
 
-    parameter_id: str = Field(alias="prmId")
+    parameter_id: ParameterId = Field(alias="prmId")
     """Parameter ID (format ``PRM...``)."""
 
-    row_id: str | None = Field(default=None, alias="rowId")
+    row_id: RowId | None = Field(default=None, alias="rowId")
     """Parameter row ID within the workflow (format ``ROW...``)."""
 
     operator: RuleOperator
@@ -93,7 +128,7 @@ class RuleCondition(BaseAlbertModel):
     value: str | float | int | None = Field(default=None, alias="value")
     """Threshold value to compare against."""
 
-    unit_id: str | None = Field(default=None, alias="unitId")
+    unit_id: UnitId | None = Field(default=None, alias="unitId")
     """Unit ID for the threshold value (format ``UNI...``)."""
 
     name: str | None = None
@@ -101,10 +136,16 @@ class RuleCondition(BaseAlbertModel):
 
 
 class ExclusionRule(BaseAlbertModel):
-    """An exclusion rule composed of one or more conditions.
+    """An exclusion rule composed of one or more conditions (🧪 Beta).
 
     All conditions within a rule must match (AND) for the rule to trigger.
     A combination is excluded if any rule matches (OR).
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
     """
 
     id: str | None = None
@@ -122,10 +163,16 @@ Rule = ExclusionRule
 
 
 class CombinationOverride(BaseAlbertModel):
-    """A manual skip or unskip override for a specific combination condition.
+    """A manual skip or unskip override for a specific combination condition (🧪 Beta).
 
     Keyed by the compound override key (format ``{groupId}#{paramId}#{rowId}-...``),
     which can be generated using [`Workflow.get_override_key`][albert.resources.workflows.Workflow.get_override_key].
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
     """
 
     id: str | None = None
@@ -142,10 +189,16 @@ class CombinationOverride(BaseAlbertModel):
 
 
 class BlockRules(BaseAlbertModel):
-    """Combination rules and overrides for a task block.
+    """Combination rules and overrides for a task block (🧪 Beta).
 
     Returned by [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules]
     and [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules].
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
     """
 
     task_id: str = Field(alias="taskId")

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -1,9 +1,12 @@
+from __future__ import annotations
+
 from enum import Enum
 from typing import Any
 
 from pydantic import Field, model_validator
 
 from albert.core.base import BaseAlbertModel
+from albert.resources.worker_jobs import WorkerJob
 
 
 # TODO: GET /tasks/{id}/blocks/{blockId}/combinations also returns
@@ -153,6 +156,9 @@ class BlockRules(BaseAlbertModel):
     overrides: list[CombinationOverride] = Field(default_factory=list)
     """Combination overrides configured on this block."""
 
+    job: WorkerJob | None = Field(default=None, exclude=True)
+    """Background worker job when combinations are regenerated during [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules]."""
+
     @model_validator(mode="before")
     @classmethod
     def _unwrap_rules(cls, data: Any) -> Any:
@@ -225,7 +231,7 @@ class CombinationLeaf(BaseAlbertModel):
 
 
 class IntervalCombinationPayload(BaseAlbertModel):
-    """The combinations payload written to S3 to trigger child workflow generation."""
+    """Payload containing generated combination definitions for a task block."""
 
     combinations: list[CombinationLeaf]
     """The list of combination definitions."""

--- a/src/albert/resources/interval_combinations.py
+++ b/src/albert/resources/interval_combinations.py
@@ -117,6 +117,10 @@ class ExclusionRule(BaseAlbertModel):
     """List of conditions that must all be satisfied for this rule to trigger."""
 
 
+Rule = ExclusionRule
+"""Alias for [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule]."""
+
+
 class CombinationOverride(BaseAlbertModel):
     """A manual skip or unskip override for a specific combination condition.
 

--- a/src/albert/resources/inventory.py
+++ b/src/albert/resources/inventory.py
@@ -568,7 +568,7 @@ class InventorySearchItem(BaseAlbertModel, HydrationMixin[InventoryItem]):
     Search returns these partial records for speed; they carry the fields most useful
     for lookups, counts, and display rather than the full item. Produced by
     [`search`][albert.collections.inventory.InventoryCollection.search]. Because it mixes
-    in [`HydrationMixin`][albert.resources._mixins.HydrationMixin], calling ``hydrate()`` on a
+    in `HydrationMixin`, calling ``hydrate()`` on a
     bound instance fetches the corresponding fully populated [`InventoryItem`][albert.resources.inventory.InventoryItem]."""
 
     id: str = Field(alias="albertId")

--- a/src/albert/resources/property_data.py
+++ b/src/albert/resources/property_data.py
@@ -387,7 +387,7 @@ class BulkPropertyData(BaseAlbertModel):
 
     A simple tabular structure: one [`BulkPropertyDataColumn`][albert.resources.property_data.BulkPropertyDataColumn] per data column,
     each holding that column's values in row order. Construct it directly, or from a
-    [`DataFrame`][albert.resources.property_data.pandas.DataFrame] with [`from_dataframe`][albert.resources.property_data.BulkPropertyData.from_dataframe], then pass it to
+    `pandas.DataFrame` with [`from_dataframe`][albert.resources.property_data.BulkPropertyData.from_dataframe], then pass it to
     [`bulk_load_task_properties`][albert.collections.property_data.PropertyDataCollection.bulk_load_task_properties].
 
     !!! example

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -17,6 +17,7 @@ from albert.core.shared.types import (
 )
 from albert.resources._mixins import HydrationMixin
 from albert.resources.data_templates import DataTemplate
+from albert.resources.interval_combinations import CombinationOverride, ExclusionRule
 from albert.resources.locations import Location
 from albert.resources.projects import Project
 from albert.resources.tagged_base import BaseTaggedResource
@@ -313,6 +314,12 @@ class Block(BaseAlbertModel):
 
     job_state: str | None = Field(default=None, alias="jobState", exclude=True)
     """State of the worker job in [`job_id`][albert.resources.tasks.Block.job_id], or ``None`` when no job is associated. Serialized as ``jobState``."""
+
+    rules: list[ExclusionRule] | None = Field(default=None, exclude=True)
+    """Combination exclusion rules for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during `create_with_combinations`. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
+
+    overrides: list[CombinationOverride] | None = Field(default=None, exclude=True)
+    """Combination overrides for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during `create_with_combinations`. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 
     def model_dump(self, *args, **kwargs):
         # Use default serialization with customized field output.

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -315,6 +315,14 @@ class Block(BaseAlbertModel):
     job_state: str | None = Field(default=None, alias="jobState", exclude=True)
     """State of the worker job in [`job_id`][albert.resources.tasks.Block.job_id], or ``None`` when no job is associated. Serialized as ``jobState``."""
 
+    intervals_start_from: Literal["all", "none"] | None = Field(
+        default=None, alias="intervalsStartFrom"
+    )
+    """Mode controlling combination evaluation on this block's workflow (``"all"`` for exclude mode, ``"none"`` for include mode). Omitted when increased intervals is disabled or when the block has no intervals."""
+
+    combinations_count: int | None = Field(default=None, alias="combinationsCount", exclude=True)
+    """Total number of interval combinations for this block. Read-only from task responses."""
+
     rules: list[ExclusionRule] | None = Field(default=None, exclude=True)
     """Combination exclusion rules for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during `create_with_combinations`. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -308,6 +308,12 @@ class Block(BaseAlbertModel):
     )
     """Read-only internal mapping of parameter quantities consumed by the block."""
 
+    job_id: str | None = Field(default=None, alias="jobId", exclude=True)
+    """The worker job generating this block's child workflows, when one has been posted (format ``JOB...``). Serialized as ``jobId``."""
+
+    job_state: str | None = Field(default=None, alias="jobState", exclude=True)
+    """State of the worker job in [`job_id`][albert.resources.tasks.Block.job_id], or ``None`` when no job is associated. Serialized as ``jobState``."""
+
     def model_dump(self, *args, **kwargs):
         # Use default serialization with customized field output.
         # Workflow and DataTemplate are both lists of length one, which is annoying to

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -324,10 +324,10 @@ class Block(BaseAlbertModel):
     """Total number of interval combinations for this block. Read-only from task responses."""
 
     rules: list[ExclusionRule] | None = Field(default=None, exclude=True)
-    """Combination exclusion rules for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during `create_with_combinations`. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
+    """Combination exclusion rules for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 
     overrides: list[CombinationOverride] | None = Field(default=None, exclude=True)
-    """Combination overrides for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during `create_with_combinations`. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
+    """Combination overrides for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 
     def model_dump(self, *args, **kwargs):
         # Use default serialization with customized field output.

--- a/src/albert/resources/tasks.py
+++ b/src/albert/resources/tasks.py
@@ -318,16 +318,19 @@ class Block(BaseAlbertModel):
     intervals_start_from: Literal["all", "none"] | None = Field(
         default=None, alias="intervalsStartFrom"
     )
-    """Mode controlling combination evaluation on this block's workflow (``"all"`` for exclude mode, ``"none"`` for include mode). Omitted when increased intervals is disabled or when the block has no intervals."""
+    """Baseline mode controlling combination generation on this block's workflow:
+    - Exclude Mode (``"all"``, default): starts with the full Cartesian product (all combinations included). Rules and overrides prune out unwanted variants.
+    - Include Mode (``"none"``): starts with zero combinations (an empty set). Rules and manual overrides selectively pull in combinations, ideal for sparse screening or DoE.
+    Omitted when increased intervals is disabled or when the block has no intervals."""
 
     combinations_count: int | None = Field(default=None, alias="combinationsCount", exclude=True)
     """Total number of interval combinations for this block. Read-only from task responses."""
 
     rules: list[ExclusionRule] | None = Field(default=None, exclude=True)
-    """Combination exclusion rules for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
+    """Combination rules for this block. Conditions within a single rule use AND logic, while multiple rules use OR logic (excluding combinations in Exclude Mode, including in Include Mode). Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 
     overrides: list[CombinationOverride] | None = Field(default=None, exclude=True)
-    """Combination overrides for this block. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
+    """Combination overrides targeting specific variants on this block by parameter values. Supports ``skip`` (exclude) or ``unskip`` (include) actions, and always takes precedence over rules. In Include Mode, set ``is_manual=True`` to cherry-pick combinations. Persisted via [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or during [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]. Always ``None`` on blocks read from task endpoints; use [`get_block_rules`][albert.collections.tasks.TaskCollection.get_block_rules] to read them."""
 
     def model_dump(self, *args, **kwargs):
         # Use default serialization with customized field output.

--- a/src/albert/resources/worker_jobs.py
+++ b/src/albert/resources/worker_jobs.py
@@ -54,6 +54,21 @@ class WorkerJobMetadata(BaseAlbertModel):
     s3_output_key: str | None = Field(default=None, alias="s3OutputKey")
     """The S3 key for the job's output file."""
 
+    albert_id: str | None = Field(default=None, alias="albertId")
+    """The parent Albert ID this job operates on (e.g. a task id for ``createChildWorkflows``). Distinct from [`WorkerJob.albert_id`][albert.resources.worker_jobs.WorkerJob.albert_id], which is the job's own id."""
+
+    block_id: str | None = Field(default=None, alias="blockId")
+    """The block this job is associated with (format ``BLK...``)."""
+
+    s3_url: str | None = Field(default=None, alias="s3Url")
+    """The S3 object key for an uploaded combinations file. Omitted when the job has no file."""
+
+    new_workflow_id: str | None = Field(default=None, alias="newWorkflowId")
+    """The workflow id assigned to the block after this job."""
+
+    old_workflow_id: str | None = Field(default=None, alias="oldWorkflowId")
+    """The workflow id being replaced. Omitted on first-time generation; equal to ``new_workflow_id`` on a rules-only regenerate."""
+
 
 class WorkerJobCreateRequest(BaseAlbertModel):
     """Request payload for creating a new worker job."""

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -365,6 +365,10 @@ class Workflow(BaseResource):
     [`get_interval_id`][albert.resources.workflows.Workflow.get_interval_id] to build the interval ID for a condition, then use it with the
     property_data endpoints to read or write that condition's results.
 
+    To construct rules and combination overrides for Property tasks using parameter names
+    and values, use [`build_rule`][albert.resources.workflows.Workflow.build_rule] and
+    [`build_override`][albert.resources.workflows.Workflow.build_override].
+
     !!! example
         ```python
         from albert import Albert

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -578,10 +578,13 @@ class Workflow(BaseResource):
         parameters and assembles the compound key in the format
         ``"{groupId}#{paramId}#{intervalRowId}-..."``.
 
-        This key is used with [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]
+        This key uniquely identifies an individual combination variant in the Cartesian product
+        space. It is used with [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]
         to skip or unskip specific combinations on a block when calling
         [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or
         creating a task via [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations].
+        Because overrides always take precedence over rules, this enables targeting individual
+        variants regardless of general rule evaluation.
 
         The workflow instance must already be saved on the platform so that interval row IDs
         are assigned. You can obtain a saved workflow from
@@ -854,11 +857,22 @@ class Workflow(BaseResource):
     ) -> ExclusionRule:
         """Build a rule from conditions or parameter criteria (🧪 Beta).
 
-        Convenience builder that constructs a named [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule].
+        Convenience builder that constructs a named [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule]
+        using human-readable parameter names and values rather than internal IDs.
         Supports single-condition rules directly via keyword arguments, or compound
-        rules with multiple conditions (evaluated with AND logic). Depending on the block's
-        ``intervals_start_from`` setting, the rule acts as an exclusion rule (in Exclude Mode
-        ``"all"``) or an inclusion rule (in Include Mode ``"none"``).
+        rules with multiple conditions.
+
+        How Rules Function:
+        - **Conditions**: A condition compares a parameter against a threshold using an
+          operator (``=``, ``!=``, ``>``, ``>=``, ``<``, ``<=``).
+        - **AND logic within a rule**: All conditions specified inside this rule must match
+          for the rule to trigger.
+        - **OR logic across rules**: On a task block, if *any* rule triggers, its outcome applies.
+        - **Starting Baseline (`intervals_start_from`)**:
+          - In Exclude Mode (``"all"``, default): The rule acts as an exclusion rule. Any
+            combination satisfying all conditions is pruned/excluded from the task block.
+          - In Include Mode (``"none"``): The rule acts as an inclusion rule. Combinations
+            satisfying all conditions are kept/included in the task block.
 
         !!! warning "Beta Feature!"
             Increased intervals combination support is currently in beta and behind a platform
@@ -986,9 +1000,23 @@ class Workflow(BaseResource):
     ) -> CombinationOverride:
         """Build a combination override from parameter values (🧪 Beta).
 
-        Matches parameter values to their canonical compound override key using
-        [`get_override_key`][albert.resources.workflows.Workflow.get_override_key] and
-        returns a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride].
+        Constructs a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]
+        targeting a single specific combination variant by its exact parameter values,
+        resolving the compound key automatically via
+        [`get_override_key`][albert.resources.workflows.Workflow.get_override_key].
+
+        How Overrides Function:
+        - **Targeted Combinations**: Overrides target a single, specific combination in the
+          Cartesian product space (e.g. Temperature = 25 and Speed = 500).
+        - **Actions**:
+          - ``action="skip"``: Explicitly excludes the combination from the task.
+          - ``action="unskip"``: Explicitly keeps or forces the inclusion of the combination.
+        - **Override Precedence**: Overrides are evaluated first and always take precedence over
+          rules. For example, an ``"unskip"`` override guarantees a combination is retained even
+          if an exclusion rule would otherwise drop it.
+        - **Manual Cherry-Picking (`is_manual=True`)**: In Include Mode (``intervals_start_from="none"``),
+          setting ``is_manual=True`` designates a manually cherry-picked combination from an
+          otherwise empty baseline.
 
         !!! warning "Beta Feature!"
             Increased intervals combination support is currently in beta and behind a platform

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -18,6 +18,7 @@ from albert.core.shared.models.base import BaseResource, EntityLink
 from albert.core.shared.types import SerializeAsEntityLink
 from albert.exceptions import AlbertException
 from albert.resources._mixins import HydrationMixin
+from albert.resources.interval_combinations import IntervalCombinationItem
 from albert.resources.parameter_groups import ParameterGroup
 from albert.resources.parameters import Parameter, ParameterCategory
 from albert.resources.units import Unit
@@ -395,6 +396,21 @@ class Workflow(BaseResource):
 
     block_mapping: str | None = Field(default=None, alias="blockMapping")
     """Caller-supplied correlation key on workflow bulk create, used to tie each created workflow to a block position (e.g. ``"0"``, ``"1"``). Also hydrated on read when a Workflow is returned in the context of a block."""
+
+    combinations_count: int | None = Field(default=None, alias="combinationsCount", exclude=True)
+    """Number of child-workflow combinations on this workflow when it is a block's FINAL workflow. Always present (including ``0``) on flag-ON reads. The embedded ``combinations`` array is empty at 500 or more; use [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations] to list them."""
+
+    # GET /tasks/{id}/blocks/{blockId} spells this Combinations; POST /tasks/multi and
+    # GET /tasks/multi/{id} spell it Combination. Both keys are permanent. Serialize as
+    # Combination so writes and GET-multi match. Prefer get_block_combinations when the
+    # count is 500 or more: the embedded array is then empty.
+    combinations: list[IntervalCombinationItem] | None = Field(
+        default=None,
+        validation_alias=AliasChoices("Combinations", "Combination"),
+        serialization_alias="Combination",
+        exclude=True,
+    )
+    """Child-workflow combinations embedded on a block's FINAL workflow. Empty at 500 or more combinations. Read ``Combinations`` or ``Combination``; serialized as ``Combination``."""
 
     # post init fields
     _interval_parameters: list[IntervalParameter] = PrivateAttr(default_factory=list)

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from collections.abc import Mapping, Sequence
 from typing import Any
 
-from pydantic import AliasChoices, Field, PrivateAttr, model_validator
+from pydantic import AliasChoices, Field, PrivateAttr, model_validator, validate_call
 
 from albert.core.base import BaseAlbertModel
 from albert.core.shared.enums import SecurityClass, Status
@@ -20,6 +20,7 @@ from albert.exceptions import AlbertException
 from albert.resources._mixins import HydrationMixin
 from albert.resources.interval_combinations import (
     CombinationOverride,
+    Condition,
     ExclusionRule,
     IntervalCombinationItem,
     OverrideAction,
@@ -562,7 +563,7 @@ class Workflow(BaseResource):
         return interval_id
 
     def get_override_key(self, parameter_values: dict[str, Any]) -> str:
-        """Build the compound override key for a set of parameter values.
+        """Build the compound override key for a set of parameter values (🧪 Beta).
 
         Matches each given parameter name and value against the workflow's intervalized
         parameters and assembles the compound key in the format
@@ -582,6 +583,12 @@ class Workflow(BaseResource):
         interval value of ``"25"``. Matching on parameter name checks both the parameter's
         name and short name (case-insensitive). Segments are ordered in the canonical
         order that the parameters appear in the workflow.
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -665,20 +672,27 @@ class Workflow(BaseResource):
             for _, item in matched
         )
 
+    @validate_call
     def build_rule_condition(
         self,
+        *,
         parameter: str,
         operator: RuleOperator | str,
         value: str | float | int | None = None,
-        *,
         unit: str | Unit | None = None,
         group: str | None = None,
     ) -> RuleCondition:
-        """Build a rule condition from a parameter name and value.
+        """Build a rule condition from a parameter name, short name, or ID and value (🧪 Beta).
 
         Resolves the parameter's group ID, parameter ID, row ID, and unit ID from
         this workflow's defined setpoints, avoiding the need to manually lookup
         internal IDs.
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -688,7 +702,7 @@ class Workflow(BaseResource):
             workflow = client.workflows.get_by_id(id="WFL456")
 
             # Simple numeric condition:
-            cond = workflow.build_rule_condition("Temperature", ">=", 90)
+            cond = workflow.build_rule_condition(parameter="Temperature", operator=">=", value=90)
             cond.parameter_group_id
             # 'PRG247776'
             cond.parameter_id
@@ -849,24 +863,31 @@ class Workflow(BaseResource):
             name=matched_sp.name or matched_sp.short_name or parameter,
         )
 
+    @validate_call
     def build_rule(
         self,
-        name: str | None = None,
         *,
-        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
+        name: str | None = None,
+        conditions: Sequence[RuleCondition | Condition | tuple[Any, ...]] | None = None,
         parameter: str | None = None,
         operator: RuleOperator | str | None = None,
         value: str | float | int | None = None,
         unit: str | Unit | None = None,
         group: str | None = None,
     ) -> ExclusionRule:
-        """Build an exclusion or inclusion rule from conditions or parameter criteria.
+        """Build a rule from conditions or parameter criteria (🧪 Beta).
 
         Convenience builder that constructs a named [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule].
         Supports single-condition rules directly via keyword arguments, or compound
         rules with multiple conditions (evaluated with AND logic). Depending on the block's
         ``intervals_start_from`` setting, the rule acts as an exclusion rule (in Exclude Mode
         ``"all"``) or an inclusion rule (in Include Mode ``"none"``).
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -895,10 +916,11 @@ class Workflow(BaseResource):
         ----------
         name : str, optional
             A descriptive label for the rule.
-        conditions : Sequence[RuleCondition or tuple], optional
+        conditions : Sequence[RuleCondition, Condition, or tuple], optional
             A sequence of [`RuleCondition`][albert.resources.interval_combinations.RuleCondition]
-            objects or tuples of arguments (e.g. ``(parameter, operator, value)``) to be
-            evaluated together with AND logic.
+            objects, [`Condition`][albert.resources.interval_combinations.Condition] named tuples,
+            or tuples of arguments (e.g. ``(parameter, operator, value)``) to be evaluated
+            together with AND logic.
         parameter : str, optional
             Parameter name, short name, or ID for a single-condition rule.
         operator : RuleOperator or str, optional
@@ -921,11 +943,6 @@ class Workflow(BaseResource):
             If neither ``conditions`` nor both ``parameter`` and ``operator`` are provided.
         AlbertException
             If any parameter cannot be resolved on the workflow.
-
-        See Also
-        --------
-        build_exclusion_rule : Semantic alias for Exclude Mode.
-        build_inclusion_rule : Semantic alias for Include Mode.
         """
         parsed_conditions: list[RuleCondition] = []
 
@@ -933,22 +950,40 @@ class Workflow(BaseResource):
             for c in conditions:
                 if isinstance(c, RuleCondition):
                     parsed_conditions.append(c)
+                elif isinstance(c, Condition):
+                    parsed_conditions.append(
+                        self.build_rule_condition(
+                            parameter=c.parameter,
+                            operator=c.operator,
+                            value=c.value,
+                            unit=c.unit,
+                            group=c.group,
+                        )
+                    )
                 elif isinstance(c, tuple):
                     if len(c) == 3:
                         p, o, v = c
-                        parsed_conditions.append(self.build_rule_condition(p, o, v))
+                        parsed_conditions.append(
+                            self.build_rule_condition(parameter=p, operator=o, value=v)
+                        )
                     elif len(c) == 4:
                         p, o, v, u = c
-                        parsed_conditions.append(self.build_rule_condition(p, o, v, unit=u))
+                        parsed_conditions.append(
+                            self.build_rule_condition(parameter=p, operator=o, value=v, unit=u)
+                        )
                     elif len(c) == 5:
                         p, o, v, u, g = c
                         parsed_conditions.append(
-                            self.build_rule_condition(p, o, v, unit=u, group=g)
+                            self.build_rule_condition(
+                                parameter=p, operator=o, value=v, unit=u, group=g
+                            )
                         )
                     else:
                         raise ValueError(f"Condition tuple must have 3 to 5 elements, got: {c}")
                 else:
-                    raise TypeError(f"Expected RuleCondition or tuple, got {type(c).__name__}")
+                    raise TypeError(
+                        f"Expected RuleCondition, Condition, or tuple, got {type(c).__name__}"
+                    )
         elif parameter is not None and operator is not None:
             parsed_conditions.append(
                 self.build_rule_condition(
@@ -964,68 +999,25 @@ class Workflow(BaseResource):
 
         return ExclusionRule(name=name, conditions=parsed_conditions)
 
-    def build_exclusion_rule(
-        self,
-        name: str | None = None,
-        *,
-        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
-        parameter: str | None = None,
-        operator: RuleOperator | str | None = None,
-        value: str | float | int | None = None,
-        unit: str | Unit | None = None,
-        group: str | None = None,
-    ) -> ExclusionRule:
-        """Build an exclusion rule for Exclude Mode.
-
-        Semantic alias for [`build_rule`][albert.resources.workflows.Workflow.build_rule].
-        """
-        return self.build_rule(
-            name=name,
-            conditions=conditions,
-            parameter=parameter,
-            operator=operator,
-            value=value,
-            unit=unit,
-            group=group,
-        )
-
-    def build_inclusion_rule(
-        self,
-        name: str | None = None,
-        *,
-        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
-        parameter: str | None = None,
-        operator: RuleOperator | str | None = None,
-        value: str | float | int | None = None,
-        unit: str | Unit | None = None,
-        group: str | None = None,
-    ) -> ExclusionRule:
-        """Build an inclusion rule for Include Mode.
-
-        Semantic alias for [`build_rule`][albert.resources.workflows.Workflow.build_rule].
-        """
-        return self.build_rule(
-            name=name,
-            conditions=conditions,
-            parameter=parameter,
-            operator=operator,
-            value=value,
-            unit=unit,
-            group=group,
-        )
-
+    @validate_call
     def build_override(
         self,
-        parameter_values: dict[str, Any],
         *,
+        parameter_values: dict[str, Any],
         action: OverrideAction | str = OverrideAction.SKIP,
         is_manual: bool | None = None,
     ) -> CombinationOverride:
-        """Build a combination override from parameter values.
+        """Build a combination override from parameter values (🧪 Beta).
 
         Matches parameter values to their canonical compound override key using
         [`get_override_key`][albert.resources.workflows.Workflow.get_override_key] and
         returns a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride].
+
+        !!! warning "Beta Feature!"
+            Increased intervals combination support is currently in beta and behind a platform
+            feature flag. Please do not use in production or without explicit guidance from
+            Albert. You might otherwise have a bad experience. This feature currently falls
+            outside of the Albert support contract, but we'd love your feedback!
 
         !!! example
             ```python
@@ -1036,13 +1028,13 @@ class Workflow(BaseResource):
 
             # Skip a specific combination:
             skip = workflow.build_override(
-                {"Temperature": 25, "Speed": 500},
+                parameter_values={"Temperature": 25, "Speed": 500},
                 action="skip",
             )
 
             # Force-include a combination (in Include Mode):
             unskip = workflow.build_override(
-                {"Temperature": 25, "Speed": 500},
+                parameter_values={"Temperature": 25, "Speed": 500},
                 action="unskip",
                 is_manual=True,
             )

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -37,8 +37,8 @@ class IntervalParameter(BaseAlbertModel):
     interval_id: IntervalId | None = Field(default=None)
     """The row ID of this single interval value (e.g. ``"ROW1"``). These are the building blocks that [`get_interval_id`][albert.resources.workflows.Workflow.get_interval_id] joins with ``X`` to form a composite interval ID."""
 
-    interval_value: str | None = Field(default=None)
-    """The value of this interval, as a string (e.g. ``"25"``)."""
+    interval_value: str | dict[str, Any] | EntityLink | None = Field(default=None)
+    """The value of this interval. A string for Normal parameters (e.g. ``"25"``), or an object with an ``id`` for Special parameters."""
 
     interval_unit: str | None = Field(default=None)
     """The unit name for this interval value, if any (e.g. ``"C"``). See Also --------"""
@@ -51,7 +51,7 @@ class Interval(BaseAlbertModel):
     setpoint), each of those values is represented by an [`Interval`][albert.resources.workflows.Interval]. A list of
     them is placed on the parameter's [`ParameterSetpoint`][albert.resources.workflows.ParameterSetpoint] via its ``intervals``
     field. The workflow then carries the resulting [`IntervalCombination`][albert.resources.workflows.IntervalCombination] entries,
-    one per interval (or per cartesian product of two intervalized parameters).
+    one per interval (or per cartesian product of intervalized parameters).
 
     !!! example
         ```python
@@ -62,11 +62,11 @@ class Interval(BaseAlbertModel):
         high = Interval(value="60", unit={"id": "UNI9999999"})
         ```"""
 
-    value: str | None = Field(default=None)
-    """The value of this interval. For Special parameters (Equipment, Consumables, Templates) this is the entity ID (e.g. ``"INVC191778"``). For Normal parameters this is a plain scalar string (e.g. ``"23"``). Required."""
+    value: str | dict[str, Any] | EntityLink | None = Field(default=None)
+    """The value of this interval. For Normal parameters this is a plain scalar string (e.g. ``"23"``). For Special parameters (Equipment, Consumables, Templates) this may be an object with an ``id`` (and optional ``name``), matching [`ParameterSetpoint.value`][albert.resources.workflows.ParameterSetpoint.value]. Empty intervals (no value) are allowed. The sibling ``name`` field is independent and is not copied from an object value."""
 
     name: str | None = Field(default=None)
-    """The display name of the interval value. Populated for Special parameters (e.g. ``"Pipette 0.01 -0.1 ml (10 - 100 μl)"``). ``None`` for Normal parameters."""
+    """The display name of the interval value. Populated for Special parameters (e.g. ``"Pipette 0.01 -0.1 ml (10 - 100 μl)"``). ``None`` for Normal parameters. Not auto-filled from an object ``value``."""
 
     unit: SerializeAsEntityLink[Unit] | None = Field(default=None, alias="Unit")
     """The unit of ``value``, where applicable. If given, the unit must have an ``id``. See Also --------"""
@@ -75,8 +75,6 @@ class Interval(BaseAlbertModel):
 
     @model_validator(mode="after")
     def validate_interval(self) -> Interval:
-        if not self.value:
-            raise ValueError("Interval: 'value' is required.")
         if self.unit and not getattr(self.unit, "id", None):
             raise ValueError("Interval: 'Unit.id' is required.")
         return self
@@ -100,13 +98,15 @@ class IntervalCombination(BaseAlbertModel):
     """One realized condition (interval combination) carried by a workflow.
 
     Returned by the workflow endpoint when at least one parameter in the workflow has
-    been intervalized. A combination is either a single intervalized parameter (interval
-    ID ``ROW#``) or the cartesian product of two intervalized parameters (interval ID
-    ``ROW#XROW#``). Its ``interval_id`` is what you pass to the property_data endpoints
-    to read or write results for that specific condition."""
+    been intervalized. A combination is a single intervalized parameter (interval ID
+    ``ROW#``) or the cartesian product of any number of intervalized parameters
+    (``ROW#XROW#X...``). On tenants with increased intervals the id may also be a child
+    workflow id (``WFL...``) or a case-sensitive barcode. Its ``interval_id`` is what you
+    pass to the property_data endpoints to read or write results for that specific
+    condition."""
 
     interval_id: IntervalId | None = Field(default=None, alias="interval")
-    """The interval ID this combination is associated with. It has the form ``ROW#`` for a single interval or ``ROW#XROW#`` for a product of two intervals. This is the same value [`get_interval_id`][albert.resources.workflows.Workflow.get_interval_id] returns."""
+    """The interval ID this combination is associated with. A ``ROW#`` chain of any length, a child workflow id (``WFL...``), a 9-character barcode, or ``"default"``. This is the same value [`get_interval_id`][albert.resources.workflows.Workflow.get_interval_id] returns for ROW-chain combinations."""
 
     interval_params: str | None = Field(default=None, alias="intervalParams")
     """The parameters participating in the interval."""
@@ -322,9 +322,9 @@ class Workflow(BaseResource):
     groups; it does not need to be created via
     [`create`][albert.collections.workflows.WorkflowCollection.create].
 
-    When one or two parameters are intervalized, the workflow acts as a *parent* that carries
+    When parameters are intervalized, the workflow acts as a *parent* that carries
     the resulting [`IntervalCombination`][albert.resources.workflows.IntervalCombination] entries. Each combination has an interval ID of
-    the form ``ROW1`` (one intervalized parameter) or ``ROW1XROW2`` (product of two). Use
+    the form ``ROW1`` (one intervalized parameter) or ``ROW1XROW2X...`` (product of several). Use
     [`get_interval_id`][albert.resources.workflows.Workflow.get_interval_id] to build the interval ID for a condition, then use it with the
     property_data endpoints to read or write that condition's results.
 
@@ -394,7 +394,7 @@ class Workflow(BaseResource):
     """The Albert ID of the workflow (``WFL...``). Set when a workflow is created or retrieved from the platform."""
 
     block_mapping: str | None = Field(default=None, alias="blockMapping")
-    """Read-only / informational. When a Workflow is returned in the context of a block, this is hydrated for convenience. See Also --------"""
+    """Caller-supplied correlation key on workflow bulk create, used to tie each created workflow to a block position (e.g. ``"0"``, ``"1"``). Also hydrated on read when a Workflow is returned in the context of a block."""
 
     # post init fields
     _interval_parameters: list[IntervalParameter] = PrivateAttr(default_factory=list)

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -477,6 +477,35 @@ class Workflow(BaseResource):
                         )
         return self
 
+    def _find_interval_parameter(
+        self, param_name: str, param_value: Any
+    ) -> tuple[int, IntervalParameter] | None:
+        """Find an interval parameter entry matching the given name and value."""
+        for idx, workflow_interval in enumerate(self._interval_parameters):
+            name_match = (
+                workflow_interval.interval_param_name
+                and workflow_interval.interval_param_name.lower() == param_name.lower()
+            ) or (
+                workflow_interval.parameter_short_name
+                and workflow_interval.parameter_short_name.lower() == param_name.lower()
+            )
+            if not name_match:
+                continue
+
+            val = workflow_interval.interval_value
+            val_match = False
+            if param_value == val or str(param_value) == str(val):
+                val_match = True
+            elif isinstance(val, dict):
+                if param_value in (val.get("id"), val.get("name")):
+                    val_match = True
+            elif hasattr(val, "id") and param_value == val.id:
+                val_match = True
+
+            if val_match:
+                return idx, workflow_interval
+        return None
+
     def get_interval_id(self, parameter_values: dict[str, Any]) -> str:
         """Build the composite interval ID for a set of parameter values.
 
@@ -526,37 +555,13 @@ class Workflow(BaseResource):
         """
         interval_id = ""
         for param_name, param_value in parameter_values.items():
-            matching_interval = None
-            for workflow_interval in self._interval_parameters:
-                name_match = (
-                    workflow_interval.interval_param_name
-                    and workflow_interval.interval_param_name.lower() == param_name.lower()
-                ) or (
-                    workflow_interval.parameter_short_name
-                    and workflow_interval.parameter_short_name.lower() == param_name.lower()
-                )
-                if not name_match:
-                    continue
-
-                val = workflow_interval.interval_value
-                val_match = False
-                if param_value == val or str(param_value) == str(val):
-                    val_match = True
-                elif isinstance(val, dict):
-                    if param_value in (val.get("id"), val.get("name")):
-                        val_match = True
-                elif hasattr(val, "id") and param_value == val.id:
-                    val_match = True
-
-                if val_match:
-                    matching_interval = workflow_interval
-                    break
-
-            if matching_interval is None:
+            matching_entry = self._find_interval_parameter(param_name, param_value)
+            if matching_entry is None:
                 raise AlbertException(
                     f"No matching interval found for parameter '{param_name}' with value '{param_value}'"
                 )
 
+            _, matching_interval = matching_entry
             interval_id += (
                 f"X{matching_interval.interval_id}"
                 if interval_id != ""
@@ -565,7 +570,8 @@ class Workflow(BaseResource):
 
         return interval_id
 
-    def get_override_key(self, parameter_values: dict[str, Any]) -> str:
+    @validate_call
+    def get_override_key(self, *, parameter_values: dict[str, Any]) -> str:
         """Build the compound override key for a set of parameter values (🧪 Beta).
 
         Matches each given parameter name and value against the workflow's intervalized
@@ -600,7 +606,7 @@ class Workflow(BaseResource):
 
             client = Albert()
             workflow = client.workflows.get_by_id(id="WFL456")
-            key = workflow.get_override_key({"Temperature": 25, "Speed": 500})
+            key = workflow.get_override_key(parameter_values={"Temperature": 25, "Speed": 500})
             # 'PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9'
 
             # Create an override to skip this specific combination:
@@ -628,32 +634,7 @@ class Workflow(BaseResource):
         matched: list[tuple[int, IntervalParameter]] = []
 
         for param_name, param_value in parameter_values.items():
-            matching_entry = None
-            for idx, workflow_interval in enumerate(self._interval_parameters):
-                name_match = (
-                    workflow_interval.interval_param_name
-                    and workflow_interval.interval_param_name.lower() == param_name.lower()
-                ) or (
-                    workflow_interval.parameter_short_name
-                    and workflow_interval.parameter_short_name.lower() == param_name.lower()
-                )
-                if not name_match:
-                    continue
-
-                val = workflow_interval.interval_value
-                val_match = False
-                if param_value == val or str(param_value) == str(val):
-                    val_match = True
-                elif isinstance(val, dict):
-                    if param_value in (val.get("id"), val.get("name")):
-                        val_match = True
-                elif hasattr(val, "id") and param_value == val.id:
-                    val_match = True
-
-                if val_match:
-                    matching_entry = (idx, workflow_interval)
-                    break
-
+            matching_entry = self._find_interval_parameter(param_name, param_value)
             if matching_entry is None:
                 raise AlbertException(
                     f"No matching interval found for parameter '{param_name}' with value '{param_value}'"
@@ -836,25 +817,18 @@ class Workflow(BaseResource):
         # Resolve value representation for Special parameters
         value_resolved = value
         if value is not None:
-            if hasattr(value, "id") and getattr(value, "id", None) is not None:
-                value_resolved = getattr(value, "name", None) or value.id
-            elif isinstance(value, dict):
-                value_resolved = (
-                    value.get("name") or value.get("id") or value.get("value") or str(value)
-                )
-            else:
-                for iv in matched_sp.intervals or []:
-                    if value == iv.value or str(value) == str(iv.value):
-                        break
-                    if isinstance(iv.value, dict) and value in (
-                        iv.value.get("id"),
-                        iv.value.get("name"),
-                    ):
-                        value_resolved = iv.value.get("id") or value
-                        break
-                    if hasattr(iv.value, "id") and value == iv.value.id:
-                        value_resolved = iv.value.id
-                        break
+            for iv in matched_sp.intervals or []:
+                if value == iv.value or str(value) == str(iv.value):
+                    break
+                if isinstance(iv.value, dict) and value in (
+                    iv.value.get("id"),
+                    iv.value.get("name"),
+                ):
+                    value_resolved = iv.value.get("id") or value
+                    break
+                if hasattr(iv.value, "id") and value == iv.value.id:
+                    value_resolved = iv.value.id
+                    break
 
         return RuleCondition(
             parameter_group_id=matched_pg.id,
@@ -1065,7 +1039,7 @@ class Workflow(BaseResource):
         ValueError
             If an invalid action string is provided.
         """
-        key = self.get_override_key(parameter_values)
+        key = self.get_override_key(parameter_values=parameter_values)
         if isinstance(action, str):
             try:
                 parsed_action = OverrideAction(action.lower())

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -81,7 +81,7 @@ class Interval(BaseAlbertModel):
         ```"""
 
     value: str | dict[str, Any] | EntityLink | None = Field(default=None)
-    """The value of this interval. For Normal parameters this is a plain scalar string (e.g. ``"23"``). For Special parameters (Equipment, Consumables, Templates) this may be an object with an ``id`` (and optional ``name``), matching [`ParameterSetpoint.value`][albert.resources.workflows.ParameterSetpoint.value]. Empty intervals (no value) are allowed. The sibling ``name`` field is independent and is not copied from an object value."""
+    """The value of this interval. For Normal parameters this is a scalar string (e.g. ``"23"``). For Special parameters (Equipment, Consumables, Templates) this may be an object with an ``id`` (and optional ``name``), matching [`ParameterSetpoint.value`][albert.resources.workflows.ParameterSetpoint.value]. Empty or hyphen intervals (represented as ``""`` or ``None``) are permitted on the platform for optional parameters and exclusion matching. The sibling ``name`` field is independent and is not copied from an object value."""
 
     name: str | None = Field(default=None)
     """The display name of the interval value. Populated for Special parameters (e.g. ``"Pipette 0.01 -0.1 ml (10 - 100 μl)"``). ``None`` for Normal parameters. Not auto-filled from an object ``value``."""
@@ -441,16 +441,15 @@ class Workflow(BaseResource):
     """Number of child-workflow combinations on this workflow when it is a block's FINAL workflow. Always present (including ``0``) on flag-ON reads. The embedded ``combinations`` array is empty at 500 or more; use [`get_block_combinations`][albert.collections.tasks.TaskCollection.get_block_combinations] to list them."""
 
     # GET /tasks/{id}/blocks/{blockId} spells this Combinations; POST /tasks/multi and
-    # GET /tasks/multi/{id} spell it Combination. Both keys are permanent. Serialize as
-    # Combination so writes and GET-multi match. Prefer get_block_combinations when the
-    # count is 500 or more: the embedded array is then empty.
+    # GET /tasks/multi/{id} spell it Combination. Both keys are permanent. The field is
+    # read-only and excluded from serialization dumps. Prefer get_block_combinations when
+    # the count is 500 or more: the embedded array is then empty.
     combinations: list[IntervalCombinationItem] | None = Field(
         default=None,
         validation_alias=AliasChoices("Combinations", "Combination"),
-        serialization_alias="Combination",
         exclude=True,
     )
-    """Child-workflow combinations embedded on a block's FINAL workflow. Empty at 500 or more combinations. Read ``Combinations`` or ``Combination``; serialized as ``Combination``."""
+    """Child-workflow combinations embedded on a block's FINAL workflow. Read-only; excluded from serialization. Empty at 500 or more combinations."""
 
     # post init fields
     _interval_parameters: list[IntervalParameter] = PrivateAttr(default_factory=list)

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from pydantic import AliasChoices, Field, PrivateAttr, model_validator
@@ -18,7 +18,14 @@ from albert.core.shared.models.base import BaseResource, EntityLink
 from albert.core.shared.types import SerializeAsEntityLink
 from albert.exceptions import AlbertException
 from albert.resources._mixins import HydrationMixin
-from albert.resources.interval_combinations import IntervalCombinationItem
+from albert.resources.interval_combinations import (
+    CombinationOverride,
+    ExclusionRule,
+    IntervalCombinationItem,
+    OverrideAction,
+    RuleCondition,
+    RuleOperator,
+)
 from albert.resources.parameter_groups import ParameterGroup
 from albert.resources.parameters import Parameter, ParameterCategory
 from albert.resources.units import Unit
@@ -300,6 +307,25 @@ class ParameterGroupSetpoints(BaseAlbertModel):
             object.__setattr__(self, "id", self.parameter_group.id)
 
         return self
+
+
+_RULE_OPERATOR_MAP: dict[str, RuleOperator] = {
+    "=": RuleOperator.EQ,
+    "==": RuleOperator.EQ,
+    "eq": RuleOperator.EQ,
+    "!=": RuleOperator.NE,
+    "<>": RuleOperator.NE,
+    "ne": RuleOperator.NE,
+    "neq": RuleOperator.NE,
+    ">": RuleOperator.GT,
+    "gt": RuleOperator.GT,
+    ">=": RuleOperator.GTE,
+    "gte": RuleOperator.GTE,
+    "<": RuleOperator.LT,
+    "lt": RuleOperator.LT,
+    "<=": RuleOperator.LTE,
+    "lte": RuleOperator.LTE,
+}
 
 
 class Workflow(BaseResource):
@@ -638,6 +664,369 @@ class Workflow(BaseResource):
             f"{item.parameter_group_id}#{item.parameter_id}#{item.interval_id}"
             for _, item in matched
         )
+
+    def build_rule_condition(
+        self,
+        parameter: str,
+        operator: RuleOperator | str,
+        value: str | float | int | None = None,
+        *,
+        unit: str | Unit | None = None,
+        group: str | None = None,
+    ) -> RuleCondition:
+        """Build a rule condition from a parameter name and value.
+
+        Resolves the parameter's group ID, parameter ID, row ID, and unit ID from
+        this workflow's defined setpoints, avoiding the need to manually lookup
+        internal IDs.
+
+        !!! example
+            ```python
+            from albert import Albert
+
+            client = Albert()
+            workflow = client.workflows.get_by_id(id="WFL456")
+
+            # Simple numeric condition:
+            cond = workflow.build_rule_condition("Temperature", ">=", 90)
+            cond.parameter_group_id
+            # 'PRG247776'
+            cond.parameter_id
+            # 'PRM100'
+            cond.row_id
+            # 'ROW2'
+            ```
+
+        Parameters
+        ----------
+        parameter : str
+            The name, short name, or parameter ID (case-insensitive) of the parameter.
+        operator : RuleOperator or str
+            The comparison operator. Accepts [`RuleOperator`][albert.resources.interval_combinations.RuleOperator]
+            or string shorthand: ``"="``, ``"=="``, ``"!="``, ``">"``, ``">="``, ``"<"``, ``"<="``.
+        value : str, float, int, optional
+            The threshold value to compare against.
+        unit : str, Unit, optional
+            Optional unit constraint (unit name, symbol, ID, or Unit model). If omitted
+            and the parameter defines a unit, that unit ID is used automatically.
+        group : str, optional
+            Parameter group ID (e.g. ``"PRG..."``) or name to disambiguate if multiple
+            groups in the workflow contain a parameter with the same name.
+
+        Returns
+        -------
+        RuleCondition
+            The fully populated rule condition.
+
+        Raises
+        ------
+        AlbertException
+            If no parameter matches, if multiple parameters match and ``group`` is not
+            specified, or if the workflow has not yet been assigned row IDs.
+        ValueError
+            If an invalid operator string is provided.
+        """
+        # Parse operator
+        if isinstance(operator, RuleOperator):
+            parsed_op = operator
+        elif isinstance(operator, str) and operator.lower() in _RULE_OPERATOR_MAP:
+            parsed_op = _RULE_OPERATOR_MAP[operator.lower()]
+        else:
+            valid = list(_RULE_OPERATOR_MAP.keys())
+            raise ValueError(
+                f"Invalid rule operator {operator!r}. Allowed: {valid} or RuleOperator."
+            )
+
+        # Locate parameter in setpoints
+        matching: list[tuple[ParameterGroupSetpoints, ParameterSetpoint]] = []
+        for pg in self.parameter_group_setpoints or []:
+            if group is not None:
+                group_id_match = pg.id and pg.id.lower() == str(group).lower()
+                group_name_match = (
+                    pg.parameter_group_name
+                    and pg.parameter_group_name.lower() == str(group).lower()
+                )
+                if not (group_id_match or group_name_match):
+                    continue
+
+            for sp in pg.parameter_setpoints or []:
+                name_match = bool(sp.name and sp.name.lower() == parameter.lower())
+                short_name_match = bool(
+                    sp.short_name and sp.short_name.lower() == parameter.lower()
+                )
+                p_id_match = bool(sp.parameter_id and sp.parameter_id.lower() == parameter.lower())
+                if name_match or short_name_match or p_id_match:
+                    matching.append((pg, sp))
+
+        if not matching:
+            msg = f"No parameter matching '{parameter}' found in workflow setpoints"
+            if group:
+                msg += f" for group '{group}'"
+            raise AlbertException(msg + ".")
+
+        if len(matching) > 1:
+            groups_found = [pg.id for pg, _ in matching]
+            raise AlbertException(
+                f"Parameter '{parameter}' is ambiguous (found in multiple parameter groups: {groups_found}). "
+                "Please specify the 'group' argument."
+            )
+
+        matched_pg, matched_sp = matching[0]
+
+        row_id = matched_sp.row_id
+        if not row_id:
+            raise AlbertException(
+                "Workflow has not been assigned row IDs by the platform yet. "
+                "Save the workflow first before building rule conditions."
+            )
+
+        # Resolve unit_id
+        unit_id: str | None = None
+        if unit is not None:
+            if hasattr(unit, "id") and getattr(unit, "id", None):
+                unit_id = str(unit.id)
+            elif isinstance(unit, str):
+                if unit.startswith("UNI"):
+                    unit_id = unit
+                elif matched_sp.unit and (
+                    getattr(matched_sp.unit, "name", None) == unit
+                    or getattr(matched_sp.unit, "symbol", None) == unit
+                    or getattr(matched_sp.unit, "id", None) == unit
+                ):
+                    unit_id = getattr(matched_sp.unit, "id", None)
+                else:
+                    for iv in matched_sp.intervals or []:
+                        if iv.unit and (
+                            iv.unit.name == unit
+                            or getattr(iv.unit, "symbol", None) == unit
+                            or iv.unit.id == unit
+                        ):
+                            unit_id = iv.unit.id
+                            break
+                    if unit_id is None:
+                        unit_id = unit
+        elif matched_sp.unit and getattr(matched_sp.unit, "id", None):
+            unit_id = str(matched_sp.unit.id)
+        else:
+            interval_unit_ids = {
+                iv.unit.id
+                for iv in (matched_sp.intervals or [])
+                if iv.unit and getattr(iv.unit, "id", None)
+            }
+            if len(interval_unit_ids) == 1:
+                unit_id = interval_unit_ids.pop()
+
+        # Resolve value representation for Special parameters
+        value_resolved = value
+        if value is not None:
+            if hasattr(value, "id") and getattr(value, "id", None) is not None:
+                value_resolved = getattr(value, "name", None) or value.id
+            elif isinstance(value, dict):
+                value_resolved = (
+                    value.get("name") or value.get("id") or value.get("value") or str(value)
+                )
+            else:
+                for iv in matched_sp.intervals or []:
+                    if value == iv.value or str(value) == str(iv.value):
+                        break
+                    if isinstance(iv.value, dict) and value in (
+                        iv.value.get("id"),
+                        iv.value.get("name"),
+                    ):
+                        value_resolved = iv.value.get("id") or value
+                        break
+                    if hasattr(iv.value, "id") and value == iv.value.id:
+                        value_resolved = iv.value.id
+                        break
+
+        return RuleCondition(
+            parameter_group_id=matched_pg.id,
+            parameter_id=matched_sp.parameter_id,
+            row_id=row_id,
+            operator=parsed_op,
+            value=value_resolved,
+            unit_id=unit_id,
+            name=matched_sp.name or matched_sp.short_name or parameter,
+        )
+
+    def build_exclusion_rule(
+        self,
+        name: str | None = None,
+        *,
+        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
+        parameter: str | None = None,
+        operator: RuleOperator | str | None = None,
+        value: str | float | int | None = None,
+        unit: str | Unit | None = None,
+        group: str | None = None,
+    ) -> ExclusionRule:
+        """Build an exclusion rule from conditions or parameter criteria.
+
+        Convenience builder that constructs a named [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule].
+        Supports single-condition rules directly via keyword arguments, or compound
+        rules with multiple conditions (evaluated with AND logic).
+
+        !!! example
+            ```python
+            from albert import Albert
+
+            client = Albert()
+            workflow = client.workflows.get_by_id(id="WFL456")
+
+            # 1. Single condition rule:
+            rule1 = workflow.build_exclusion_rule(
+                name="Exclude cold temperatures",
+                parameter="Temperature",
+                operator="<",
+                value=15,
+            )
+
+            # 2. Multi-condition rule (AND):
+            rule2 = workflow.build_exclusion_rule(
+                name="Crosslinking risk",
+                conditions=[
+                    ("Temperature", ">=", 90),
+                    ("Speed", ">=", 1500),
+                ],
+            )
+            ```
+
+        Parameters
+        ----------
+        name : str, optional
+            A descriptive label for the exclusion rule.
+        conditions : Sequence[RuleCondition or tuple], optional
+            A sequence of [`RuleCondition`][albert.resources.interval_combinations.RuleCondition]
+            objects or tuples of arguments (e.g. ``(parameter, operator, value)``) to be
+            evaluated together with AND logic.
+        parameter : str, optional
+            Parameter name, short name, or ID for a single-condition rule.
+        operator : RuleOperator or str, optional
+            Comparison operator for a single-condition rule.
+        value : str, float, int, optional
+            Threshold value for a single-condition rule.
+        unit : str, Unit, optional
+            Optional unit for a single-condition rule.
+        group : str, optional
+            Optional parameter group ID or name for disambiguation.
+
+        Returns
+        -------
+        ExclusionRule
+            The constructed exclusion rule containing the resolved conditions.
+
+        Raises
+        ------
+        ValueError
+            If neither ``conditions`` nor both ``parameter`` and ``operator`` are provided.
+        AlbertException
+            If any parameter cannot be resolved on the workflow.
+        """
+        parsed_conditions: list[RuleCondition] = []
+
+        if conditions is not None:
+            for c in conditions:
+                if isinstance(c, RuleCondition):
+                    parsed_conditions.append(c)
+                elif isinstance(c, tuple):
+                    if len(c) == 3:
+                        p, o, v = c
+                        parsed_conditions.append(self.build_rule_condition(p, o, v))
+                    elif len(c) == 4:
+                        p, o, v, u = c
+                        parsed_conditions.append(self.build_rule_condition(p, o, v, unit=u))
+                    elif len(c) == 5:
+                        p, o, v, u, g = c
+                        parsed_conditions.append(
+                            self.build_rule_condition(p, o, v, unit=u, group=g)
+                        )
+                    else:
+                        raise ValueError(f"Condition tuple must have 3 to 5 elements, got: {c}")
+                else:
+                    raise TypeError(f"Expected RuleCondition or tuple, got {type(c).__name__}")
+        elif parameter is not None and operator is not None:
+            parsed_conditions.append(
+                self.build_rule_condition(
+                    parameter=parameter,
+                    operator=operator,
+                    value=value,
+                    unit=unit,
+                    group=group,
+                )
+            )
+        else:
+            raise ValueError("Provide either 'conditions' or both 'parameter' and 'operator'.")
+
+        return ExclusionRule(name=name, conditions=parsed_conditions)
+
+    def build_override(
+        self,
+        parameter_values: dict[str, Any],
+        *,
+        action: OverrideAction | str = OverrideAction.SKIP,
+        is_manual: bool | None = None,
+    ) -> CombinationOverride:
+        """Build a combination override from parameter values.
+
+        Matches parameter values to their canonical compound override key using
+        [`get_override_key`][albert.resources.workflows.Workflow.get_override_key] and
+        returns a [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride].
+
+        !!! example
+            ```python
+            from albert import Albert
+
+            client = Albert()
+            workflow = client.workflows.get_by_id(id="WFL456")
+
+            # Skip a specific combination:
+            skip = workflow.build_override(
+                {"Temperature": 25, "Speed": 500},
+                action="skip",
+            )
+
+            # Force-include a combination (in Include Mode):
+            unskip = workflow.build_override(
+                {"Temperature": 25, "Speed": 500},
+                action="unskip",
+                is_manual=True,
+            )
+            ```
+
+        Parameters
+        ----------
+        parameter_values : dict[str, Any]
+            Mapping of parameter names (or short names) to their target interval values.
+        action : OverrideAction or str, default OverrideAction.SKIP
+            The action to apply (``"skip"`` or ``"unskip"``, or an
+            [`OverrideAction`][albert.resources.interval_combinations.OverrideAction]).
+        is_manual : bool, optional
+            Whether the override was manually added (used in Include Mode).
+
+        Returns
+        -------
+        CombinationOverride
+            The constructed combination override with the resolved compound key.
+
+        Raises
+        ------
+        AlbertException
+            If any parameter value does not match an interval defined on the workflow.
+        ValueError
+            If an invalid action string is provided.
+        """
+        key = self.get_override_key(parameter_values)
+        if isinstance(action, str):
+            try:
+                parsed_action = OverrideAction(action.lower())
+            except ValueError:
+                raise ValueError(
+                    f"Invalid override action '{action}'. Allowed: 'skip', 'unskip', or OverrideAction"
+                ) from None
+        else:
+            parsed_action = action
+
+        return CombinationOverride(key=key, action=parsed_action, is_manual=is_manual)
 
 
 class WorkflowParameterSet(BaseAlbertModel):

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -42,7 +42,16 @@ class IntervalParameter(BaseAlbertModel):
     """The value of this interval. A string for Normal parameters (e.g. ``"25"``), or an object with an ``id`` for Special parameters."""
 
     interval_unit: str | None = Field(default=None)
-    """The unit name for this interval value, if any (e.g. ``"C"``). See Also --------"""
+    """The unit name for this interval value, if any (e.g. ``"C"``)."""
+
+    parameter_group_id: str | None = Field(default=None)
+    """The parameter group or data template ID (format ``PRG...`` or ``DAT...``)."""
+
+    parameter_id: str | None = Field(default=None)
+    """The parameter ID (format ``PRM...``)."""
+
+    parameter_short_name: str | None = Field(default=None)
+    """The short name of the intervalized parameter."""
 
 
 class Interval(BaseAlbertModel):
@@ -423,13 +432,17 @@ class Workflow(BaseResource):
         for parameter_group_setpoint in self.parameter_group_setpoints:
             for parameter_setpoint in parameter_group_setpoint.parameter_setpoints:
                 if parameter_setpoint.intervals is not None:
+                    param_name = parameter_setpoint.name or parameter_setpoint.short_name
                     for interval in parameter_setpoint.intervals:
                         self._interval_parameters.append(
                             IntervalParameter(
-                                interval_param_name=parameter_setpoint.name,
+                                interval_param_name=param_name,
                                 interval_id=interval.row_id,
                                 interval_value=interval.value,
                                 interval_unit=interval.unit.name if interval.unit else None,
+                                parameter_group_id=parameter_group_setpoint.id,
+                                parameter_id=parameter_setpoint.parameter_id,
+                                parameter_short_name=parameter_setpoint.short_name,
                             )
                         )
         return self
@@ -485,10 +498,27 @@ class Workflow(BaseResource):
         for param_name, param_value in parameter_values.items():
             matching_interval = None
             for workflow_interval in self._interval_parameters:
-                if workflow_interval.interval_param_name.lower() == param_name.lower() and (
-                    param_value == workflow_interval.interval_value
-                    or str(param_value) == workflow_interval.interval_value
-                ):
+                name_match = (
+                    workflow_interval.interval_param_name
+                    and workflow_interval.interval_param_name.lower() == param_name.lower()
+                ) or (
+                    workflow_interval.parameter_short_name
+                    and workflow_interval.parameter_short_name.lower() == param_name.lower()
+                )
+                if not name_match:
+                    continue
+
+                val = workflow_interval.interval_value
+                val_match = False
+                if param_value == val or str(param_value) == str(val):
+                    val_match = True
+                elif isinstance(val, dict):
+                    if param_value in (val.get("id"), val.get("name")):
+                        val_match = True
+                elif hasattr(val, "id") and param_value == val.id:
+                    val_match = True
+
+                if val_match:
                     matching_interval = workflow_interval
                     break
 
@@ -504,6 +534,94 @@ class Workflow(BaseResource):
             )
 
         return interval_id
+
+    def get_override_key(self, parameter_values: dict[str, Any]) -> str:
+        """Build the compound override key for a set of parameter values.
+
+        Matches each given parameter name and value against the workflow's intervalized
+        parameters and assembles the compound key in the format
+        ``"{groupId}#{paramId}#{intervalRowId}-..."``.
+
+        This key is used with [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]
+        to skip or unskip specific combinations on a block.
+
+        Matching on value is case-insensitive to type: ``25`` and ``"25"`` both match an
+        interval value of ``"25"``. Matching on parameter name checks both the parameter's
+        name and short name (case-insensitive). Segments are ordered in the canonical
+        order that the parameters appear in the workflow.
+
+        !!! example
+            ```python
+            workflow.get_override_key({"Temperature": 25, "Speed": 500})
+            # 'PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9'
+            ```
+
+        Parameters
+        ----------
+        parameter_values : dict[str, Any]
+            Mapping of parameter names to their values. Values may be numbers or strings
+            and must match interval values defined on the workflow.
+
+        Returns
+        -------
+        str
+            The compound override key (e.g. ``"PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9"``).
+
+        Raises
+        ------
+        AlbertException
+            If any parameter value does not match a defined interval in the workflow,
+            or if the workflow has not yet been assigned row IDs by the backend.
+        """
+        matched: list[tuple[int, IntervalParameter]] = []
+
+        for param_name, param_value in parameter_values.items():
+            matching_entry = None
+            for idx, workflow_interval in enumerate(self._interval_parameters):
+                name_match = (
+                    workflow_interval.interval_param_name
+                    and workflow_interval.interval_param_name.lower() == param_name.lower()
+                ) or (
+                    workflow_interval.parameter_short_name
+                    and workflow_interval.parameter_short_name.lower() == param_name.lower()
+                )
+                if not name_match:
+                    continue
+
+                val = workflow_interval.interval_value
+                val_match = False
+                if param_value == val or str(param_value) == str(val):
+                    val_match = True
+                elif isinstance(val, dict):
+                    if param_value in (val.get("id"), val.get("name")):
+                        val_match = True
+                elif hasattr(val, "id") and param_value == val.id:
+                    val_match = True
+
+                if val_match:
+                    matching_entry = (idx, workflow_interval)
+                    break
+
+            if matching_entry is None:
+                raise AlbertException(
+                    f"No matching interval found for parameter '{param_name}' with value '{param_value}'"
+                )
+
+            _, item = matching_entry
+            if not item.interval_id:
+                raise AlbertException(
+                    "Workflow has not been assigned interval row IDs by the backend yet. "
+                    "Save the workflow first before building override keys."
+                )
+
+            matched.append(matching_entry)
+
+        # Canonical ordering: sort by position in workflow sequence
+        matched.sort(key=lambda x: x[0])
+        return "-".join(
+            f"{item.parameter_group_id}#{item.parameter_id}#{item.interval_id}"
+            for _, item in matched
+        )
 
 
 class WorkflowParameterSet(BaseAlbertModel):

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -849,7 +849,7 @@ class Workflow(BaseResource):
             name=matched_sp.name or matched_sp.short_name or parameter,
         )
 
-    def build_exclusion_rule(
+    def build_rule(
         self,
         name: str | None = None,
         *,
@@ -860,11 +860,13 @@ class Workflow(BaseResource):
         unit: str | Unit | None = None,
         group: str | None = None,
     ) -> ExclusionRule:
-        """Build an exclusion rule from conditions or parameter criteria.
+        """Build an exclusion or inclusion rule from conditions or parameter criteria.
 
         Convenience builder that constructs a named [`ExclusionRule`][albert.resources.interval_combinations.ExclusionRule].
         Supports single-condition rules directly via keyword arguments, or compound
-        rules with multiple conditions (evaluated with AND logic).
+        rules with multiple conditions (evaluated with AND logic). Depending on the block's
+        ``intervals_start_from`` setting, the rule acts as an exclusion rule (in Exclude Mode
+        ``"all"``) or an inclusion rule (in Include Mode ``"none"``).
 
         !!! example
             ```python
@@ -874,15 +876,13 @@ class Workflow(BaseResource):
             workflow = client.workflows.get_by_id(id="WFL456")
 
             # 1. Single condition rule:
-            rule1 = workflow.build_exclusion_rule(
+            rule1 = workflow.build_rule(
                 name="Exclude cold temperatures",
-                parameter="Temperature",
-                operator="<",
-                value=15,
+                conditions=[("Temperature", "<", 15)],
             )
 
-            # 2. Multi-condition rule (AND):
-            rule2 = workflow.build_exclusion_rule(
+            # 2. Multi-condition rule (AND logic):
+            rule2 = workflow.build_rule(
                 name="Crosslinking risk",
                 conditions=[
                     ("Temperature", ">=", 90),
@@ -894,7 +894,7 @@ class Workflow(BaseResource):
         Parameters
         ----------
         name : str, optional
-            A descriptive label for the exclusion rule.
+            A descriptive label for the rule.
         conditions : Sequence[RuleCondition or tuple], optional
             A sequence of [`RuleCondition`][albert.resources.interval_combinations.RuleCondition]
             objects or tuples of arguments (e.g. ``(parameter, operator, value)``) to be
@@ -913,7 +913,7 @@ class Workflow(BaseResource):
         Returns
         -------
         ExclusionRule
-            The constructed exclusion rule containing the resolved conditions.
+            The constructed rule containing the resolved conditions.
 
         Raises
         ------
@@ -921,6 +921,11 @@ class Workflow(BaseResource):
             If neither ``conditions`` nor both ``parameter`` and ``operator`` are provided.
         AlbertException
             If any parameter cannot be resolved on the workflow.
+
+        See Also
+        --------
+        build_exclusion_rule : Semantic alias for Exclude Mode.
+        build_inclusion_rule : Semantic alias for Include Mode.
         """
         parsed_conditions: list[RuleCondition] = []
 
@@ -958,6 +963,56 @@ class Workflow(BaseResource):
             raise ValueError("Provide either 'conditions' or both 'parameter' and 'operator'.")
 
         return ExclusionRule(name=name, conditions=parsed_conditions)
+
+    def build_exclusion_rule(
+        self,
+        name: str | None = None,
+        *,
+        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
+        parameter: str | None = None,
+        operator: RuleOperator | str | None = None,
+        value: str | float | int | None = None,
+        unit: str | Unit | None = None,
+        group: str | None = None,
+    ) -> ExclusionRule:
+        """Build an exclusion rule for Exclude Mode.
+
+        Semantic alias for [`build_rule`][albert.resources.workflows.Workflow.build_rule].
+        """
+        return self.build_rule(
+            name=name,
+            conditions=conditions,
+            parameter=parameter,
+            operator=operator,
+            value=value,
+            unit=unit,
+            group=group,
+        )
+
+    def build_inclusion_rule(
+        self,
+        name: str | None = None,
+        *,
+        conditions: Sequence[RuleCondition | tuple[Any, ...]] | None = None,
+        parameter: str | None = None,
+        operator: RuleOperator | str | None = None,
+        value: str | float | int | None = None,
+        unit: str | Unit | None = None,
+        group: str | None = None,
+    ) -> ExclusionRule:
+        """Build an inclusion rule for Include Mode.
+
+        Semantic alias for [`build_rule`][albert.resources.workflows.Workflow.build_rule].
+        """
+        return self.build_rule(
+            name=name,
+            conditions=conditions,
+            parameter=parameter,
+            operator=operator,
+            value=value,
+            unit=unit,
+            group=group,
+        )
 
     def build_override(
         self,

--- a/src/albert/resources/workflows.py
+++ b/src/albert/resources/workflows.py
@@ -543,7 +543,14 @@ class Workflow(BaseResource):
         ``"{groupId}#{paramId}#{intervalRowId}-..."``.
 
         This key is used with [`CombinationOverride`][albert.resources.interval_combinations.CombinationOverride]
-        to skip or unskip specific combinations on a block.
+        to skip or unskip specific combinations on a block when calling
+        [`set_block_rules`][albert.collections.tasks.TaskCollection.set_block_rules] or
+        creating a task via [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations].
+
+        The workflow instance must already be saved on the platform so that interval row IDs
+        are assigned. You can obtain a saved workflow from
+        [`client.workflows.get_by_id`][albert.collections.workflows.WorkflowCollection.get_by_id]
+        or from a fetched task block's workflow.
 
         Matching on value is case-insensitive to type: ``25`` and ``"25"`` both match an
         interval value of ``"25"``. Matching on parameter name checks both the parameter's
@@ -552,15 +559,24 @@ class Workflow(BaseResource):
 
         !!! example
             ```python
-            workflow.get_override_key({"Temperature": 25, "Speed": 500})
+            from albert import Albert
+            from albert.resources.interval_combinations import CombinationOverride, OverrideAction
+
+            client = Albert()
+            workflow = client.workflows.get_by_id(id="WFL456")
+            key = workflow.get_override_key({"Temperature": 25, "Speed": 500})
             # 'PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9'
+
+            # Create an override to skip this specific combination:
+            override = CombinationOverride(key=key, action=OverrideAction.SKIP)
             ```
 
         Parameters
         ----------
         parameter_values : dict[str, Any]
-            Mapping of parameter names to their values. Values may be numbers or strings
-            and must match interval values defined on the workflow.
+            Mapping of parameter names (or short names) to their target interval values.
+            Values may be numbers or strings and must match interval setpoint values
+            defined on the workflow.
 
         Returns
         -------
@@ -571,7 +587,7 @@ class Workflow(BaseResource):
         ------
         AlbertException
             If any parameter value does not match a defined interval in the workflow,
-            or if the workflow has not yet been assigned row IDs by the backend.
+            or if the workflow has not yet been assigned row IDs by the platform.
         """
         matched: list[tuple[int, IntervalParameter]] = []
 

--- a/src/albert/utils/data_template.py
+++ b/src/albert/utils/data_template.py
@@ -6,11 +6,8 @@ import uuid
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from tenacity import retry, stop_after_attempt, wait_exponential
-
 from albert.collections.attachments import AttachmentCollection
 from albert.collections.files import FileCollection
-from albert.core.logging import logger
 from albert.core.shared.identifiers import AttachmentId, DataColumnId, DataTemplateId
 from albert.core.shared.models.patch import (
     GeneralPatchDatum,
@@ -28,7 +25,6 @@ from albert.resources.parameter_groups import (
 )
 from albert.resources.tasks import CsvCurveInput, CsvCurveResponse, TaskMetadata
 from albert.resources.worker_jobs import (
-    WORKER_JOB_PENDING_STATES,
     WorkerJob,
     WorkerJobCreateRequest,
     WorkerJobMetadata,
@@ -42,6 +38,7 @@ from albert.utils.tasks import (
     map_csv_headers_to_columns,
     resolve_attachment,
 )
+from albert.utils.worker_jobs import poll_worker_job
 
 if TYPE_CHECKING:
     from albert.core.session import AlbertSession
@@ -415,35 +412,15 @@ def create_curve_import_job(
     if not job_id:
         raise ValueError("Worker job creation did not return an identifier.")
 
-    class _WorkerJobPending(Exception):
-        """Internal sentinel exception indicating the worker job is still running."""
-
-    @retry(
-        stop=stop_after_attempt(_CURVE_JOB_MAX_ATTEMPTS),
-        wait=wait_exponential(min=_CURVE_JOB_POLL_INTERVAL, max=_CURVE_JOB_MAX_WAIT),
-        reraise=True,
+    worker_job = poll_worker_job(
+        session=session,
+        job_id=job_id,
+        max_attempts=_CURVE_JOB_MAX_ATTEMPTS,
+        poll_interval=_CURVE_JOB_POLL_INTERVAL,
+        max_wait=_CURVE_JOB_MAX_WAIT,
+        raise_on_failure=False,
+        job_description=f"Curve data import for template {data_template_id} column {column_id}",
     )
-    def _poll_worker_job() -> WorkerJob:
-        """Poll a worker job status for completion."""
-        status_response = session.get(f"/api/v3/worker-jobs/{job_id}")
-        current_job = WorkerJob.model_validate(status_response.json())
-        state = current_job.state
-
-        if state in WORKER_JOB_PENDING_STATES:
-            logger.info(
-                "Curve data import in progress for template %s column %s",
-                data_template_id,
-                column_id,
-            )
-            raise _WorkerJobPending()
-        return current_job
-
-    try:
-        worker_job = _poll_worker_job()
-    except _WorkerJobPending as exc:
-        raise TimeoutError(
-            f"Worker job {job_id} did not complete within the retry window."
-        ) from exc
 
     is_success = worker_job.state == WorkerJobState.SUCCESSFUL
     if not is_success:

--- a/src/albert/utils/interval_combinations.py
+++ b/src/albert/utils/interval_combinations.py
@@ -142,7 +142,7 @@ def condition_matches_param(
 
     Implements the exact matching semantics from the frontend engine:
     - row ID must match if condition specifies a row ID.
-    - If condition does not specify row ID, parameter ID and group ID are checked.
+    - If condition does not specify row ID, parameter ID is checked.
     - Unit mismatch trivially satisfies ``ne`` (different unit means not equal).
     - Unit mismatch fails all other comparison operators.
     - Ordered comparisons (``gt``, ``gte``, ``lt``, ``lte``) require both sides to be numeric.

--- a/src/albert/utils/interval_combinations.py
+++ b/src/albert/utils/interval_combinations.py
@@ -276,7 +276,7 @@ def generate_interval_combinations(
     overrides: list[CombinationOverride] | None = None,
     intervals_start_from: Literal["all", "none"] = "all",
 ) -> IntervalCombinationPayload:
-    """Calculate interval combinations from a workflow and evaluate rules and overrides.
+    """Calculate interval combinations from a workflow and evaluate rules and overrides (🧪 Beta).
 
     Pure, session-free computation engine that calculates the active set of combinations:
     1. Expands parameter intervals into the full cartesian product.
@@ -293,6 +293,12 @@ def generate_interval_combinations(
     [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]
     and [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations],
     and can also be called directly to simulate or preview combinations locally.
+
+    !!! warning "Beta Feature!"
+        Increased intervals combination support is currently in beta and behind a platform
+        feature flag. Please do not use in production or without explicit guidance from
+        Albert. You might otherwise have a bad experience. This feature currently falls
+        outside of the Albert support contract, but we'd love your feedback!
 
     !!! example
         ```python

--- a/src/albert/utils/interval_combinations.py
+++ b/src/albert/utils/interval_combinations.py
@@ -1,0 +1,562 @@
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, Literal
+
+from albert.exceptions import AlbertException
+from albert.resources.interval_combinations import (
+    CombinationLeaf,
+    CombinationOverride,
+    CombinationParameter,
+    CombinationParameterGroup,
+    ExclusionRule,
+    IntervalCombinationPayload,
+    RuleCondition,
+)
+from albert.resources.workflows import ParameterGroupSetpoints, Workflow
+
+MAX_RESULTS = 2000
+
+
+def _to_number(val: Any) -> float | None:
+    """Parse a value into a float using JavaScript Number() coercion semantics.
+
+    Returns None for values that would coerce to NaN or are empty/invalid.
+    Specifically matches the JavaScript frontend coercion table:
+    - "0x10" -> 16.0
+    - "1_0" -> None (Python float allows underscores, JS Number() returns NaN)
+    - "0b11" -> 3.0
+    - "" -> None (guarded out before conversion)
+    - "Infinity" -> inf
+    - "-Infinity" -> -inf
+    """
+    if val is None:
+        return None
+
+    if isinstance(val, bool):
+        return None
+
+    if isinstance(val, (int, float)):
+        if math.isnan(val):
+            return None
+        return float(val)
+
+    if isinstance(val, str):
+        s = val.strip()
+        if not s:
+            return None
+        if "_" in s:
+            # JavaScript Number() does not accept numeric underscores
+            return None
+        if s.lower() == "nan":
+            return None
+        if s in ("Infinity", "+Infinity"):
+            return float("inf")
+        if s == "-Infinity":
+            return float("-inf")
+        if s.startswith(("0x", "0X")):
+            try:
+                return float(int(s, 16))
+            except ValueError:
+                return None
+        if s.startswith(("0b", "0B")):
+            try:
+                return float(int(s, 2))
+            except ValueError:
+                return None
+        if s.startswith(("0o", "0O")):
+            try:
+                return float(int(s, 8))
+            except ValueError:
+                return None
+        try:
+            return float(s)
+        except ValueError:
+            return None
+
+    return None
+
+
+def _to_str(val: Any) -> str:
+    """Extract a normalized string value from a raw parameter or condition value."""
+    if val is None:
+        return ""
+    if isinstance(val, dict):
+        if "value" in val and val["value"] is not None:
+            return str(val["value"])
+        if "id" in val and val["id"] is not None:
+            return str(val["id"])
+        if "name" in val and val["name"] is not None:
+            return str(val["name"])
+        return str(val)
+    if hasattr(val, "id") and getattr(val, "id", None) is not None:
+        return str(val.id)
+    return str(val)
+
+
+def _get_unit_id(unit: Any) -> str:
+    """Extract unit ID string from an entity link, dict, or string."""
+    if not unit:
+        return ""
+    if isinstance(unit, dict):
+        return str(unit.get("id") or "")
+    if hasattr(unit, "id") and getattr(unit, "id", None) is not None:
+        return str(unit.id)
+    return str(unit)
+
+
+def override_key_to_interval_row_key(key: str) -> str:
+    """Convert a compound override key to the legacy interval row key format.
+
+    Extracts the interval row ID from each segment of a compound key and joins
+    them with ``"X"``.
+
+    !!! example
+        ```python
+        override_key_to_interval_row_key("PRG1#PRM100#ROW4-PRG1#PRM200#ROW9")
+        # 'ROW4XROW9'
+        ```
+
+    Parameters
+    ----------
+    key : str
+        The compound override key (format ``"{groupId}#{paramId}#{rowId}-..."``).
+
+    Returns
+    -------
+    str
+        The legacy interval row key (format ``"ROW#XROW#..."``).
+    """
+    segments = key.split("-")
+    row_ids = [seg.split("#")[-1] for seg in segments if "#" in seg]
+    return "X".join(row_ids)
+
+
+def condition_matches_param(
+    param: CombinationParameter | dict[str, Any],
+    cond: RuleCondition,
+) -> bool:
+    """Evaluate whether a single rule condition matches a combination parameter.
+
+    Implements the exact matching semantics from the frontend engine:
+    - row ID must match if condition specifies a row ID.
+    - If condition does not specify row ID, parameter ID and group ID are checked.
+    - Unit mismatch trivially satisfies ``ne`` (different unit means not equal).
+    - Unit mismatch fails all other comparison operators.
+    - Ordered comparisons (``gt``, ``gte``, ``lt``, ``lte``) require both sides to be numeric.
+    - Empty condition values match empty parameter values for ``eq`` / ``ne``.
+    """
+    prm_id = param.id if isinstance(param, CombinationParameter) else str(param.get("id", ""))
+    prm_row_id = (
+        param.row_id if isinstance(param, CombinationParameter) else str(param.get("rowId", ""))
+    )
+    prm_val = param.value if isinstance(param, CombinationParameter) else param.get("value")
+    prm_unit = param.unit if isinstance(param, CombinationParameter) else param.get("Unit")
+
+    # Match parameter identity
+    if (
+        cond.row_id
+        and prm_row_id != cond.row_id
+        or not cond.row_id
+        and cond.parameter_id
+        and prm_id != cond.parameter_id
+    ):
+        return False
+
+    op_val = cond.operator.value if isinstance(cond.operator, Enum) else str(cond.operator).lower()
+
+    is_cond_empty = cond.value in (None, "")
+    is_prm_empty = prm_val in (None, "")
+
+    prm_unit_id = _get_unit_id(prm_unit)
+    cond_unit_id = str(cond.unit_id) if cond.unit_id else ""
+    has_unit_constraint = bool(cond.unit_id and not is_prm_empty and not is_cond_empty)
+    unit_mismatch = has_unit_constraint and (prm_unit_id != cond_unit_id)
+
+    # A unit mismatch trivially satisfies 'ne'
+    if op_val == "ne" and unit_mismatch:
+        return True
+
+    # Empty condition value handling
+    if is_cond_empty:
+        unit_matches = not cond.unit_id or (prm_unit_id == cond_unit_id)
+        if op_val == "eq":
+            return is_prm_empty and unit_matches
+        if op_val == "ne":
+            if cond.unit_id:
+                return not (is_prm_empty and unit_matches)
+            return not is_prm_empty
+        return False
+
+    # Non-empty condition vs empty parameter
+    if is_prm_empty:
+        if op_val == "ne":
+            unit_matches = not cond.unit_id or (prm_unit_id == cond_unit_id)
+            return unit_matches
+        return False
+
+    # Normal comparison: non-empty condition and non-empty parameter
+    prm_str = _to_str(prm_val)
+    cond_str = _to_str(cond.value)
+
+    prm_num = _to_number(prm_str)
+    cond_num = _to_number(cond_str)
+    both_numeric = prm_num is not None and cond_num is not None
+
+    matched = False
+    if op_val == "eq":
+        matched = prm_num == cond_num if both_numeric else prm_str == cond_str
+    elif op_val == "ne":
+        matched = prm_num != cond_num if both_numeric else prm_str != cond_str
+    elif op_val == "gt":
+        matched = both_numeric and prm_num > cond_num
+    elif op_val == "gte":
+        matched = both_numeric and prm_num >= cond_num
+    elif op_val == "lt":
+        matched = both_numeric and prm_num < cond_num
+    elif op_val == "lte":
+        matched = both_numeric and prm_num <= cond_num
+
+    if not matched:
+        return False
+    return not unit_mismatch
+
+
+def rule_matches_leaf(leaf: CombinationLeaf, rule: ExclusionRule) -> bool:
+    """Evaluate whether all conditions in a rule match any parameter in the leaf (AND)."""
+    if not rule.conditions:
+        return False
+
+    # Flatten all parameters in the leaf
+    all_params: list[CombinationParameter] = []
+    for group in leaf.parameter_groups:
+        all_params.extend(group.parameters)
+
+    for cond in rule.conditions:
+        condition_met = any(condition_matches_param(p, cond) for p in all_params)
+        if not condition_met:
+            return False
+
+    return True
+
+
+def combination_to_override_key(leaf: CombinationLeaf) -> str:
+    """Build the compound override key for a realized combination leaf."""
+    segments: list[str] = []
+    for group in leaf.parameter_groups:
+        for p in group.parameters:
+            if p.is_interval and p.interval_row_id:
+                segments.append(f"{group.id}#{p.id}#{p.interval_row_id}")
+    return "-".join(segments)
+
+
+def _get_field(obj: Any, attr: str, alias: str | None = None, default: Any = None) -> Any:
+    """Safely get a field from a model or dict by attribute name or alias."""
+    if hasattr(obj, attr):
+        val = getattr(obj, attr)
+        if val is not None:
+            return val
+    if alias and hasattr(obj, alias):
+        val = getattr(obj, alias)
+        if val is not None:
+            return val
+    if isinstance(obj, dict):
+        if attr in obj and obj[attr] is not None:
+            return obj[attr]
+        if alias and alias in obj and obj[alias] is not None:
+            return obj[alias]
+    return default
+
+
+def generate_interval_combinations(
+    workflow: Workflow | Sequence[ParameterGroupSetpoints] | list[dict[str, Any]],
+    rules: list[ExclusionRule] | None = None,
+    overrides: list[CombinationOverride] | None = None,
+    intervals_start_from: Literal["all", "none"] = "all",
+) -> IntervalCombinationPayload:
+    """Evaluate combination rules and overrides to generate S3 combination definitions.
+
+    Pure, session-free computation engine matching the frontend StreamUltraEngine:
+    1. Expands parameter intervals into the cartesian product.
+    2. Builds canonical compound override keys.
+    3. Evaluates direct overrides (``skip`` / ``unskip``).
+    4. Evaluates exclusion / inclusion rules depending on ``intervals_start_from``.
+    5. Validates the 2,000 combinations hard cap.
+
+    Parameters
+    ----------
+    workflow : Workflow or Sequence[ParameterGroupSetpoints] or list[dict]
+        The parent workflow or parameter group setpoints containing intervals.
+    rules : list[ExclusionRule], optional
+        The combination exclusion/inclusion rules to evaluate.
+    overrides : list[CombinationOverride], optional
+        The combination overrides (skip/unskip) to apply.
+    intervals_start_from : {"all", "none"}, default "all"
+        The evaluation mode: ``"all"`` (exclude mode) or ``"none"`` (include mode).
+
+    Returns
+    -------
+    IntervalCombinationPayload
+        The combinations payload ready for S3 upload.
+
+    Raises
+    ------
+    AlbertException
+        If the resulting combinations exceed 2,000 or if row IDs are unassigned.
+    """
+    raw_groups: list[Any]
+    if isinstance(workflow, Workflow):
+        raw_groups = workflow.parameter_group_setpoints or []
+    elif isinstance(workflow, Sequence):
+        raw_groups = list(workflow)
+    else:
+        raw_groups = []
+
+    if not raw_groups:
+        return IntervalCombinationPayload(combinations=[])
+
+    # Check whether ANY parameter has intervals
+    has_any_intervals = False
+    for group in raw_groups:
+        setpoints = _get_field(group, "parameter_setpoints", alias="Parameters", default=[])
+        for sp in setpoints:
+            ivs = _get_field(sp, "intervals", alias="Intervals", default=[])
+            if ivs and len(ivs) > 0:
+                has_any_intervals = True
+                break
+        if has_any_intervals:
+            break
+
+    if not has_any_intervals:
+        # A block with no intervals has no combinations to generate via worker file
+        return IntervalCombinationPayload(combinations=[])
+
+    # Pre-parse overrides into skip and unskip lookup sets
+    skip_set: set[str] = set()
+    unskip_set: set[str] = set()
+    for ov in overrides or []:
+        action = ov.action.value if isinstance(ov.action, Enum) else str(ov.action).lower()
+        if action == "skip":
+            skip_set.add(ov.key)
+        elif action == "unskip":
+            unskip_set.add(ov.key)
+
+    rules_list = rules or []
+
+    # Step 1: Expand each group into variants
+    expanded_groups: list[list[CombinationParameterGroup]] = []
+
+    for group in raw_groups:
+        grp_id = str(_get_field(group, "id", default=""))
+        grp_seq = _get_field(group, "sequence", alias="prgSequence")
+        grp_row_id = str(_get_field(group, "row_id", alias="rowId", default="ROW1"))
+
+        raw_setpoints = _get_field(group, "parameter_setpoints", alias="Parameters", default=[])
+
+        variable_params = []
+        for sp in raw_setpoints:
+            ivs = _get_field(sp, "intervals", alias="Intervals", default=[])
+            if ivs and len(ivs) > 0:
+                variable_params.append(sp)
+
+        if not variable_params:
+            # Fixed group: 1 variant with fixed parameters
+            fixed_params: list[CombinationParameter] = []
+            for sp in raw_setpoints:
+                p_id = str(_get_field(sp, "parameter_id", default=""))
+                p_row_id = str(_get_field(sp, "row_id", alias="rowId", default="ROW1"))
+                p_seq = _get_field(sp, "sequence", alias="prgPrmRowId")
+                p_cat_raw = _get_field(sp, "category", default="Normal")
+                p_cat = (
+                    p_cat_raw.value if isinstance(p_cat_raw, Enum) else str(p_cat_raw or "Normal")
+                )
+                p_short_name = _get_field(sp, "short_name", alias="shortName")
+                p_name = _get_field(sp, "name") or p_short_name or p_id
+                p_val = _get_field(sp, "value")
+                p_unit = _extract_unit_dict(sp)
+
+                fixed_params.append(
+                    CombinationParameter(
+                        id=p_id,
+                        prg_prm_row_id=p_seq,
+                        row_id=p_row_id,
+                        category=p_cat,
+                        short_name=p_short_name,
+                        required=False,
+                        interval_row_id=None,
+                        name=str(p_name),
+                        value=p_val,
+                        unit=p_unit,
+                        is_interval=False,
+                    )
+                )
+
+            expanded_groups.append(
+                [
+                    CombinationParameterGroup(
+                        id=grp_id,
+                        prg_sequence=grp_seq,
+                        row_id=grp_row_id,
+                        parameters=fixed_params,
+                    )
+                ]
+            )
+            continue
+
+        # Fold variable parameters (last variable parameter varies fastest)
+        combos: list[dict[str, Any]] = [{}]
+        for sp in variable_params:
+            sp_row_id = str(_get_field(sp, "row_id", alias="rowId", default="ROW1"))
+            sp_ivs = _get_field(sp, "intervals", alias="Intervals", default=[])
+            next_combos: list[dict[str, Any]] = []
+            for base in combos:
+                for iv in sp_ivs:
+                    iv_val = _get_field(iv, "value")
+                    iv_row_id = _get_field(iv, "row_id", alias="rowId")
+                    if not iv_row_id:
+                        raise AlbertException(
+                            "Workflow has not been assigned interval row IDs by the backend yet. "
+                            "Save the workflow first before generating combinations."
+                        )
+                    iv_unit = _extract_unit_dict(iv)
+                    iv_name = _get_field(iv, "name", default="")
+
+                    new_combo = dict(base)
+                    new_combo[sp_row_id] = {
+                        "value": iv_val,
+                        "interval_row_id": str(iv_row_id),
+                        "unit": iv_unit,
+                        "name": iv_name or "",
+                    }
+                    next_combos.append(new_combo)
+            combos = next_combos
+
+        variable_row_ids = {
+            str(_get_field(sp, "row_id", alias="rowId", default="ROW1")) for sp in variable_params
+        }
+
+        # Build variants for this group
+        group_variants: list[CombinationParameterGroup] = []
+        for sel in combos:
+            params_list: list[CombinationParameter] = []
+            for sp in raw_setpoints:
+                sp_p_id = str(_get_field(sp, "parameter_id", default=""))
+                sp_row_id = str(_get_field(sp, "row_id", alias="rowId", default="ROW1"))
+                sp_seq = _get_field(sp, "sequence", alias="prgPrmRowId")
+                sp_cat_raw = _get_field(sp, "category", default="Normal")
+                sp_cat = (
+                    p_cat_raw.value
+                    if isinstance(sp_cat_raw, Enum)
+                    else str(sp_cat_raw or "Normal")
+                )
+                sp_short_name = _get_field(sp, "short_name", alias="shortName")
+                sp_name = _get_field(sp, "name") or sp_short_name or sp_p_id
+
+                is_var = sp_row_id in variable_row_ids
+                if is_var:
+                    selected = sel[sp_row_id]
+                    p_val = selected["value"]
+                    p_unit = selected["unit"] or _extract_unit_dict(sp)
+                    p_iv_row_id = selected["interval_row_id"]
+                    is_interval = True
+                else:
+                    p_val = _get_field(sp, "value")
+                    p_unit = _extract_unit_dict(sp)
+                    p_iv_row_id = None
+                    is_interval = False
+
+                params_list.append(
+                    CombinationParameter(
+                        id=sp_p_id,
+                        prg_prm_row_id=sp_seq,
+                        row_id=sp_row_id,
+                        category=sp_cat,
+                        short_name=sp_short_name,
+                        required=False,
+                        interval_row_id=p_iv_row_id,
+                        name=str(sp_name),
+                        value=p_val,
+                        unit=p_unit,
+                        is_interval=is_interval,
+                    )
+                )
+
+            group_variants.append(
+                CombinationParameterGroup(
+                    id=grp_id,
+                    prg_sequence=grp_seq,
+                    row_id=grp_row_id,
+                    parameters=params_list,
+                )
+            )
+
+        expanded_groups.append(group_variants)
+
+    # Step 2: Cartesian product across groups (DFS)
+    leaves: list[CombinationLeaf] = []
+
+    def _dfs(group_idx: int, current_groups: list[CombinationParameterGroup]) -> None:
+        if group_idx == len(expanded_groups):
+            leaves.append(CombinationLeaf(parameter_groups=list(current_groups)))
+            return
+
+        for variant in expanded_groups[group_idx]:
+            current_groups.append(variant)
+            _dfs(group_idx + 1, current_groups)
+            current_groups.pop()
+
+    _dfs(0, [])
+
+    # Step 3: Evaluate overrides and rules
+    result_combinations: list[CombinationLeaf] = []
+
+    for leaf in leaves:
+        key = combination_to_override_key(leaf)
+
+        # Overrides have top precedence
+        if key in skip_set:
+            continue
+        if key in unskip_set:
+            result_combinations.append(leaf)
+            continue
+
+        # Evaluate rules
+        matched_any_rule = False
+        for rule in rules_list:
+            if rule_matches_leaf(leaf, rule):
+                matched_any_rule = True
+                break
+
+        if intervals_start_from == "all":
+            # Exclude mode: matching a rule excludes it
+            if not matched_any_rule:
+                result_combinations.append(leaf)
+        else:
+            # Include mode: matching a rule includes it
+            if matched_any_rule:
+                result_combinations.append(leaf)
+
+        if len(result_combinations) > MAX_RESULTS:
+            raise AlbertException(
+                f"Generated combinations count exceeds maximum allowed limit of {MAX_RESULTS}. "
+                "Please add exclusion rules or reduce interval setpoints."
+            )
+
+    return IntervalCombinationPayload(combinations=result_combinations)
+
+
+def _extract_unit_dict(obj: Any) -> dict[str, Any] | None:
+    """Extract unit as a clean dictionary."""
+    unit = _get_field(obj, "unit", alias="Unit")
+    if not unit:
+        return None
+    if isinstance(unit, dict):
+        return {"id": unit.get("id"), "name": unit.get("name")}
+    if hasattr(unit, "id"):
+        return {
+            "id": getattr(unit, "id", None),
+            "name": getattr(unit, "name", None),
+        }
+    return {"id": str(unit)}

--- a/src/albert/utils/interval_combinations.py
+++ b/src/albert/utils/interval_combinations.py
@@ -276,21 +276,46 @@ def generate_interval_combinations(
     overrides: list[CombinationOverride] | None = None,
     intervals_start_from: Literal["all", "none"] = "all",
 ) -> IntervalCombinationPayload:
-    """Evaluate combination rules and overrides to generate S3 combination definitions.
+    """Calculate interval combinations from a workflow and evaluate rules and overrides.
 
-    Pure, session-free computation engine matching the frontend StreamUltraEngine:
-    1. Expands parameter intervals into the cartesian product.
-    2. Builds canonical compound override keys.
-    3. Evaluates direct overrides (``skip`` / ``unskip``).
-    4. Evaluates exclusion / inclusion rules depending on ``intervals_start_from``.
-    5. Validates the 2,000 combinations hard cap.
+    Pure, session-free computation engine that calculates the active set of combinations:
+    1. Expands parameter intervals into the full cartesian product.
+    2. Builds canonical compound override keys for each combination.
+    3. Evaluates direct overrides (``skip`` / ``unskip``), taking precedence over rules.
+    4. Evaluates exclusion or inclusion rules depending on ``intervals_start_from``:
+       - ``"all"`` (Exclude Mode): Starts with all combinations included; excludes
+         combinations matching any exclusion rule.
+       - ``"none"`` (Include Mode): Starts with no combinations included; includes
+         combinations matching any inclusion rule.
+    5. Enforces the platform safety cap of 2,000 combinations.
+
+    This client-side computation is used internally by
+    [`create_with_combinations`][albert.collections.tasks.TaskCollection.create_with_combinations]
+    and [`generate_block_combinations`][albert.collections.tasks.TaskCollection.generate_block_combinations],
+    and can also be called directly to simulate or preview combinations locally.
+
+    !!! example
+        ```python
+        from albert import Albert
+        from albert.utils.interval_combinations import generate_interval_combinations
+
+        client = Albert()
+        workflow = client.workflows.get_by_id(id="WFL456")
+        payload = generate_interval_combinations(
+            workflow=workflow,
+            intervals_start_from="all",
+        )
+        len(payload.combinations)
+        # 12
+        ```
 
     Parameters
     ----------
     workflow : Workflow or Sequence[ParameterGroupSetpoints] or list[dict]
         The parent workflow or parameter group setpoints containing intervals.
+        Must already have assigned row IDs.
     rules : list[ExclusionRule], optional
-        The combination exclusion/inclusion rules to evaluate.
+        The combination exclusion or inclusion rules to evaluate.
     overrides : list[CombinationOverride], optional
         The combination overrides (skip/unskip) to apply.
     intervals_start_from : {"all", "none"}, default "all"
@@ -299,7 +324,7 @@ def generate_interval_combinations(
     Returns
     -------
     IntervalCombinationPayload
-        The combinations payload ready for S3 upload.
+        The combinations payload containing the calculated combination leaves.
 
     Raises
     ------
@@ -447,7 +472,7 @@ def generate_interval_combinations(
                 sp_seq = _get_field(sp, "sequence", alias="prgPrmRowId")
                 sp_cat_raw = _get_field(sp, "category", default="Normal")
                 sp_cat = (
-                    p_cat_raw.value
+                    sp_cat_raw.value
                     if isinstance(sp_cat_raw, Enum)
                     else str(sp_cat_raw or "Normal")
                 )

--- a/src/albert/utils/worker_jobs.py
+++ b/src/albert/utils/worker_jobs.py
@@ -1,0 +1,95 @@
+"""Utilities for working with background worker jobs."""
+
+from __future__ import annotations
+
+from tenacity import retry, stop_after_attempt, wait_exponential
+
+from albert.core.logging import logger
+from albert.core.session import AlbertSession
+from albert.exceptions import AlbertException
+from albert.resources.worker_jobs import (
+    WORKER_JOB_PENDING_STATES,
+    WorkerJob,
+    WorkerJobState,
+)
+
+DEFAULT_WORKER_JOB_POLL_INTERVAL = 2.0
+DEFAULT_WORKER_JOB_MAX_ATTEMPTS = 60
+DEFAULT_WORKER_JOB_MAX_WAIT = 10.0
+
+
+class _WorkerJobPending(Exception):
+    """Internal sentinel exception indicating the worker job is still running."""
+
+
+def poll_worker_job(
+    *,
+    session: AlbertSession,
+    job_id: str,
+    max_attempts: int = DEFAULT_WORKER_JOB_MAX_ATTEMPTS,
+    poll_interval: float = DEFAULT_WORKER_JOB_POLL_INTERVAL,
+    max_wait: float = DEFAULT_WORKER_JOB_MAX_WAIT,
+    raise_on_failure: bool = True,
+    job_description: str = "Worker job",
+) -> WorkerJob:
+    """Poll a worker job until it reaches a terminal state.
+
+    Parameters
+    ----------
+    session : AlbertSession
+        Authenticated session for platform requests.
+    job_id : str
+        The worker job identifier (format ``JOB...``), such as ``block.job_id``
+        or ``worker_job.albert_id``.
+    max_attempts : int, optional
+        Maximum number of polling attempts, by default 60.
+    poll_interval : float, optional
+        Minimum wait time in seconds between attempts, by default 2.0.
+    max_wait : float, optional
+        Maximum wait time in seconds between attempts, by default 10.0.
+    raise_on_failure : bool, optional
+        Whether to raise an exception if the job finishes with state other than
+        ``successful``, by default True.
+    job_description : str, optional
+        Human-readable description for logging.
+
+    Returns
+    -------
+    WorkerJob
+        The completed worker job.
+
+    Raises
+    ------
+    TimeoutError
+        If the job does not complete within the retry window.
+    AlbertException
+        If ``raise_on_failure`` is True and the job failed or was cancelled.
+    """
+
+    @retry(
+        stop=stop_after_attempt(max_attempts),
+        wait=wait_exponential(min=poll_interval, max=max_wait),
+        reraise=True,
+    )
+    def _poll() -> WorkerJob:
+        status_response = session.get(f"/api/v3/worker-jobs/{job_id}")
+        current_job = WorkerJob.model_validate(status_response.json())
+        state = current_job.state
+
+        if state in WORKER_JOB_PENDING_STATES:
+            logger.info("%s %s in progress (state: %s)", job_description, job_id, state)
+            raise _WorkerJobPending()
+        return current_job
+
+    try:
+        worker_job = _poll()
+    except _WorkerJobPending as exc:
+        raise TimeoutError(
+            f"{job_description} {job_id} did not complete within the retry window."
+        ) from exc
+
+    if raise_on_failure and worker_job.state != WorkerJobState.SUCCESSFUL:
+        message = worker_job.state_message or f"job state is {worker_job.state.value}"
+        raise AlbertException(f"{job_description} {job_id} failed: {message}")
+
+    return worker_job

--- a/tests/collections/test_property_data.py
+++ b/tests/collections/test_property_data.py
@@ -76,11 +76,13 @@ def test_check_for_interval_data(client: Albert, seeded_tasks, seeded_workflows)
         this_workflow = [x for x in seeded_workflows if x.id in [y.id for y in block.workflow]][0]
         if this_workflow.interval_combinations and len(this_workflow.interval_combinations) > 0:
             for interval in this_workflow.interval_combinations:
-                check = client.property_data.check_block_interval_for_data(
+                checks = client.property_data.check_block_interval_for_data(
                     block_id=block.id, task_id=task.id, interval_id=interval.interval_id
                 )
 
-                assert isinstance(check, CheckPropertyData)
+                assert checks
+                for check in checks:
+                    assert isinstance(check, CheckPropertyData)
 
 
 def test_add_to_inv(client: Albert, seeded_inventory, seeded_data_columns):

--- a/tests/collections/test_property_data.py
+++ b/tests/collections/test_property_data.py
@@ -76,13 +76,11 @@ def test_check_for_interval_data(client: Albert, seeded_tasks, seeded_workflows)
         this_workflow = [x for x in seeded_workflows if x.id in [y.id for y in block.workflow]][0]
         if this_workflow.interval_combinations and len(this_workflow.interval_combinations) > 0:
             for interval in this_workflow.interval_combinations:
-                checks = client.property_data.check_block_interval_for_data(
+                check = client.property_data.check_block_interval_for_data(
                     block_id=block.id, task_id=task.id, interval_id=interval.interval_id
                 )
 
-                assert checks
-                for check in checks:
-                    assert isinstance(check, CheckPropertyData)
+                assert isinstance(check, CheckPropertyData)
 
 
 def test_add_to_inv(client: Albert, seeded_inventory, seeded_data_columns):

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -252,6 +252,7 @@ def test_task_get_history(client: Albert, seeded_tasks):
     assert isinstance(task_history.items, list)
 
 
+@pytest.mark.xfail(reason="increased intervals is not live on ten0 test env")
 def test_get_and_set_block_rules(
     client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
 ):

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -14,10 +14,12 @@ from albert.resources.tags import Tag
 from albert.resources.tasks import (
     BaseTask,
     BatchTask,
+    Block,
     PropertyTask,
     TaskCategory,
     TaskSearchItem,
 )
+from albert.resources.worker_jobs import WorkerJob
 from albert.resources.workflows import Workflow
 from tests.utils.test_patches import change_metadata, make_metadata_update_assertions
 from tests.utils.wait import poll_until
@@ -257,7 +259,7 @@ def test_get_and_set_block_rules(
     client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
 ):
     """Test getting and setting block combination rules and overrides."""
-    task = next(x for x in seeded_tasks if isinstance(x, BatchTask) and x.blocks is not None)
+    task = next(x for x in seeded_tasks if isinstance(x, PropertyTask) and x.blocks is not None)
     task = client.tasks.get_by_id(id=task.id)
     client.tasks.add_block(
         task_id=task.id,
@@ -294,6 +296,7 @@ def test_get_and_set_block_rules(
             block_id=block.id,
             rules=[rule],
             overrides=[override],
+            wait=False,
         )
         assert isinstance(updated, BlockRules)
         assert len(updated.rules) == 1
@@ -302,6 +305,7 @@ def test_get_and_set_block_rules(
         assert updated.rules[0].conditions[0].operator == RuleOperator.GT
         assert len(updated.overrides) == 1
         assert updated.overrides[0].action == OverrideAction.SKIP
+        assert updated.job is not None
 
         # Fetch again to verify persistence
         fetched = client.tasks.get_block_rules(task_id=task.id, block_id=block.id)
@@ -316,8 +320,57 @@ def test_get_and_set_block_rules(
             block_id=block.id,
             rules=[],
             overrides=[],
+            wait=False,
         )
         assert cleared.rules == []
         assert cleared.overrides == []
+        assert cleared.job is not None
     finally:
         client.tasks.remove_block(task_id=task.id, block_id=block.id)
+
+
+@pytest.mark.xfail(reason="increased intervals is not live on ten0 test env")
+def test_generate_block_combinations_integration(
+    client: Albert, seeded_tasks, seeded_data_templates, seeded_workflows
+):
+    """Test generating block combinations on a task block."""
+    task = next(x for x in seeded_tasks if isinstance(x, PropertyTask) and x.blocks is not None)
+    task = client.tasks.get_by_id(id=task.id)
+    client.tasks.add_block(
+        task_id=task.id,
+        data_template_id=seeded_data_templates[0].id,
+        workflow_id=seeded_workflows[0].id,
+    )
+    task = client.tasks.get_by_id(id=task.id)
+    block = task.blocks[-1]
+    try:
+        job = client.tasks.generate_block_combinations(
+            task_id=task.id,
+            block_id=block.id,
+            wait=False,
+        )
+        assert isinstance(job, WorkerJob)
+        assert job.job_type == "createChildWorkflows"
+    finally:
+        client.tasks.remove_block(task_id=task.id, block_id=block.id)
+
+
+@pytest.mark.xfail(reason="increased intervals is not live on ten0 test env")
+def test_create_with_combinations_integration(
+    client: Albert, seeded_projects, seeded_data_templates, seeded_workflows
+):
+    """Test orchestrating task creation with combinations."""
+    task = PropertyTask(
+        name="Test Task With Combinations",
+        parent_id=seeded_projects[0].id,
+        blocks=[
+            Block(
+                data_template=[{"id": seeded_data_templates[0].id}],
+                workflow=[{"id": seeded_workflows[0].id}],
+            )
+        ],
+    )
+    created = client.tasks.create_with_combinations(task=task, wait=False)
+    assert created.id is not None
+    assert len(created.blocks) == 1
+    assert created.blocks[0].job_id is not None

--- a/tests/collections/test_tasks.py
+++ b/tests/collections/test_tasks.py
@@ -1,6 +1,14 @@
 import pytest
 
 from albert import Albert
+from albert.resources.interval_combinations import (
+    BlockRules,
+    CombinationOverride,
+    ExclusionRule,
+    OverrideAction,
+    RuleCondition,
+    RuleOperator,
+)
 from albert.resources.lists import ListItem
 from albert.resources.tags import Tag
 from albert.resources.tasks import (
@@ -242,3 +250,73 @@ def test_remove_block_from_batch_task(client: Albert, seeded_tasks, seeded_workf
 def test_task_get_history(client: Albert, seeded_tasks):
     task_history = client.tasks.get_history(id=seeded_tasks[0].id)
     assert isinstance(task_history.items, list)
+
+
+def test_get_and_set_block_rules(
+    client: Albert, seeded_tasks, seeded_workflows, seeded_data_templates
+):
+    """Test getting and setting block combination rules and overrides."""
+    task = next(x for x in seeded_tasks if isinstance(x, BatchTask) and x.blocks is not None)
+    task = client.tasks.get_by_id(id=task.id)
+    client.tasks.add_block(
+        task_id=task.id,
+        data_template_id=seeded_data_templates[0].id,
+        workflow_id=seeded_workflows[0].id,
+    )
+    task = client.tasks.get_by_id(id=task.id)
+    block = task.blocks[-1]
+    try:
+        # Initially empty
+        initial = client.tasks.get_block_rules(task_id=task.id, block_id=block.id)
+        assert isinstance(initial, BlockRules)
+        assert initial.rules == []
+        assert initial.overrides == []
+
+        # Set rules and overrides
+        rule = ExclusionRule(
+            name="Test Exclusion Rule",
+            conditions=[
+                RuleCondition(
+                    parameter_group_id="PRG1",
+                    parameter_id="PRM1",
+                    operator=RuleOperator.GT,
+                    value=50,
+                )
+            ],
+        )
+        override = CombinationOverride(
+            key="PRG1#PRM1#ROW1",
+            action=OverrideAction.SKIP,
+        )
+        updated = client.tasks.set_block_rules(
+            task_id=task.id,
+            block_id=block.id,
+            rules=[rule],
+            overrides=[override],
+        )
+        assert isinstance(updated, BlockRules)
+        assert len(updated.rules) == 1
+        assert updated.rules[0].name == "Test Exclusion Rule"
+        assert len(updated.rules[0].conditions) == 1
+        assert updated.rules[0].conditions[0].operator == RuleOperator.GT
+        assert len(updated.overrides) == 1
+        assert updated.overrides[0].action == OverrideAction.SKIP
+
+        # Fetch again to verify persistence
+        fetched = client.tasks.get_block_rules(task_id=task.id, block_id=block.id)
+        assert len(fetched.rules) == 1
+        assert fetched.rules[0].name == "Test Exclusion Rule"
+        assert len(fetched.overrides) == 1
+        assert fetched.overrides[0].action == OverrideAction.SKIP
+
+        # Clear rules and overrides
+        cleared = client.tasks.set_block_rules(
+            task_id=task.id,
+            block_id=block.id,
+            rules=[],
+            overrides=[],
+        )
+        assert cleared.rules == []
+        assert cleared.overrides == []
+    finally:
+        client.tasks.remove_block(task_id=task.id, block_id=block.id)

--- a/tests/core/shared/test_identifiers.py
+++ b/tests/core/shared/test_identifiers.py
@@ -27,6 +27,8 @@ from albert.core.shared.identifiers import (
     ensure_workflow_id,
     ensure_worksheet_id,
 )
+from albert.resources.worker_jobs import WorkerJobMetadata
+from albert.resources.workflows import Interval, IntervalCombination
 
 
 @pytest.mark.parametrize(
@@ -90,6 +92,12 @@ def test_ensure_lot_id_display_format():
 def test_ensure_interval_id():
     assert ensure_interval_id("ROW123") == "ROW123"
     assert ensure_interval_id("ROW123XROW456") == "ROW123XROW456"
+    assert ensure_interval_id("ROW123XROW456XROW789") == "ROW123XROW456XROW789"
+    assert ensure_interval_id("row123") == "ROW123"
+    assert ensure_interval_id("default") == "default"
+    assert ensure_interval_id("WFL375962") == "WFL375962"
+    assert ensure_interval_id("V1a9Km2xL") == "V1a9Km2xL"
+
     with pytest.raises(ValueError, match="IntervalId cannot be empty"):
         ensure_interval_id("")
 
@@ -97,20 +105,14 @@ def test_ensure_interval_id():
 
     assert ensure_row_id("row123Xrow456") == "ROW123XROW456"
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
-        ensure_interval_id("ROW123XROW456XROW789")
-
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="Must be a ROW chain"):
         ensure_interval_id("123")
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="Must be a ROW chain"):
         ensure_interval_id("123X456")
 
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
+    with pytest.raises(ValueError, match="Must be a ROW chain"):
         ensure_interval_id("ROW123XROW456X")
-
-    with pytest.raises(ValueError, match="Must be in format ROW# or ROW#XROW#"):
-        ensure_interval_id("ROW123XROW456XROW789")
 
 
 @pytest.mark.parametrize(
@@ -276,3 +278,39 @@ def test_validate_call_with_return_types():
         return inventory_id
 
     assert return_func("A123") == "INVA123"
+
+
+def test_interval_accepts_object_value_and_empty():
+    empty = Interval.model_validate({})
+    assert empty.value is None
+
+    special = Interval.model_validate(
+        {"value": {"id": "INVC89189", "name": "C89189 || BUL3"}, "name": "C89189 || BUL3"}
+    )
+    assert special.value == {"id": "INVC89189", "name": "C89189 || BUL3"}
+    assert special.name == "C89189 || BUL3"
+
+
+def test_interval_combination_accepts_three_segment_id():
+    combo = IntervalCombination.model_validate({"interval": "ROW3XROW8XROW13"})
+    assert combo.interval_id == "ROW3XROW8XROW13"
+
+
+def test_worker_job_metadata_preserves_child_workflow_fields():
+    metadata = WorkerJobMetadata.model_validate(
+        {
+            "albertId": "TASFOR361819",
+            "parentType": "TAS",
+            "blockId": "BLK1",
+            "s3Url": "intervalcombinations/TASFOR361819/BLK1/ufo-ExDhXV.json",
+            "newWorkflowId": "WFL383358",
+            "oldWorkflowId": "WFL375193",
+        }
+    )
+    dumped = metadata.model_dump(by_alias=True, exclude_none=True)
+    assert dumped["albertId"] == "TASFOR361819"
+    assert dumped["blockId"] == "BLK1"
+    assert dumped["s3Url"] == "intervalcombinations/TASFOR361819/BLK1/ufo-ExDhXV.json"
+    assert dumped["newWorkflowId"] == "WFL383358"
+    assert dumped["oldWorkflowId"] == "WFL375193"
+    assert dumped["parentType"] == "TAS"

--- a/tests/core/shared/test_identifiers.py
+++ b/tests/core/shared/test_identifiers.py
@@ -284,6 +284,9 @@ def test_interval_accepts_object_value_and_empty():
     empty = Interval.model_validate({})
     assert empty.value is None
 
+    empty_str = Interval(value="")
+    assert empty_str.value == ""
+
     special = Interval.model_validate(
         {"value": {"id": "INVC89189", "name": "C89189 || BUL3"}, "name": "C89189 || BUL3"}
     )

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -1,9 +1,11 @@
 import pytest
+from pydantic import ValidationError
 
 from albert.exceptions import AlbertException
 from albert.resources.interval_combinations import (
     BlockRules,
     CombinationOverride,
+    Condition,
     ExclusionRule,
     OverrideAction,
     RuleCondition,
@@ -221,6 +223,7 @@ def test_workflow_build_rule_condition():
                 parameter_setpoints=[
                     ParameterSetpoint(
                         parameter_id="PRM100",
+                        name="Temperature",
                         short_name="Temp",
                         row_id="ROW1",
                         unit={"id": "UNI1", "name": "C"},
@@ -244,34 +247,48 @@ def test_workflow_build_rule_condition():
         ],
     )
 
-    cond = wf.build_rule_condition("Temp", ">=", 90)
+    cond = wf.build_rule_condition(parameter="Temp", operator=">=", value=90)
     assert cond.parameter_group_id == "PRG247776"
     assert cond.parameter_id == "PRM100"
     assert cond.row_id == "ROW1"
     assert cond.operator == RuleOperator.GTE
     assert cond.value == 90
     assert cond.unit_id == "UNI1"
-    assert cond.name == "Temp"
+    assert cond.name == "Temperature"
+
+    # Parameter can be specified by full name, short name, or parameter ID (case-insensitive)
+    cond_name = wf.build_rule_condition(parameter="Temperature", operator=">=", value=90)
+    assert cond_name.parameter_id == "PRM100"
+
+    cond_short = wf.build_rule_condition(parameter="temp", operator=">=", value=90)
+    assert cond_short.parameter_id == "PRM100"
+
+    cond_id = wf.build_rule_condition(parameter="prm100", operator=">=", value=90)
+    assert cond_id.parameter_id == "PRM100"
+
+    # Enforces keyword-only arguments via validate_call
+    with pytest.raises((TypeError, ValidationError)):
+        wf.build_rule_condition("Temp", ">=", 90)  # type: ignore[misc]
 
     # Operator string variations
-    assert wf.build_rule_condition("Temp", "=").operator == RuleOperator.EQ
-    assert wf.build_rule_condition("Temp", "==").operator == RuleOperator.EQ
-    assert wf.build_rule_condition("Temp", "!=").operator == RuleOperator.NE
-    assert wf.build_rule_condition("Temp", "<").operator == RuleOperator.LT
-    assert wf.build_rule_condition("Temp", "<=").operator == RuleOperator.LTE
-    assert wf.build_rule_condition("Temp", ">").operator == RuleOperator.GT
+    assert wf.build_rule_condition(parameter="Temp", operator="=").operator == RuleOperator.EQ
+    assert wf.build_rule_condition(parameter="Temp", operator="==").operator == RuleOperator.EQ
+    assert wf.build_rule_condition(parameter="Temp", operator="!=").operator == RuleOperator.NE
+    assert wf.build_rule_condition(parameter="Temp", operator="<").operator == RuleOperator.LT
+    assert wf.build_rule_condition(parameter="Temp", operator="<=").operator == RuleOperator.LTE
+    assert wf.build_rule_condition(parameter="Temp", operator=">").operator == RuleOperator.GT
 
     # Explicit unit override
-    cond_unit = wf.build_rule_condition("Speed", ">", 1000, unit="UNI99")
+    cond_unit = wf.build_rule_condition(parameter="Speed", operator=">", value=1000, unit="UNI99")
     assert cond_unit.unit_id == "UNI99"
 
     # Invalid operator
     with pytest.raises(ValueError, match="Invalid rule operator"):
-        wf.build_rule_condition("Temp", "INVALID_OP")
+        wf.build_rule_condition(parameter="Temp", operator="INVALID_OP")
 
     # Missing parameter
     with pytest.raises(AlbertException, match="No parameter matching 'MissingParam'"):
-        wf.build_rule_condition("MissingParam", "=")
+        wf.build_rule_condition(parameter="MissingParam", operator="=")
 
 
 def test_workflow_build_rule_condition_disambiguation_and_unsaved():
@@ -299,16 +316,18 @@ def test_workflow_build_rule_condition_disambiguation_and_unsaved():
 
     # Ambiguous when group not specified
     with pytest.raises(AlbertException, match="is ambiguous"):
-        wf_multi.build_rule_condition("Viscosity", "=")
+        wf_multi.build_rule_condition(parameter="Viscosity", operator="=")
 
     # Disambiguated by group ID
-    c1 = wf_multi.build_rule_condition("Viscosity", "=", 10, group="PRG1")
+    c1 = wf_multi.build_rule_condition(parameter="Viscosity", operator="=", value=10, group="PRG1")
     assert c1.parameter_group_id == "PRG1"
     assert c1.parameter_id == "PRM10"
     assert c1.row_id == "ROW1"
 
     # Disambiguated by group name
-    c2 = wf_multi.build_rule_condition("Viscosity", "=", 20, group="Group Two")
+    c2 = wf_multi.build_rule_condition(
+        parameter="Viscosity", operator="=", value=20, group="Group Two"
+    )
     assert c2.parameter_group_id == "PRG2"
     assert c2.parameter_id == "PRM20"
     assert c2.row_id == "ROW2"
@@ -326,11 +345,11 @@ def test_workflow_build_rule_condition_disambiguation_and_unsaved():
         ],
     )
     with pytest.raises(AlbertException, match="not been assigned row IDs"):
-        wf_unsaved.build_rule_condition("Temp", "=")
+        wf_unsaved.build_rule_condition(parameter="Temp", operator="=")
 
 
-def test_workflow_build_exclusion_rule():
-    """Test Workflow.build_exclusion_rule handles single and multi-condition rules."""
+def test_workflow_build_rule():
+    """Test Workflow.build_rule handles single condition kwargs, tuples, Condition, and RuleCondition."""
     wf = Workflow(
         name="Screening Workflow",
         parameter_group_setpoints=[
@@ -361,7 +380,7 @@ def test_workflow_build_exclusion_rule():
     )
 
     # 1. Single condition directly via kwargs
-    rule1 = wf.build_exclusion_rule(
+    rule1 = wf.build_rule(
         name="Exclude cold",
         parameter="Temp",
         operator="<",
@@ -374,7 +393,7 @@ def test_workflow_build_exclusion_rule():
     assert rule1.conditions[0].value == 15
 
     # 2. Multi-condition via tuples
-    rule2 = wf.build_exclusion_rule(
+    rule2 = wf.build_rule(
         name="Crosslinking risk",
         conditions=[
             ("Temp", ">=", 90),
@@ -388,20 +407,22 @@ def test_workflow_build_exclusion_rule():
     assert rule2.conditions[1].parameter_id == "PRM200"
     assert rule2.conditions[1].operator == RuleOperator.GTE
 
-    # 3. Multi-condition via RuleCondition instances
-    c1 = wf.build_rule_condition("Temp", ">=", 90)
-    c2 = wf.build_rule_condition("Speed", ">=", 1500)
+    # 3. Multi-condition via Condition NamedTuple
+    rule_named = wf.build_rule(
+        name="Named Condition",
+        conditions=[
+            Condition(parameter="Temp", operator=">=", value=90),
+            Condition(parameter="Speed", operator=">=", value=1500),
+        ],
+    )
+    assert rule_named.name == "Named Condition"
+    assert len(rule_named.conditions) == 2
+
+    # 4. Multi-condition via RuleCondition instances
+    c1 = wf.build_rule_condition(parameter="Temp", operator=">=", value=90)
+    c2 = wf.build_rule_condition(parameter="Speed", operator=">=", value=1500)
     rule3 = wf.build_rule(name="Rule 3", conditions=[c1, c2])
     assert len(rule3.conditions) == 2
-
-    # 4. Inclusion rule builder alias
-    rule_inc = wf.build_inclusion_rule(
-        name="Include low temp",
-        conditions=[("Temp", "<", 30)],
-    )
-    assert rule_inc.name == "Include low temp"
-    assert len(rule_inc.conditions) == 1
-    assert rule_inc.conditions[0].operator == RuleOperator.LT
 
     # Error when neither conditions nor parameter/operator provided
     with pytest.raises(ValueError, match="Provide either 'conditions'"):
@@ -437,16 +458,20 @@ def test_workflow_build_override():
         ],
     )
 
-    # Default action (skip)
-    override_skip = wf.build_override({"Temp": 25, "Speed": 500})
+    # Default action (skip) with keyword-only argument
+    override_skip = wf.build_override(parameter_values={"Temp": 25, "Speed": 500})
     assert isinstance(override_skip, CombinationOverride)
     assert override_skip.key == "PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW8"
     assert override_skip.action == OverrideAction.SKIP
     assert override_skip.is_manual is None
 
+    # Enforces keyword-only arguments via validate_call
+    with pytest.raises((TypeError, ValidationError)):
+        wf.build_override({"Temp": 25, "Speed": 500})  # type: ignore[misc]
+
     # Unskip with is_manual
     override_unskip = wf.build_override(
-        {"Speed": 1500, "Temp": 60},
+        parameter_values={"Speed": 1500, "Temp": 60},
         action="unskip",
         is_manual=True,
     )
@@ -456,4 +481,4 @@ def test_workflow_build_override():
 
     # Invalid action
     with pytest.raises(ValueError, match="Invalid override action"):
-        wf.build_override({"Temp": 25, "Speed": 500}, action="invalid")
+        wf.build_override(parameter_values={"Temp": 25, "Speed": 500}, action="invalid")

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -482,3 +482,30 @@ def test_workflow_build_override():
     # Invalid action
     with pytest.raises(ValueError, match="Invalid override action"):
         wf.build_override(parameter_values={"Temp": 25, "Speed": 500}, action="invalid")
+
+
+def test_workflow_combinations_deserialization_and_exclusion():
+    """Test that Workflow.combinations deserializes from both aliases and is excluded on dump."""
+    payload1 = {
+        "name": "W1",
+        "Combinations": [{"id": "WFL101", "name": "Combo 1", "intervalBarcode": "OhI8ap0HY"}],
+    }
+    wf1 = Workflow.model_validate(payload1)
+    assert wf1.combinations is not None
+    assert len(wf1.combinations) == 1
+    assert wf1.combinations[0].id == "WFL101"
+    assert wf1.combinations[0].interval_barcode == "OhI8ap0HY"
+
+    # Also validates from singular 'Combination'
+    payload2 = {
+        "name": "W2",
+        "Combination": [{"id": "WFL102", "name": "Combo 2", "intervalBarcode": "V1a9Km2xL"}],
+    }
+    wf2 = Workflow.model_validate(payload2)
+    assert wf2.combinations is not None
+    assert wf2.combinations[0].id == "WFL102"
+
+    # Verifies it is excluded from model_dump
+    dumped1 = wf1.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert "Combinations" not in dumped1
+    assert "Combination" not in dumped1

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -1,0 +1,211 @@
+import pytest
+
+from albert.exceptions import AlbertException
+from albert.resources.interval_combinations import (
+    BlockRules,
+    CombinationOverride,
+    ExclusionRule,
+    OverrideAction,
+    RuleCondition,
+    RuleOperator,
+)
+from albert.resources.tasks import Block
+from albert.resources.workflows import (
+    Interval,
+    ParameterGroupSetpoints,
+    ParameterSetpoint,
+    Workflow,
+)
+
+
+def test_rule_condition_serialization():
+    """Test RuleCondition serialization to camelCase wire format."""
+    condition = RuleCondition(
+        parameter_group_id="PRG247776",
+        parameter_id="PRM100",
+        row_id="ROW2",
+        operator=RuleOperator.GTE,
+        value="90",
+        unit_id="UNI1",
+        name="Temperature",
+    )
+    wire = condition.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert wire == {
+        "prgId": "PRG247776",
+        "prmId": "PRM100",
+        "rowId": "ROW2",
+        "operator": "gte",
+        "value": "90",
+        "unitId": "UNI1",
+        "name": "Temperature",
+    }
+
+
+def test_rule_condition_deserialization():
+    """Test RuleCondition deserialization from wire camelCase format."""
+    wire = {
+        "prgId": "PRG247776",
+        "prmId": "PRM100",
+        "rowId": "ROW2",
+        "operator": "gte",
+        "value": 90,
+    }
+    condition = RuleCondition.model_validate(wire)
+    assert condition.parameter_group_id == "PRG247776"
+    assert condition.parameter_id == "PRM100"
+    assert condition.row_id == "ROW2"
+    assert condition.operator == RuleOperator.GTE
+    assert condition.value == 90
+    assert condition.unit_id is None
+
+
+def test_combination_override_serialization():
+    """Test CombinationOverride serialization."""
+    override = CombinationOverride(
+        key="PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9",
+        action=OverrideAction.SKIP,
+    )
+    wire = override.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert wire == {
+        "key": "PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW9",
+        "action": "skip",
+    }
+
+
+def test_block_rules_unwrap_response():
+    """Test BlockRules unwraps paginated rules envelope."""
+    payload = {
+        "taskId": "TASFOR123",
+        "blockId": "BLK1",
+        "rules": {
+            "items": [
+                {
+                    "id": "rule-uuid-1",
+                    "name": "High temp cutoff",
+                    "conditions": [
+                        {
+                            "prgId": "PRG1",
+                            "prmId": "PRM1",
+                            "rowId": "ROW2",
+                            "operator": "gt",
+                            "value": 100,
+                        }
+                    ],
+                }
+            ],
+            "lastKey": None,
+        },
+        "overrides": [
+            {
+                "id": "override-uuid-1",
+                "key": "PRG1#PRM1#ROW2",
+                "action": "unskip",
+            }
+        ],
+    }
+    block_rules = BlockRules.model_validate(payload)
+    assert block_rules.task_id == "TASFOR123"
+    assert block_rules.block_id == "BLK1"
+    assert len(block_rules.rules) == 1
+    assert block_rules.rules[0].id == "rule-uuid-1"
+    assert block_rules.rules[0].name == "High temp cutoff"
+    assert len(block_rules.rules[0].conditions) == 1
+    assert block_rules.rules[0].conditions[0].parameter_group_id == "PRG1"
+    assert len(block_rules.overrides) == 1
+    assert block_rules.overrides[0].id == "override-uuid-1"
+    assert block_rules.overrides[0].action == OverrideAction.UNSKIP
+
+
+def test_workflow_get_override_key():
+    """Test Workflow.get_override_key builds compound keys in canonical order."""
+    wf = Workflow(
+        name="Screening Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG247776",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM100",
+                        short_name="Temp",
+                        intervals=[
+                            Interval(value="25", unit={"id": "UNI1"}, row_id="ROW4"),
+                            Interval(value="60", unit={"id": "UNI1"}, row_id="ROW5"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM200",
+                        short_name="Speed",
+                        intervals=[
+                            Interval(value="500", unit={"id": "UNI2"}, row_id="ROW8"),
+                            Interval(value="1500", unit={"id": "UNI2"}, row_id="ROW9"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Normal order
+    key1 = wf.get_override_key({"Temp": 25, "Speed": 500})
+    assert key1 == "PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW8"
+
+    # Inverted caller arg order -> same canonical order in key
+    key2 = wf.get_override_key({"Speed": 1500, "Temp": 60})
+    assert key2 == "PRG247776#PRM100#ROW5-PRG247776#PRM200#ROW9"
+
+    # Missing interval raises AlbertException
+    with pytest.raises(AlbertException, match="No matching interval found"):
+        wf.get_override_key({"Temp": 999})
+
+
+def test_workflow_get_override_key_unassigned_row_id():
+    """Test get_override_key raises when row IDs have not been assigned yet."""
+    wf = Workflow(
+        name="Unsaved Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        name="Temp",
+                        intervals=[
+                            Interval(value="25"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+    with pytest.raises(AlbertException, match="not been assigned interval row IDs"):
+        wf.get_override_key({"Temp": 25})
+
+
+def test_block_rules_and_overrides_excluded_from_dump():
+    """Test Block excludes rules and overrides from model_dump payload."""
+    rule = ExclusionRule(
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                row_id="ROW2",
+                operator=RuleOperator.EQ,
+                value="25",
+            )
+        ]
+    )
+    override = CombinationOverride(key="PRG1#PRM1#ROW2", action=OverrideAction.SKIP)
+    block = Block(
+        workflow=[{"id": "WFL1"}],
+        data_template=[{"id": "DAT1"}],
+        rules=[rule],
+        overrides=[override],
+    )
+    assert block.rules == [rule]
+    assert block.overrides == [override]
+
+    dumped = block.model_dump(by_alias=True, mode="json", exclude_none=True)
+    assert "rules" not in dumped
+    assert "overrides" not in dumped
+    assert "Workflow" in dumped
+    assert "Datatemplate" in dumped

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -209,3 +209,242 @@ def test_block_rules_and_overrides_excluded_from_dump():
     assert "overrides" not in dumped
     assert "Workflow" in dumped
     assert "Datatemplate" in dumped
+
+
+def test_workflow_build_rule_condition():
+    """Test Workflow.build_rule_condition resolves IDs, unit, and operator correctly."""
+    wf = Workflow(
+        name="Screening Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG247776",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM100",
+                        short_name="Temp",
+                        row_id="ROW1",
+                        unit={"id": "UNI1", "name": "C"},
+                        intervals=[
+                            Interval(value="25", unit={"id": "UNI1"}, row_id="ROW4"),
+                            Interval(value="60", unit={"id": "UNI1"}, row_id="ROW5"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM200",
+                        short_name="Speed",
+                        row_id="ROW2",
+                        unit={"id": "UNI2", "name": "RPM"},
+                        intervals=[
+                            Interval(value="500", unit={"id": "UNI2"}, row_id="ROW8"),
+                            Interval(value="1500", unit={"id": "UNI2"}, row_id="ROW9"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    cond = wf.build_rule_condition("Temp", ">=", 90)
+    assert cond.parameter_group_id == "PRG247776"
+    assert cond.parameter_id == "PRM100"
+    assert cond.row_id == "ROW1"
+    assert cond.operator == RuleOperator.GTE
+    assert cond.value == 90
+    assert cond.unit_id == "UNI1"
+    assert cond.name == "Temp"
+
+    # Operator string variations
+    assert wf.build_rule_condition("Temp", "=").operator == RuleOperator.EQ
+    assert wf.build_rule_condition("Temp", "==").operator == RuleOperator.EQ
+    assert wf.build_rule_condition("Temp", "!=").operator == RuleOperator.NE
+    assert wf.build_rule_condition("Temp", "<").operator == RuleOperator.LT
+    assert wf.build_rule_condition("Temp", "<=").operator == RuleOperator.LTE
+    assert wf.build_rule_condition("Temp", ">").operator == RuleOperator.GT
+
+    # Explicit unit override
+    cond_unit = wf.build_rule_condition("Speed", ">", 1000, unit="UNI99")
+    assert cond_unit.unit_id == "UNI99"
+
+    # Invalid operator
+    with pytest.raises(ValueError, match="Invalid rule operator"):
+        wf.build_rule_condition("Temp", "INVALID_OP")
+
+    # Missing parameter
+    with pytest.raises(AlbertException, match="No parameter matching 'MissingParam'"):
+        wf.build_rule_condition("MissingParam", "=")
+
+
+def test_workflow_build_rule_condition_disambiguation_and_unsaved():
+    """Test build_rule_condition disambiguation with group and error on unsaved workflow."""
+    # Workflow with same param name in two groups
+    wf_multi = Workflow(
+        name="Multi-group Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                parameter_group_name="Group One",
+                parameter_setpoints=[
+                    ParameterSetpoint(parameter_id="PRM10", name="Viscosity", row_id="ROW1"),
+                ],
+            ),
+            ParameterGroupSetpoints(
+                id="PRG2",
+                parameter_group_name="Group Two",
+                parameter_setpoints=[
+                    ParameterSetpoint(parameter_id="PRM20", name="Viscosity", row_id="ROW2"),
+                ],
+            ),
+        ],
+    )
+
+    # Ambiguous when group not specified
+    with pytest.raises(AlbertException, match="is ambiguous"):
+        wf_multi.build_rule_condition("Viscosity", "=")
+
+    # Disambiguated by group ID
+    c1 = wf_multi.build_rule_condition("Viscosity", "=", 10, group="PRG1")
+    assert c1.parameter_group_id == "PRG1"
+    assert c1.parameter_id == "PRM10"
+    assert c1.row_id == "ROW1"
+
+    # Disambiguated by group name
+    c2 = wf_multi.build_rule_condition("Viscosity", "=", 20, group="Group Two")
+    assert c2.parameter_group_id == "PRG2"
+    assert c2.parameter_id == "PRM20"
+    assert c2.row_id == "ROW2"
+
+    # Unsaved workflow (missing row_id on setpoint)
+    wf_unsaved = Workflow(
+        name="Unsaved",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                parameter_setpoints=[
+                    ParameterSetpoint(parameter_id="PRM1", name="Temp"),
+                ],
+            )
+        ],
+    )
+    with pytest.raises(AlbertException, match="not been assigned row IDs"):
+        wf_unsaved.build_rule_condition("Temp", "=")
+
+
+def test_workflow_build_exclusion_rule():
+    """Test Workflow.build_exclusion_rule handles single and multi-condition rules."""
+    wf = Workflow(
+        name="Screening Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG247776",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM100",
+                        short_name="Temp",
+                        row_id="ROW1",
+                        unit={"id": "UNI1"},
+                        intervals=[
+                            Interval(value="25", unit={"id": "UNI1"}, row_id="ROW4"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM200",
+                        short_name="Speed",
+                        row_id="ROW2",
+                        unit={"id": "UNI2"},
+                        intervals=[
+                            Interval(value="500", unit={"id": "UNI2"}, row_id="ROW8"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # 1. Single condition directly via kwargs
+    rule1 = wf.build_exclusion_rule(
+        name="Exclude cold",
+        parameter="Temp",
+        operator="<",
+        value=15,
+    )
+    assert rule1.name == "Exclude cold"
+    assert len(rule1.conditions) == 1
+    assert rule1.conditions[0].parameter_id == "PRM100"
+    assert rule1.conditions[0].operator == RuleOperator.LT
+    assert rule1.conditions[0].value == 15
+
+    # 2. Multi-condition via tuples
+    rule2 = wf.build_exclusion_rule(
+        name="Crosslinking risk",
+        conditions=[
+            ("Temp", ">=", 90),
+            ("Speed", ">=", 1500),
+        ],
+    )
+    assert rule2.name == "Crosslinking risk"
+    assert len(rule2.conditions) == 2
+    assert rule2.conditions[0].parameter_id == "PRM100"
+    assert rule2.conditions[0].operator == RuleOperator.GTE
+    assert rule2.conditions[1].parameter_id == "PRM200"
+    assert rule2.conditions[1].operator == RuleOperator.GTE
+
+    # 3. Multi-condition via RuleCondition instances
+    c1 = wf.build_rule_condition("Temp", ">=", 90)
+    c2 = wf.build_rule_condition("Speed", ">=", 1500)
+    rule3 = wf.build_exclusion_rule(name="Rule 3", conditions=[c1, c2])
+    assert len(rule3.conditions) == 2
+
+    # Error when neither conditions nor parameter/operator provided
+    with pytest.raises(ValueError, match="Provide either 'conditions'"):
+        wf.build_exclusion_rule(name="Empty")
+
+
+def test_workflow_build_override():
+    """Test Workflow.build_override creates CombinationOverride with canonical key."""
+    wf = Workflow(
+        name="Screening Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG247776",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM100",
+                        short_name="Temp",
+                        intervals=[
+                            Interval(value="25", unit={"id": "UNI1"}, row_id="ROW4"),
+                            Interval(value="60", unit={"id": "UNI1"}, row_id="ROW5"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM200",
+                        short_name="Speed",
+                        intervals=[
+                            Interval(value="500", unit={"id": "UNI2"}, row_id="ROW8"),
+                            Interval(value="1500", unit={"id": "UNI2"}, row_id="ROW9"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Default action (skip)
+    override_skip = wf.build_override({"Temp": 25, "Speed": 500})
+    assert isinstance(override_skip, CombinationOverride)
+    assert override_skip.key == "PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW8"
+    assert override_skip.action == OverrideAction.SKIP
+    assert override_skip.is_manual is None
+
+    # Unskip with is_manual
+    override_unskip = wf.build_override(
+        {"Speed": 1500, "Temp": 60},
+        action="unskip",
+        is_manual=True,
+    )
+    assert override_unskip.key == "PRG247776#PRM100#ROW5-PRG247776#PRM200#ROW9"
+    assert override_unskip.action == OverrideAction.UNSKIP
+    assert override_unskip.is_manual is True
+
+    # Invalid action
+    with pytest.raises(ValueError, match="Invalid override action"):
+        wf.build_override({"Temp": 25, "Speed": 500}, action="invalid")

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -147,17 +147,21 @@ def test_workflow_get_override_key():
         ],
     )
 
-    # Normal order
-    key1 = wf.get_override_key({"Temp": 25, "Speed": 500})
+    # Normal order (keyword-only parameter_values)
+    key1 = wf.get_override_key(parameter_values={"Temp": 25, "Speed": 500})
     assert key1 == "PRG247776#PRM100#ROW4-PRG247776#PRM200#ROW8"
 
+    # Enforces keyword-only call via validate_call
+    with pytest.raises((TypeError, ValidationError)):
+        wf.get_override_key({"Temp": 25, "Speed": 500})  # type: ignore[misc]
+
     # Inverted caller arg order -> same canonical order in key
-    key2 = wf.get_override_key({"Speed": 1500, "Temp": 60})
+    key2 = wf.get_override_key(parameter_values={"Speed": 1500, "Temp": 60})
     assert key2 == "PRG247776#PRM100#ROW5-PRG247776#PRM200#ROW9"
 
     # Missing interval raises AlbertException
     with pytest.raises(AlbertException, match="No matching interval found"):
-        wf.get_override_key({"Temp": 999})
+        wf.get_override_key(parameter_values={"Temp": 999})
 
 
 def test_workflow_get_override_key_unassigned_row_id():
@@ -180,7 +184,7 @@ def test_workflow_get_override_key_unassigned_row_id():
         ],
     )
     with pytest.raises(AlbertException, match="not been assigned interval row IDs"):
-        wf.get_override_key({"Temp": 25})
+        wf.get_override_key(parameter_values={"Temp": 25})
 
 
 def test_block_rules_and_overrides_excluded_from_dump():

--- a/tests/resources/test_interval_combinations.py
+++ b/tests/resources/test_interval_combinations.py
@@ -391,12 +391,21 @@ def test_workflow_build_exclusion_rule():
     # 3. Multi-condition via RuleCondition instances
     c1 = wf.build_rule_condition("Temp", ">=", 90)
     c2 = wf.build_rule_condition("Speed", ">=", 1500)
-    rule3 = wf.build_exclusion_rule(name="Rule 3", conditions=[c1, c2])
+    rule3 = wf.build_rule(name="Rule 3", conditions=[c1, c2])
     assert len(rule3.conditions) == 2
+
+    # 4. Inclusion rule builder alias
+    rule_inc = wf.build_inclusion_rule(
+        name="Include low temp",
+        conditions=[("Temp", "<", 30)],
+    )
+    assert rule_inc.name == "Include low temp"
+    assert len(rule_inc.conditions) == 1
+    assert rule_inc.conditions[0].operator == RuleOperator.LT
 
     # Error when neither conditions nor parameter/operator provided
     with pytest.raises(ValueError, match="Provide either 'conditions'"):
-        wf.build_exclusion_rule(name="Empty")
+        wf.build_rule(name="Empty")
 
 
 def test_workflow_build_override():

--- a/tests/unit/test_interval_combinations_engine.py
+++ b/tests/unit/test_interval_combinations_engine.py
@@ -1,0 +1,639 @@
+import pytest
+
+from albert.exceptions import AlbertException
+from albert.resources.interval_combinations import (
+    CombinationOverride,
+    ExclusionRule,
+    IntervalCombinationPayload,
+    OverrideAction,
+    RuleCondition,
+    RuleOperator,
+)
+from albert.resources.workflows import (
+    Interval,
+    ParameterGroupSetpoints,
+    ParameterSetpoint,
+    Workflow,
+)
+from albert.utils.interval_combinations import (
+    _to_number,
+    condition_matches_param,
+    generate_interval_combinations,
+    override_key_to_interval_row_key,
+)
+
+
+def test_to_number_javascript_coercion_table():
+    """Verify JavaScript Number() coercion table from the specification."""
+    # From plan table:
+    assert _to_number("0x10") == 16.0
+    assert _to_number("1_0") is None
+    assert _to_number("0b11") == 3.0
+    assert _to_number("") is None
+    assert _to_number("Infinity") == float("inf")
+    assert _to_number("-Infinity") == float("-inf")
+
+    # Additional standard inputs:
+    assert _to_number("25") == 25.0
+    assert _to_number("  123.45  ") == 123.45
+    assert _to_number("-42.5") == -42.5
+    assert _to_number("0o17") == 15.0
+    assert _to_number("1e3") == 1000.0
+
+    # Non-numeric inputs returning None:
+    assert _to_number(None) is None
+    assert _to_number(True) is None
+    assert _to_number(False) is None
+    assert _to_number("abc") is None
+    assert _to_number("12a") is None
+    assert _to_number("NaN") is None
+
+
+def test_override_key_to_interval_row_key():
+    """Test converting compound override keys to legacy ROW chains."""
+    assert override_key_to_interval_row_key("PRG1#PRM100#ROW4-PRG1#PRM200#ROW9") == "ROW4XROW9"
+    assert override_key_to_interval_row_key("PRG1#PRM100#ROW1") == "ROW1"
+    assert (
+        override_key_to_interval_row_key("PRG1#PRM1#ROW2-PRG2#PRM2#ROW5-PRG3#PRM3#ROW8")
+        == "ROW2XROW5XROW8"
+    )
+
+
+def test_condition_matches_param_numeric_operators():
+    """Test numeric operator comparisons (gt, gte, lt, lte, eq, ne)."""
+    param = {"id": "PRM1", "rowId": "ROW1", "value": "100", "Unit": {"id": "UNI1"}}
+
+    # GT
+    assert condition_matches_param(
+        param,
+        RuleCondition(
+            parameter_group_id="PRG1",
+            parameter_id="PRM1",
+            operator=RuleOperator.GT,
+            value=90,
+        ),
+    )
+    assert not condition_matches_param(
+        param,
+        RuleCondition(
+            parameter_group_id="PRG1",
+            parameter_id="PRM1",
+            operator=RuleOperator.GT,
+            value=100,
+        ),
+    )
+
+    # GTE
+    assert condition_matches_param(
+        param,
+        RuleCondition(
+            parameter_group_id="PRG1",
+            parameter_id="PRM1",
+            operator=RuleOperator.GTE,
+            value=100,
+        ),
+    )
+
+    # LT
+    assert condition_matches_param(
+        param,
+        RuleCondition(
+            parameter_group_id="PRG1",
+            parameter_id="PRM1",
+            operator=RuleOperator.LT,
+            value=150,
+        ),
+    )
+
+    # Ordered operators on non-numeric strings return False
+    str_param = {"id": "PRM1", "rowId": "ROW1", "value": "abc"}
+    assert not condition_matches_param(
+        str_param,
+        RuleCondition(
+            parameter_group_id="PRG1",
+            parameter_id="PRM1",
+            operator=RuleOperator.GT,
+            value=10,
+        ),
+    )
+
+
+def test_condition_matches_param_unit_handling():
+    """Test that a unit mismatch trivially satisfies 'ne' and fails all other operators."""
+    param_kg = {"id": "PRM1", "rowId": "ROW1", "value": "100", "Unit": {"id": "UNI_KG"}}
+
+    # Same numeric value, different unit: 'ne' must match!
+    cond_lb_ne = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.NE,
+        value="100",
+        unit_id="UNI_LB",
+    )
+    assert condition_matches_param(param_kg, cond_lb_ne)
+
+    # Same numeric value, different unit: 'eq' must NOT match!
+    cond_lb_eq = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.EQ,
+        value="100",
+        unit_id="UNI_LB",
+    )
+    assert not condition_matches_param(param_kg, cond_lb_eq)
+
+    # Same numeric value, same unit: 'eq' matches, 'ne' does not
+    cond_kg_eq = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.EQ,
+        value="100",
+        unit_id="UNI_KG",
+    )
+    cond_kg_ne = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.NE,
+        value="100",
+        unit_id="UNI_KG",
+    )
+    assert condition_matches_param(param_kg, cond_kg_eq)
+    assert not condition_matches_param(param_kg, cond_kg_ne)
+
+
+def test_condition_matches_param_empty_values():
+    """Test matching against empty values and nulls."""
+    empty_param = {"id": "PRM1", "rowId": "ROW1", "value": "", "Unit": None}
+
+    # eq empty matches empty param
+    cond_eq_empty = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.EQ,
+        value=None,
+    )
+    assert condition_matches_param(empty_param, cond_eq_empty)
+
+    # ne empty does not match empty param
+    cond_ne_empty = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.NE,
+        value="",
+    )
+    assert not condition_matches_param(empty_param, cond_ne_empty)
+
+    # non-empty condition vs empty param: ne matches, eq does not
+    cond_eq_val = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.EQ,
+        value="50",
+    )
+    cond_ne_val = RuleCondition(
+        parameter_group_id="PRG1",
+        parameter_id="PRM1",
+        operator=RuleOperator.NE,
+        value="50",
+    )
+    assert not condition_matches_param(empty_param, cond_eq_val)
+    assert condition_matches_param(empty_param, cond_ne_val)
+
+
+def test_generate_combinations_no_intervals():
+    """Test that a workflow with no intervals yields an empty combinations payload."""
+    wf = Workflow(
+        name="Fixed Workflow",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW1",
+                parameter_setpoints=[
+                    ParameterSetpoint(parameter_id="PRM1", row_id="ROW2", value="25"),
+                ],
+            )
+        ],
+    )
+    payload = generate_interval_combinations(wf)
+    assert isinstance(payload, IntervalCombinationPayload)
+    assert payload.combinations == []
+
+
+def test_generate_combinations_dual_mode_exclude_and_include():
+    """Test cartesian product with dual-mode evaluation (exclude vs include)."""
+    # 2 Temp (25, 60) x 2 Speed (500, 1000) = 4 combinations
+    wf = Workflow(
+        name="Screen",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                sequence=1,
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        short_name="Temp",
+                        intervals=[
+                            Interval(value="25", row_id="ROW1"),
+                            Interval(value="60", row_id="ROW2"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM2",
+                        row_id="ROW_P2",
+                        short_name="Speed",
+                        intervals=[
+                            Interval(value="500", row_id="ROW3"),
+                            Interval(value="1000", row_id="ROW4"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Rule: Temp == 60 AND Speed == 1000
+    rule = ExclusionRule(
+        name="High Temp and High Speed",
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                operator=RuleOperator.EQ,
+                value="60",
+            ),
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM2",
+                operator=RuleOperator.EQ,
+                value="1000",
+            ),
+        ],
+    )
+
+    # 1. Exclude mode ('all'): 4 total - 1 matched rule = 3 combinations
+    payload_all = generate_interval_combinations(wf, rules=[rule], intervals_start_from="all")
+    assert len(payload_all.combinations) == 3
+
+    # 2. Exclude mode with UNSKIP override: unskips the rule-excluded combo -> 4 combinations
+    unskip_override = CombinationOverride(
+        key="PRG1#PRM1#ROW2-PRG1#PRM2#ROW4",
+        action=OverrideAction.UNSKIP,
+    )
+    payload_all_unskip = generate_interval_combinations(
+        wf, rules=[rule], overrides=[unskip_override], intervals_start_from="all"
+    )
+    assert len(payload_all_unskip.combinations) == 4
+
+    # 3. Exclude mode with SKIP override on a non-rule combo: drops it -> 2 combinations
+    skip_override = CombinationOverride(
+        key="PRG1#PRM1#ROW1-PRG1#PRM2#ROW3",
+        action=OverrideAction.SKIP,
+    )
+    payload_all_skip = generate_interval_combinations(
+        wf,
+        rules=[rule],
+        overrides=[skip_override],
+        intervals_start_from="all",
+    )
+    assert len(payload_all_skip.combinations) == 2
+
+    # 4. Include mode ('none'): starts with 0, rule includes 1 combo
+    payload_none = generate_interval_combinations(wf, rules=[rule], intervals_start_from="none")
+    assert len(payload_none.combinations) == 1
+
+    # 5. Include mode with UNSKIP override on another combo -> 2 combinations included
+    payload_none_unskip = generate_interval_combinations(
+        wf,
+        rules=[rule],
+        overrides=[unskip_override, skip_override],  # unskip (Temp 60, Speed 1000)
+        intervals_start_from="none",
+    )
+    # The rule matches (60, 1000); unskip also targets (60, 1000); skip drops (25, 500)
+    assert len(payload_none_unskip.combinations) == 1
+
+
+def test_anchor_fixture_24_to_19():
+    """Test the verified 24 -> 19 anchor fixture from the plan.
+
+    Setup:
+    - Temperature: 4 intervals (25, 60, 90, 120)
+    - Speed: 3 intervals (500, 1000, 1500)
+    - Formula: 2 intervals (FormA, FormB)
+    Total combinations = 4 * 3 * 2 = 24.
+    - 1 rule: Temperature >= 120 AND Speed >= 1500 (matches 2 combos: 120x1500 for FormA & FormB).
+    - 3 skips:
+      - (Temp 25, Speed 500, FormA)
+      - (Temp 25, Speed 500, FormB)
+      - (Temp 60, Speed 500, FormA)
+    Result: 24 - 2 (rule) - 3 (skips) = 19 combinations.
+    """
+    wf = Workflow(
+        name="Screening Anchor",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                sequence=1,
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        short_name="Temp",
+                        intervals=[
+                            Interval(value="25", row_id="ROW10"),
+                            Interval(value="60", row_id="ROW11"),
+                            Interval(value="90", row_id="ROW12"),
+                            Interval(value="120", row_id="ROW13"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM2",
+                        row_id="ROW_P2",
+                        short_name="Speed",
+                        intervals=[
+                            Interval(value="500", row_id="ROW20"),
+                            Interval(value="1000", row_id="ROW21"),
+                            Interval(value="1500", row_id="ROW22"),
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM3",
+                        row_id="ROW_P3",
+                        short_name="Formula",
+                        intervals=[
+                            Interval(value="FormA", row_id="ROW30"),
+                            Interval(value="FormB", row_id="ROW31"),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    # Two-condition rule: Temp >= 120 and Speed >= 1500
+    rule = ExclusionRule(
+        name="Max stress exclusion",
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                operator=RuleOperator.GTE,
+                value=120,
+            ),
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM2",
+                operator=RuleOperator.GTE,
+                value=1500,
+            ),
+        ],
+    )
+
+    # 3 skip overrides (disjoint from the rule)
+    overrides = [
+        CombinationOverride(
+            key="PRG1#PRM1#ROW10-PRG1#PRM2#ROW20-PRG1#PRM3#ROW30",
+            action=OverrideAction.SKIP,
+        ),
+        CombinationOverride(
+            key="PRG1#PRM1#ROW10-PRG1#PRM2#ROW20-PRG1#PRM3#ROW31",
+            action=OverrideAction.SKIP,
+        ),
+        CombinationOverride(
+            key="PRG1#PRM1#ROW11-PRG1#PRM2#ROW20-PRG1#PRM3#ROW30",
+            action=OverrideAction.SKIP,
+        ),
+    ]
+
+    payload = generate_interval_combinations(
+        wf, rules=[rule], overrides=overrides, intervals_start_from="all"
+    )
+    assert len(payload.combinations) == 19
+
+
+def test_generate_combinations_exceeds_max_cap():
+    """Test that exceeding MAX_RESULTS (2000) raises AlbertException."""
+    # Build a workflow yielding 50 * 50 = 2500 combinations
+    wf = Workflow(
+        name="Oversized",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        intervals=[
+                            Interval(value=str(i), row_id=f"ROW{1000 + i}") for i in range(50)
+                        ],
+                    ),
+                    ParameterSetpoint(
+                        parameter_id="PRM2",
+                        row_id="ROW_P2",
+                        intervals=[
+                            Interval(value=str(i), row_id=f"ROW{2000 + i}") for i in range(50)
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    with pytest.raises(AlbertException, match="exceeds maximum allowed limit of 2000"):
+        generate_interval_combinations(wf, intervals_start_from="all")
+
+
+def test_s3_payload_serialization():
+    """Test that IntervalCombinationPayload dumps into the exact wire format for S3."""
+    wf = Workflow(
+        name="Wire Spec",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG247776",
+                row_id="ROW_G1",
+                sequence=1,
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM100",
+                        row_id="ROW_P1",
+                        name="Temperature",
+                        sequence="ROW1",
+                        intervals=[
+                            Interval(
+                                value="25",
+                                row_id="ROW4",
+                                unit={"id": "UNI1", "name": "C"},
+                            )
+                        ],
+                    )
+                ],
+            )
+        ],
+    )
+    payload = generate_interval_combinations(wf)
+    wire = payload.model_dump(by_alias=True, mode="json", exclude_none=True)
+
+    assert "combinations" in wire
+    assert len(wire["combinations"]) == 1
+    combo = wire["combinations"][0]
+    assert "ParameterGroups" in combo
+    group = combo["ParameterGroups"][0]
+    assert group["id"] == "PRG247776"
+    assert group["rowId"] == "ROW_G1"
+    assert group["prgSequence"] == 1
+    prm = group["Parameters"][0]
+    assert prm["id"] == "PRM100"
+    assert prm["rowId"] == "ROW_P1"
+    assert prm["prgPrmRowId"] == "ROW1"
+    assert prm["intervalRowId"] == "ROW4"
+    assert prm["name"] == "Temperature"
+    assert prm["value"] == "25"
+    assert prm["Unit"] == {"id": "UNI1", "name": "C"}
+    assert prm["isInterval"] is True
+
+
+def test_multi_group_cartesian_product_and_key_structure():
+    """Test cartesian product across multiple parameter groups."""
+    wf = Workflow(
+        name="Multi Group",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                sequence=1,
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        intervals=[
+                            Interval(value="10", row_id="ROW1"),
+                            Interval(value="20", row_id="ROW2"),
+                        ],
+                    ),
+                    # Fixed parameter in group 1
+                    ParameterSetpoint(
+                        parameter_id="PRM_FIXED",
+                        row_id="ROW_PF",
+                        value="Fixed1",
+                    ),
+                ],
+            ),
+            ParameterGroupSetpoints(
+                id="PRG2",
+                row_id="ROW_G2",
+                sequence=2,
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM2",
+                        row_id="ROW_P2",
+                        intervals=[
+                            Interval(value="A", row_id="ROW3"),
+                            Interval(value="B", row_id="ROW4"),
+                            Interval(value="C", row_id="ROW5"),
+                        ],
+                    ),
+                ],
+            ),
+        ],
+    )
+
+    payload = generate_interval_combinations(wf)
+    # 2 in group 1 * 3 in group 2 = 6 combinations
+    assert len(payload.combinations) == 6
+
+    # Verify that fixed parameter is present on every combination
+    for combo in payload.combinations:
+        g1 = combo.parameter_groups[0]
+        assert len(g1.parameters) == 2
+        fixed = [p for p in g1.parameters if p.id == "PRM_FIXED"][0]
+        assert fixed.value == "Fixed1"
+        assert fixed.is_interval is False
+        assert fixed.interval_row_id is None
+
+
+def test_frontend_parity_two_hyphens_different_units():
+    """Parity test with frontend: eq empty+unitId excludes only that specific empty interval."""
+    # Material = {80@UNI1, 100@UNI1, empty@UNI1, empty@UNI2}
+    # Rule eq null + unitId UNI1 -> only Unitless/matching empty excluded -> included 3.
+    wf = Workflow(
+        name="Hyphen units",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        intervals=[
+                            Interval(value="80", row_id="ROW1", unit={"id": "UNI1"}),
+                            Interval(value="100", row_id="ROW2", unit={"id": "UNI1"}),
+                            Interval(value="", row_id="ROW3", unit={"id": "UNI1"}),
+                            Interval(value="", row_id="ROW4", unit={"id": "UNI2"}),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    rule = ExclusionRule(
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                operator=RuleOperator.EQ,
+                value=None,
+                unit_id="UNI1",
+            )
+        ]
+    )
+
+    payload = generate_interval_combinations(wf, rules=[rule], intervals_start_from="all")
+    assert len(payload.combinations) == 3
+
+
+def test_frontend_parity_same_value_different_units_ne():
+    """Parity test with frontend: ne + unitId excludes only the differing-unit interval."""
+    # Weight = {100@UNI_KG, 100@UNI_LB}
+    # Rule ne 100 + unitId UNI_KG -> matches 100@UNI_LB because of unit mismatch!
+    # Therefore, 100@UNI_LB is excluded, leaving 100@UNI_KG included.
+    wf = Workflow(
+        name="Unit NE",
+        parameter_group_setpoints=[
+            ParameterGroupSetpoints(
+                id="PRG1",
+                row_id="ROW_G1",
+                parameter_setpoints=[
+                    ParameterSetpoint(
+                        parameter_id="PRM1",
+                        row_id="ROW_P1",
+                        intervals=[
+                            Interval(value="100", row_id="ROW1", unit={"id": "UNI_KG"}),
+                            Interval(value="100", row_id="ROW2", unit={"id": "UNI_LB"}),
+                        ],
+                    ),
+                ],
+            )
+        ],
+    )
+
+    rule = ExclusionRule(
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                operator=RuleOperator.NE,
+                value="100",
+                unit_id="UNI_KG",
+            )
+        ]
+    )
+
+    payload = generate_interval_combinations(wf, rules=[rule], intervals_start_from="all")
+    assert len(payload.combinations) == 1
+    remaining_param = payload.combinations[0].parameter_groups[0].parameters[0]
+    assert remaining_param.unit == {"id": "UNI_KG", "name": None}

--- a/tests/unit/test_tasks_combinations.py
+++ b/tests/unit/test_tasks_combinations.py
@@ -1,0 +1,604 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from albert.collections.tasks import TaskCollection
+from albert.exceptions import CombinationGenerationError
+from albert.resources.interval_combinations import ExclusionRule, RuleCondition, RuleOperator
+from albert.resources.tasks import BatchTask, Block, PropertyTask
+from albert.resources.worker_jobs import WorkerJob, WorkerJobMetadata, WorkerJobState
+from albert.utils.worker_jobs import poll_worker_job
+
+
+def test_combination_generation_error_attributes():
+    """Test that CombinationGenerationError preserves task, failed_blocks, and job_states."""
+    task = PropertyTask(id="TASFOR123", name="Test Task")
+    failed_blocks = ["BLK2", "BLK3"]
+    job_states = {"BLK1": "successful", "BLK2": "failed", "BLK3": "failed"}
+
+    err = CombinationGenerationError(
+        "Combination generation failed for blocks: BLK2, BLK3",
+        task=task,
+        failed_blocks=failed_blocks,
+        job_states=job_states,
+    )
+
+    assert err.task.id == "TASFOR123"
+    assert err.failed_blocks == ["BLK2", "BLK3"]
+    assert err.job_states == job_states
+    assert "Combination generation failed" in str(err)
+
+
+def test_create_with_combinations_rejects_non_property_task():
+    """Test that create_with_combinations rejects non-PropertyTask."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    batch_task = BatchTask(id="TASMAN1", name="Batch Lab Task")
+    with pytest.raises((TypeError, ValidationError)):
+        tasks_collection.create_with_combinations(task=batch_task)  # type: ignore[arg-type]
+
+
+def test_generate_block_combinations_rejects_non_property_task():
+    """Test that generate_block_combinations raises TypeError if task is not a PropertyTask."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    batch_task = BatchTask(id="TASMAN1", name="Batch Lab Task")
+    tasks_collection.get_by_id = MagicMock(return_value=batch_task)  # type: ignore[method-assign]
+
+    with pytest.raises(TypeError, match="must be a PropertyTask"):
+        tasks_collection.generate_block_combinations(task_id="TASMAN1", block_id="BLK1")
+
+
+def test_generate_block_combinations_raises_value_error_for_missing_block():
+    """Test that generate_block_combinations raises ValueError if block is missing."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    prop_task = PropertyTask(
+        id="TASFOR1",
+        name="Property Task",
+        blocks=[Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}])],
+    )
+    tasks_collection.get_by_id = MagicMock(return_value=prop_task)  # type: ignore[method-assign]
+
+    with pytest.raises(ValueError, match="Block BLK2 not found"):
+        tasks_collection.generate_block_combinations(task_id="TASFOR1", block_id="BLK2")
+
+
+def test_poll_worker_job_raises_on_failed_state():
+    """Test that poll_worker_job raises AlbertException when job fails."""
+    session = MagicMock()
+    job_resp = MagicMock()
+    job_resp.json.return_value = {
+        "albertId": "JOB123",
+        "jobType": "createChildWorkflows",
+        "state": "failed",
+        "stateMessage": "Execution error in worker",
+        "metadata": {"parentType": "TAS", "albertId": "TAS1"},
+    }
+    session.get.return_value = job_resp
+
+    with pytest.raises(Exception, match="Worker job JOB123 failed: Execution error"):
+        poll_worker_job(session=session, job_id="JOB123", raise_on_failure=True)
+
+
+def test_poll_worker_job_returns_job_when_not_raising_on_failure():
+    """Test that poll_worker_job returns the job without raising when raise_on_failure=False."""
+    session = MagicMock()
+    job_resp = MagicMock()
+    job_resp.json.return_value = {
+        "albertId": "JOB123",
+        "jobType": "createChildWorkflows",
+        "state": "failed",
+        "stateMessage": "Execution error in worker",
+        "metadata": {"parentType": "TAS", "albertId": "TAS1"},
+    }
+    session.get.return_value = job_resp
+
+    job = poll_worker_job(session=session, job_id="JOB123", raise_on_failure=False)
+    assert isinstance(job, WorkerJob)
+    assert job.state == WorkerJobState.FAILED
+    assert job.albert_id == "JOB123"
+
+
+def test_generate_block_combinations_no_intervals_submits_bare_job():
+    """Test that non-intervalized blocks submit a worker job without S3 upload."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    prop_task = PropertyTask(
+        id="TASFOR1",
+        name="Property Task",
+        blocks=[Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL10"}])],
+    )
+    tasks_collection.get_by_id = MagicMock(return_value=prop_task)  # type: ignore[method-assign]
+
+    # Workflow without intervalized parameters
+    wfl_resp = MagicMock()
+    wfl_resp.json.return_value = {
+        "id": "WFL10",
+        "name": "Static Workflow",
+        "parameterGroupSetpoints": [
+            {
+                "id": "PRG1",
+                "parameters": [
+                    {"id": "PRM1", "value": "100", "rowId": "ROW1"},
+                ],
+            }
+        ],
+    }
+    session.get.return_value = wfl_resp
+
+    # Block rules (empty)
+    tasks_collection.get_block_rules = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(rules=[], overrides=[])
+    )
+
+    # Worker job response
+    job_post_resp = MagicMock()
+    job_post_resp.json.return_value = {
+        "albertId": "JOB999",
+        "jobType": "createChildWorkflows",
+        "state": "successful",
+        "metadata": {
+            "parentType": "TAS",
+            "albertId": "TASFOR1",
+            "blockId": "BLK1",
+            "newWorkflowId": "WFL10",
+        },
+    }
+    session.post.return_value = job_post_resp
+
+    job = tasks_collection.generate_block_combinations(
+        task_id="TASFOR1", block_id="BLK1", wait=False
+    )
+
+    assert job.albert_id == "JOB999"
+    # Ensure S3 /files/sign was NOT called
+    assert not any(
+        "/files/sign" in call.args[0] for call in session.post.call_args_list if call.args
+    )
+    # Ensure worker job was posted with metadata having NO s3Url
+    worker_job_calls = [
+        call
+        for call in session.post.call_args_list
+        if call.args and "/api/v3/worker-jobs" in call.args[0]
+    ]
+    assert len(worker_job_calls) == 1
+    metadata_sent = worker_job_calls[0].kwargs["json"]["metadata"]
+    assert "s3Url" not in metadata_sent
+    assert metadata_sent["albertId"] == "TASFOR1"
+    assert metadata_sent["blockId"] == "BLK1"
+    assert metadata_sent["newWorkflowId"] == "WFL10"
+
+
+def test_generate_block_combinations_prefers_first_workflow_when_categories_unset():
+    """Test that FINAL-before-INITIAL blocks use the first workflow before categories are set."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    prop_task = PropertyTask(
+        id="TASFOR1",
+        name="Property Task",
+        blocks=[
+            Block(
+                id="BLK1",
+                data_template=[{"id": "DAT1"}],
+                workflow=[{"id": "WFL20"}, {"id": "WFL21"}],
+            )
+        ],
+    )
+    tasks_collection.get_by_id = MagicMock(return_value=prop_task)  # type: ignore[method-assign]
+
+    wfl_resp = MagicMock()
+    wfl_resp.json.return_value = {
+        "id": "WFL20",
+        "name": "Interval Workflow",
+        "ParameterGroups": [],
+    }
+    session.get.return_value = wfl_resp
+
+    tasks_collection.get_block_rules = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(rules=[], overrides=[])
+    )
+
+    job_post_resp = MagicMock()
+    job_post_resp.json.return_value = {
+        "albertId": "JOB777",
+        "jobType": "createChildWorkflows",
+        "state": "successful",
+        "metadata": {
+            "parentType": "TAS",
+            "albertId": "TASFOR1",
+            "blockId": "BLK1",
+            "newWorkflowId": "WFL20",
+        },
+    }
+    session.post.return_value = job_post_resp
+
+    tasks_collection.generate_block_combinations(task_id="TASFOR1", block_id="BLK1", wait=False)
+
+    session.get.assert_called_once_with("/api/v3/workflows/WFL20")
+
+
+def test_generate_block_combinations_intervalized_uploads_and_submits_s3_url(monkeypatch):
+    """Test that intervalized blocks generate combinations, upload to S3, and pass s3Url."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    prop_task = PropertyTask(
+        id="TASFOR1",
+        name="Property Task",
+        blocks=[Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL20"}])],
+    )
+    tasks_collection.get_by_id = MagicMock(return_value=prop_task)  # type: ignore[method-assign]
+
+    # Workflow with intervalized parameters
+    wfl_resp = MagicMock()
+    wfl_resp.json.return_value = {
+        "albertId": "WFL20",
+        "name": "Interval Workflow",
+        "ParameterGroups": [
+            {
+                "id": "PRG1",
+                "rowId": "ROW1",
+                "Parameters": [
+                    {
+                        "id": "PRM1",
+                        "shortName": "Temp",
+                        "rowId": "ROW1",
+                        "Intervals": [
+                            {"rowId": "ROW1", "value": "20"},
+                            {"rowId": "ROW2", "value": "30"},
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    session.get.return_value = wfl_resp
+
+    tasks_collection.get_block_rules = MagicMock(  # type: ignore[method-assign]
+        return_value=MagicMock(rules=[], overrides=[])
+    )
+
+    # Sign response
+    sign_resp = MagicMock()
+    sign_resp.json.return_value = [{"URL": "https://s3.amazonaws.com/test-bucket/signed-url"}]
+    # Worker job response
+    job_post_resp = MagicMock()
+    job_post_resp.json.return_value = {
+        "albertId": "JOB888",
+        "jobType": "createChildWorkflows",
+        "state": "successful",
+        "metadata": {
+            "parentType": "TAS",
+            "albertId": "TASFOR1",
+            "blockId": "BLK1",
+            "newWorkflowId": "WFL20",
+            "s3Url": "intervalcombinations/TASFOR1/BLK1/test.json",
+        },
+    }
+
+    def mock_post(url, *args, **kwargs):
+        if "/files/sign" in url:
+            return sign_resp
+        if "/worker-jobs" in url:
+            return job_post_resp
+        return MagicMock()
+
+    session.post.side_effect = mock_post
+
+    mock_requests_put = MagicMock()
+    mock_requests_put.return_value.status_code = 200
+    monkeypatch.setattr("albert.collections.tasks.requests.put", mock_requests_put)
+
+    job = tasks_collection.generate_block_combinations(
+        task_id="TASFOR1", block_id="BLK1", wait=False
+    )
+
+    assert job.albert_id == "JOB888"
+    assert mock_requests_put.called
+    assert "https://s3.amazonaws.com/test-bucket/signed-url" in mock_requests_put.call_args[0]
+
+
+def test_create_with_combinations_multi_block_gap_and_rules(monkeypatch):
+    """Test that create_with_combinations saves rules and generates combinations for blocks."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    # Task with two blocks, each with rules
+    input_task = PropertyTask(
+        name="Two Block Task",
+        parent_id="PRO1",
+        blocks=[
+            Block(
+                data_template=[{"id": "DAT1"}],
+                workflow=[{"id": "WFL1"}],
+                rules=[
+                    ExclusionRule(
+                        name="Rule 1",
+                        conditions=[
+                            RuleCondition(
+                                parameter_group_id="PRG1",
+                                parameter_id="PRM1",
+                                operator=RuleOperator.GT,
+                                value=50,
+                            )
+                        ],
+                    )
+                ],
+            ),
+            Block(
+                data_template=[{"id": "DAT2"}],
+                workflow=[{"id": "WFL2"}],
+            ),
+        ],
+    )
+
+    created_task_mock = PropertyTask(
+        id="TASFOR99",
+        name="Two Block Task",
+        parent_id="PRO1",
+        blocks=[
+            Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+            Block(id="BLK2", data_template=[{"id": "DAT2"}], workflow=[{"id": "WFL2"}]),
+        ],
+    )
+    tasks_collection.create = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+    tasks_collection.get_by_id = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+
+    mock_generate = MagicMock()
+    job1 = WorkerJob(
+        albert_id="JOB1",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR99"},
+    )
+    job2 = WorkerJob(
+        albert_id="JOB2",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR99"},
+    )
+    mock_generate.side_effect = [job1, job2]
+    tasks_collection.generate_block_combinations = mock_generate  # type: ignore[method-assign]
+
+    # Mock time.sleep to verify 10-second spacing
+    sleep_calls = []
+    current_time = [100.0]
+
+    def fake_sleep(s):
+        sleep_calls.append(s)
+        current_time[0] += s
+
+    monkeypatch.setattr("albert.collections.tasks.time.sleep", fake_sleep)
+    monkeypatch.setattr("albert.collections.tasks.time.time", lambda: current_time[0])
+
+    # Mock poll_worker_job to return successful
+    monkeypatch.setattr(
+        "albert.collections.tasks.poll_worker_job",
+        lambda *args, **kwargs: WorkerJob(
+            albert_id=kwargs.get("job_id", "JOB1"),
+            job_type="createChildWorkflows",
+            state=WorkerJobState.SUCCESSFUL,
+            metadata=WorkerJobMetadata(parent_type="TAS", albert_id="TASFOR99"),
+        ),
+    )
+
+    res = tasks_collection.create_with_combinations(task=input_task, wait=True)
+
+    assert res.id == "TASFOR99"
+    # PUT /tasks/{id}/rules was called once
+    assert any(
+        "/api/v3/tasks/TASFOR99/rules" in call.args[0] for call in session.put.call_args_list
+    )
+    # generate_block_combinations was called for both blocks
+    assert mock_generate.call_count == 2
+    # Sleep was called with 10.0 between the two blocks
+    assert sleep_calls == [10.0]
+
+
+def test_create_with_combinations_raises_error_on_failed_block(monkeypatch):
+    """Test that create_with_combinations raises CombinationGenerationError on block failure."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    input_task = PropertyTask(
+        name="Task with Failing Block",
+        parent_id="PRO1",
+        blocks=[
+            Block(data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+            Block(data_template=[{"id": "DAT2"}], workflow=[{"id": "WFL2"}]),
+        ],
+    )
+
+    created_task_mock = PropertyTask(
+        id="TASFOR100",
+        name="Task with Failing Block",
+        parent_id="PRO1",
+        blocks=[
+            Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+            Block(id="BLK2", data_template=[{"id": "DAT2"}], workflow=[{"id": "WFL2"}]),
+        ],
+    )
+    tasks_collection.create = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+    tasks_collection.get_by_id = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+
+    job1 = WorkerJob(
+        albert_id="JOB1",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR100"},
+    )
+    job2 = WorkerJob(
+        albert_id="JOB2",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.FAILED,
+        metadata={"parentType": "TAS", "albertId": "TASFOR100"},
+    )
+    tasks_collection.generate_block_combinations = MagicMock(side_effect=[job1, job2])  # type: ignore[method-assign]
+
+    monkeypatch.setattr("albert.collections.tasks.time.sleep", lambda s: None)
+    monkeypatch.setattr("albert.collections.tasks.time.time", lambda: 100.0)
+
+    # Mock poll_worker_job to return job1 successful and job2 failed
+    def mock_poll(*args, **kwargs):
+        job_id = kwargs.get("job_id")
+        if job_id == "JOB1":
+            return job1
+        return job2
+
+    monkeypatch.setattr("albert.collections.tasks.poll_worker_job", mock_poll)
+
+    with pytest.raises(CombinationGenerationError) as exc_info:
+        tasks_collection.create_with_combinations(task=input_task, wait=True)
+
+    err = exc_info.value
+    assert err.task.id == "TASFOR100"
+    assert err.failed_blocks == ["BLK2"]
+    assert err.job_states["BLK1"] == "successful"
+    assert err.job_states["BLK2"] == "failed"
+
+
+def test_set_block_rules_automatically_calls_generate_block_combinations():
+    """Test that set_block_rules automatically regenerates combinations and attaches job."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    # Mock PUT /tasks/TASFOR1/rules
+    put_resp = MagicMock()
+    put_resp.json.return_value = [
+        {
+            "blockId": "BLK1",
+            "rules": [
+                {
+                    "conditions": [
+                        {
+                            "prgId": "PRG1",
+                            "prmId": "PRM1",
+                            "rowId": "ROW1",
+                            "operator": "gte",
+                            "value": "90",
+                        }
+                    ]
+                }
+            ],
+            "overrides": [],
+        }
+    ]
+    session.put.return_value = put_resp
+
+    # Mock get_by_id to resolve block workflow
+    prop_task = PropertyTask(
+        id="TASFOR1",
+        name="Property Task",
+        blocks=[Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL99"}])],
+    )
+    tasks_collection.get_by_id = MagicMock(return_value=prop_task)  # type: ignore[method-assign]
+
+    mock_job = WorkerJob(
+        albert_id="JOB555",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR1", "blockId": "BLK1"},
+    )
+    tasks_collection.generate_block_combinations = MagicMock(return_value=mock_job)  # type: ignore[method-assign]
+
+    rule = ExclusionRule(
+        conditions=[
+            RuleCondition(
+                parameter_group_id="PRG1",
+                parameter_id="PRM1",
+                row_id="ROW1",
+                operator=RuleOperator.GTE,
+                value="90",
+            )
+        ]
+    )
+
+    block_rules = tasks_collection.set_block_rules(
+        task_id="TASFOR1",
+        block_id="BLK1",
+        rules=[rule],
+    )
+
+    # Verify rules were saved via PUT
+    session.put.assert_called_once()
+    assert "/TASFOR1/rules" in session.put.call_args[0][0]
+
+    # Verify generate_block_combinations was called automatically
+    tasks_collection.generate_block_combinations.assert_called_once_with(
+        task_id="TASFOR1",
+        block_id="BLK1",
+        old_workflow_id="WFL99",
+        wait=True,
+    )
+
+    # Verify job is attached to the returned BlockRules
+    assert block_rules.job is mock_job
+    assert block_rules.job.albert_id == "JOB555"
+    assert block_rules.job.state == WorkerJobState.SUCCESSFUL
+
+
+def test_set_block_rules_with_generate_combinations_false_skips_generation():
+    """Test that set_block_rules skips generation when generate_combinations=False."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    put_resp = MagicMock()
+    put_resp.json.return_value = [{"blockId": "BLK1", "rules": [], "overrides": []}]
+    session.put.return_value = put_resp
+
+    tasks_collection.generate_block_combinations = MagicMock()  # type: ignore[method-assign]
+    tasks_collection.get_by_id = MagicMock()  # type: ignore[method-assign]
+
+    block_rules = tasks_collection.set_block_rules(
+        task_id="TASFOR1",
+        block_id="BLK1",
+        rules=[],
+        generate_combinations=False,
+    )
+
+    # Verify generate_block_combinations was NOT called
+    tasks_collection.generate_block_combinations.assert_not_called()
+    tasks_collection.get_by_id.assert_not_called()
+    assert block_rules.job is None
+
+
+def test_set_block_rules_with_custom_old_workflow_id_and_wait_false():
+    """Test that set_block_rules honors explicit old_workflow_id and wait=False."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    put_resp = MagicMock()
+    put_resp.json.return_value = [{"blockId": "BLK1", "rules": [], "overrides": []}]
+    session.put.return_value = put_resp
+
+    mock_job = WorkerJob(
+        albert_id="JOB666",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUBMITTED,
+        metadata={"parentType": "TAS", "albertId": "TASFOR1", "blockId": "BLK1"},
+    )
+    tasks_collection.generate_block_combinations = MagicMock(return_value=mock_job)  # type: ignore[method-assign]
+
+    block_rules = tasks_collection.set_block_rules(
+        task_id="TASFOR1",
+        block_id="BLK1",
+        rules=[],
+        old_workflow_id="WFL_PREVIOUS",
+        wait=False,
+    )
+
+    tasks_collection.generate_block_combinations.assert_called_once_with(
+        task_id="TASFOR1",
+        block_id="BLK1",
+        old_workflow_id="WFL_PREVIOUS",
+        wait=False,
+    )
+    assert block_rules.job is mock_job
+    assert block_rules.job.albert_id == "JOB666"

--- a/tests/unit/test_tasks_combinations.py
+++ b/tests/unit/test_tasks_combinations.py
@@ -1,11 +1,18 @@
 from unittest.mock import MagicMock
 
 import pytest
+import requests
 from pydantic import ValidationError
 
 from albert.collections.tasks import TaskCollection
-from albert.exceptions import CombinationGenerationError
-from albert.resources.interval_combinations import ExclusionRule, RuleCondition, RuleOperator
+from albert.exceptions import AlbertException, CombinationGenerationError
+from albert.resources.interval_combinations import (
+    CombinationOverride,
+    ExclusionRule,
+    OverrideAction,
+    RuleCondition,
+    RuleOperator,
+)
 from albert.resources.tasks import BatchTask, Block, PropertyTask
 from albert.resources.worker_jobs import WorkerJob, WorkerJobMetadata, WorkerJobState
 from albert.utils.worker_jobs import poll_worker_job
@@ -392,6 +399,9 @@ def test_create_with_combinations_multi_block_gap_and_rules(monkeypatch):
     res = tasks_collection.create_with_combinations(task=input_task, wait=True)
 
     assert res.id == "TASFOR99"
+    # Verify input_task was not mutated (deep copied)
+    assert input_task.blocks[0].intervals_start_from is None
+    assert input_task.blocks[1].intervals_start_from is None
     # PUT /tasks/{id}/rules was called once
     assert any(
         "/api/v3/tasks/TASFOR99/rules" in call.args[0] for call in session.put.call_args_list
@@ -509,6 +519,8 @@ def test_set_block_rules_automatically_calls_generate_block_combinations():
     tasks_collection.generate_block_combinations = MagicMock(return_value=mock_job)  # type: ignore[method-assign]
 
     rule = ExclusionRule(
+        id="RUL-123",
+        name="Rule 1",
         conditions=[
             RuleCondition(
                 parameter_group_id="PRG1",
@@ -517,18 +529,52 @@ def test_set_block_rules_automatically_calls_generate_block_combinations():
                 operator=RuleOperator.GTE,
                 value="90",
             )
-        ]
+        ],
+    )
+    override = CombinationOverride(
+        id="OVR-456",
+        key="PRG1#PRM1#ROW1",
+        action=OverrideAction.SKIP,
     )
 
     block_rules = tasks_collection.set_block_rules(
         task_id="TASFOR1",
         block_id="BLK1",
         rules=[rule],
+        overrides=[override],
     )
 
-    # Verify rules were saved via PUT
+    # Verify rules were saved via PUT with preserved IDs and model_dump serialization
     session.put.assert_called_once()
     assert "/TASFOR1/rules" in session.put.call_args[0][0]
+    payload = session.put.call_args[1]["json"]
+    assert payload == [
+        {
+            "blockId": "BLK1",
+            "rules": [
+                {
+                    "id": "RUL-123",
+                    "name": "Rule 1",
+                    "conditions": [
+                        {
+                            "prgId": "PRG1",
+                            "prmId": "PRM1",
+                            "rowId": "ROW1",
+                            "operator": "gte",
+                            "value": "90",
+                        }
+                    ],
+                }
+            ],
+            "overrides": [
+                {
+                    "id": "OVR-456",
+                    "key": "PRG1#PRM1#ROW1",
+                    "action": "skip",
+                }
+            ],
+        }
+    ]
 
     # Verify generate_block_combinations was called automatically
     tasks_collection.generate_block_combinations.assert_called_once_with(
@@ -602,3 +648,110 @@ def test_set_block_rules_with_custom_old_workflow_id_and_wait_false():
     )
     assert block_rules.job is mock_job
     assert block_rules.job.albert_id == "JOB666"
+
+
+def test_create_with_combinations_catches_timeout_and_albert_exception(monkeypatch):
+    """Test that TimeoutError and AlbertException in poll are caught and reported as failed blocks."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    input_task = PropertyTask(
+        name="Task with Timeout",
+        parent_id="PRO1",
+        blocks=[
+            Block(data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+            Block(data_template=[{"id": "DAT2"}], workflow=[{"id": "WFL2"}]),
+        ],
+    )
+
+    created_task_mock = PropertyTask(
+        id="TASFOR101",
+        name="Task with Timeout",
+        parent_id="PRO1",
+        blocks=[
+            Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+            Block(id="BLK2", data_template=[{"id": "DAT2"}], workflow=[{"id": "WFL2"}]),
+        ],
+    )
+    tasks_collection.create = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+    tasks_collection.get_by_id = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+
+    job1 = WorkerJob(
+        albert_id="JOB1",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR101"},
+    )
+    job2 = WorkerJob(
+        albert_id="JOB2",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR101"},
+    )
+    tasks_collection.generate_block_combinations = MagicMock(side_effect=[job1, job2])  # type: ignore[method-assign]
+
+    monkeypatch.setattr("albert.collections.tasks.time.sleep", lambda s: None)
+    monkeypatch.setattr("albert.collections.tasks.time.time", lambda: 100.0)
+
+    # First job raises TimeoutError, second raises AlbertException
+    side_effects = [
+        TimeoutError("timed out waiting for worker job"),
+        AlbertException("job failed"),
+    ]
+    monkeypatch.setattr(
+        "albert.collections.tasks.poll_worker_job", MagicMock(side_effect=side_effects)
+    )
+
+    with pytest.raises(CombinationGenerationError) as exc_info:
+        tasks_collection.create_with_combinations(task=input_task, wait=True)
+
+    err = exc_info.value
+    assert err.task.id == "TASFOR101"
+    assert err.failed_blocks == ["BLK1", "BLK2"]
+    assert err.job_states["BLK1"] == "failed"
+    assert err.job_states["BLK2"] == "failed"
+
+
+def test_create_with_combinations_propagates_network_exception(monkeypatch):
+    """Test that unexpected network exceptions during poll are not swallowed."""
+    session = MagicMock()
+    tasks_collection = TaskCollection(session=session)
+
+    input_task = PropertyTask(
+        name="Task with Network Error",
+        parent_id="PRO1",
+        blocks=[
+            Block(data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+        ],
+    )
+
+    created_task_mock = PropertyTask(
+        id="TASFOR102",
+        name="Task with Network Error",
+        parent_id="PRO1",
+        blocks=[
+            Block(id="BLK1", data_template=[{"id": "DAT1"}], workflow=[{"id": "WFL1"}]),
+        ],
+    )
+    tasks_collection.create = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+    tasks_collection.get_by_id = MagicMock(return_value=created_task_mock)  # type: ignore[method-assign]
+
+    job1 = WorkerJob(
+        albert_id="JOB1",
+        job_type="createChildWorkflows",
+        state=WorkerJobState.SUCCESSFUL,
+        metadata={"parentType": "TAS", "albertId": "TASFOR102"},
+    )
+    tasks_collection.generate_block_combinations = MagicMock(return_value=job1)  # type: ignore[method-assign]
+
+    monkeypatch.setattr("albert.collections.tasks.time.sleep", lambda s: None)
+    monkeypatch.setattr("albert.collections.tasks.time.time", lambda: 100.0)
+
+    # poll_worker_job raises a connection error
+    monkeypatch.setattr(
+        "albert.collections.tasks.poll_worker_job",
+        MagicMock(side_effect=requests.exceptions.ConnectionError("Connection lost")),
+    )
+
+    with pytest.raises(requests.exceptions.ConnectionError, match="Connection lost"):
+        tasks_collection.create_with_combinations(task=input_task, wait=True)


### PR DESCRIPTION
## What

Callers on increased-intervals tenants can create intervalized Property tasks, configure and persist block exclusion/inclusion rules and overrides, automatically generate child-workflow combinations via background worker jobs, and inspect combination items with barcode preservation.

## Why

Flag-ON tenants replace legacy positional ROW intervals with denormalized child workflows, lift intervalized-parameter caps, and require client-side Cartesian product generation, rule evaluation, and worker job orchestration.

## How

- `create_with_combinations` orchestrates bulk workflow creation, task creation, rules persistence, per-block combination generation, and enforces a mandatory 10-second gap between worker jobs.
- `generate_block_combinations` evaluates combination rules client-side, signs and uploads the S3 payload, posts the `createChildWorkflows` worker job, and polls to terminal state.
- `set_block_rules` persists rules and automatically re-evaluates and regenerates child-workflow combinations on Albert Invent by default, passing the current workflow as `old_workflow_id` so unchanged barcodes are preserved and obsolete combinations are voided.
- Value-based helpers on `Workflow` (`build_rule`, `build_rule_condition`, `build_override`) allow callers to define rules and overrides using human-readable parameter names and values rather than manually looking up workflow-local IDs (`PRG...`, `PRM...`, `ROW...`).
- Helpers use `@validate_call` with keyword-only arguments (`*`), and support both `Condition` NamedTuples and plain tuples (e.g. `("Temperature", ">=", 90)`).
- Dual-mode evaluation (`intervalsStartFrom: 'all' | 'none'`) in `generate_interval_combinations` accurately models frontend parity for JS numeric coercion, override precedence, and condition matching.
- Partial failures in `create_with_combinations` raise `CombinationGenerationError`, carrying the created task instance and failed block IDs for targeted retries.
- All increased-intervals methods and models carry `(🧪 Beta)` badges and feature flag warning callouts.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/unit/test_tasks_combinations.py tests/unit/test_interval_combinations_engine.py -v`
- [x] `uv run pytest tests/resources/test_interval_combinations.py -v`
- [x] `uv run pytest tests/core/shared/test_identifiers.py -v`
- [x] `uv run mkdocs build --strict`

## SDK Changes

- Added `TaskCollection.create_with_combinations`, `TaskCollection.generate_block_combinations`, `TaskCollection.get_block_combinations`, `TaskCollection.get_block_rules`, and `TaskCollection.set_block_rules` (🧪 Beta).
- Added models `IntervalCombinationItem`, `RuleOperator`, `OverrideAction`, `Condition`, `RuleCondition`, `ExclusionRule`, `CombinationOverride`, `BlockRules`, and S3 payload models (🧪 Beta).
- Added `Workflow.build_rule_condition`, `Workflow.build_rule`, and `Workflow.build_override` to construct rules and overrides using parameter names and values with keyword-only arguments (🧪 Beta).
- Added `Workflow.get_override_key` to build canonical override keys from parameter values (🧪 Beta).
- Added `CombinationGenerationError` for resilient error handling and partial failure recovery.
- Added `poll_worker_job` in `albert.utils.worker_jobs` for background worker job polling.