### PR TITLE
fix(property_data): force text/csv on curve CSV uploads

### DIFF
--- a/src/albert/collections/attachments.py
+++ b/src/albert/collections/attachments.py
@@ -471,6 +471,7 @@ class AttachmentCollection(BaseCollection):
         note_text: str = "",
         file_name: str = "",
         upload_key: str | None = None,
+        content_type: str | None = None,
     ) -> Note:
         """Uploads a file and attaches it to a new note. A user can be tagged in the note_text string by using f-string and the User.to_note_mention() method.
         This allows for easy tagging and referencing of users within notes. example: f"Hello {tagged_user.to_note_mention()}!"
@@ -500,6 +501,9 @@ class AttachmentCollection(BaseCollection):
         upload_key : str | None, optional
             Override the storage key used when signing and uploading the file.
             Defaults to ``{parent_id}/{note_id}/{file_name}``.
+        content_type : str | None, optional
+            Explicit MIME type for the upload. When omitted, inferred from
+            ``file_name`` or ``upload_key``; defaults to ``application/octet-stream``.
 
         Returns
         -------
@@ -521,9 +525,12 @@ class AttachmentCollection(BaseCollection):
         else:
             attachment_name = file_name
             upload_name = f"{parent_id}/{registered_note.id}/{file_name}"
-        file_type = mimetypes.guess_type(attachment_name or upload_name)[0]
-        if file_type is None:
-            file_type = "application/octet-stream"
+        if content_type is None:
+            file_type = mimetypes.guess_type(attachment_name or upload_name)[0]
+            if file_type is None:
+                file_type = "application/octet-stream"
+        else:
+            file_type = content_type
         file_collection = self._get_file_collection()
 
         file_collection.sign_and_upload_file(

--- a/src/albert/utils/data_template.py
+++ b/src/albert/utils/data_template.py
@@ -234,6 +234,7 @@ def prepare_curve_input_attachment(
                 f"curve-input/{data_template_id}/{column_id}/{uuid.uuid4().hex[:10]}{suffix}"
             )
 
+    upload_content_type = "text/csv" if "csv" in normalized_extensions else None
     resolved_attachment_id = AttachmentId(
         resolve_attachment(
             attachment_collection=attachment_collection,
@@ -243,6 +244,7 @@ def prepare_curve_input_attachment(
             allowed_extensions=normalized_extensions,
             note_text=None,
             upload_key=upload_key,
+            content_type=upload_content_type,
         )
     )
 

--- a/src/albert/utils/tasks.py
+++ b/src/albert/utils/tasks.py
@@ -139,6 +139,7 @@ def resolve_attachment(
     allowed_extensions: set[str],
     note_text: str | None,
     upload_key: str | None = None,
+    content_type: str | None = None,
 ) -> str:
     """Ensure an attachment is available, optionally uploading a new file."""
     if file_path is not None:
@@ -158,6 +159,7 @@ def resolve_attachment(
                 note_text=note_text_to_use,
                 file_name=path.name,
                 upload_key=upload_key,
+                content_type=content_type,
             )
         uploaded_attachments = uploaded_attachment_note.attachments or []
         if not uploaded_attachments:


### PR DESCRIPTION
## What

Curve property data uploads via `CurvePropertyValue` now store the input file in S3 with `Content-Type: text/csv`, so the `importCurveData` worker accepts them.

## Why

Fixes https://github.com/albert-labs/albert-python/issues/672. The SDK inferred MIME type from the local filename when uploading curve CSVs; extensionless paths (or platform-specific CSV types) were stored as `application/octet-stream`, which the worker rejects even though the file content is valid CSV. Manual UI uploads worked because they set `text/csv` explicitly.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_attachments.py tests/collections/test_data_templates.py tests/collections/test_property_data.py -v -n 4`

## SDK Changes

Curve CSV uploads through `add_properties_to_task()` / data template curve examples no longer depend on the local file extension for S3 content type.