### PR TITLE
feat(users): add delete method

### DIFF
--- a/src/albert/collections/users.py
+++ b/src/albert/collections/users.py
@@ -66,6 +66,8 @@ class UserCollection(BaseCollection):
         Create a new user account.
     update(user) -> User
         Update an existing user.
+    delete(id) -> None
+        Delete a user by its ID.
     """
 
     _api_version = "v3"
@@ -424,3 +426,24 @@ class UserCollection(BaseCollection):
 
         updated_user = self.get_by_id(id=user.id)
         return updated_user
+
+    @validate_call
+    def delete(self, *, id: UserId) -> None:
+        """Delete a user by its ID.
+
+        !!! example
+            ```python
+            client.users.delete(id="USR12")
+            ```
+
+        Parameters
+        ----------
+        id : UserId
+            The User ID to delete.
+
+        Returns
+        -------
+        None
+        """
+        url = f"{self.base_path}/{id}"
+        self.session.delete(url)

--- a/tests/collections/test_users.py
+++ b/tests/collections/test_users.py
@@ -90,3 +90,17 @@ def test_hydrate_user(client: Albert):
 
     if not hydrated_any:
         pytest.skip("No search hits could be hydrated (stale index IDs)")
+
+
+def test_user_delete_non_existent(client: Albert):
+    """Test deleting a non-existent user raises NotFoundError."""
+    with pytest.raises(NotFoundError):
+        client.users.delete(id="USR999999999")
+
+
+def test_user_delete_invalid_id(client: Albert):
+    """Test deleting with invalid ID format raises ValidationError."""
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        client.users.delete(id="INVALID_ID")


### PR DESCRIPTION
## What

Callers can now delete users directly via `client.users.delete(id=...)`.

## Why

Closes #729. The backend provides `DELETE /api/v3/users/{id}`, but `UserCollection` was missing a corresponding `delete` method.

## Testing

- [x] `uv run ruff format .`
- [x] `uv run ruff check . --fix`
- [x] `uv run pytest tests/collections/test_users.py -v`

## SDK Changes

Added `delete(id=...)` to `UserCollection` for deleting user accounts by ID.